### PR TITLE
Add the 1 vulnerable artifact found by `shadedetector` for CVE-2019-12402

### DIFF
--- a/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/README.md
+++ b/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/README.md
@@ -1,0 +1,24 @@
+# [CVE-2019-12402 -- Commons-Compress] (https://nvd.nist.gov/vuln/detail/CVE-2019-12402)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+Project uses `apache:commons_compress:1.18` , tests from https://github.com/apache/commons-compress/blob/4ad5d80a6272e007f64a6ac66829ca189a8093b9/src/test/java/org/apache/commons/compress/archivers/zip/NioZipEncodingTest.java
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. Irrelevant tests removed
+2. JUnit version replaced by Junit5
+3. uses Java 8 (note that compress does not have to be build)
+4. added timeout to `NioZipEncodingTest::partialSurrogatePair` to detect that computation is stuck in infinite loop
+
+Note that one test __fails__ indicating the vulnerability! After replacing `apache:commons_compress:1.18` by `apache:commons_compress:1.19`
+the respective test passes. 
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/pom.xml
+++ b/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2019-12402 POV</description>
+    <name>CVE-2019-12402</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.1tchy.java9modular.org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.18.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,2206 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2019-12402",
+    "groupID" : "foo",
+    "artifactID" : "io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:25:47.423480Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "commons-compress-1.18.1.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/io/github/1tchy/java9modular/org/apache/commons/commons-compress/1.18.1/commons-compress-1.18.1.jar",
+    "md5" : "68f2b96a08d0e5dab96adceebae414ec",
+    "sha1" : "e39931d7155bf6468dcc141de72b42ffed09ac50",
+    "sha256" : "e852b4bca9d1bfb58ac1776a9e1a0f5799e3a93558cfbcdd86d6f95a0e359cc3",
+    "description" : "\nApache Commons Compress software defines an API for working with\ncompression and archive formats.  These include: bzip2, gzip, pack200,\nlzma, xz, Snappy, traditional Unix Compress, DEFLATE, DEFLATE64, LZ4,\nBrotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.\n  ",
+    "projectReferences" : [ "CVE-2019-12402:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "commons-compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "lzma"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "module-info"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xz"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "bodewig at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "chtompki at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "damjan at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ebourg at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ggregory at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "grobmeier at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "julius at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sebb at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tcurdt at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bodewig"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "chtompki"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "damjan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ebourg"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ggregory"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "grobmeier"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "julius"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sebb"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tcurdt"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Christian Grobmeier"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Damjan Jovanovic"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Emmanuel Bourg"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Gary Gregory"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Julius Davies"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rob Tompkins"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Sebastian Bazley"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stefan Bodewig"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Torsten Curdt"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "io.github.1tchy.java9modular.org.apache.commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "parent"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "io.github.1tchy.java9modular"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://commons.apache.org/proper/commons-compress/"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "commons-compress"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "compress"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "compress"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "lzma"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "module-info"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xz"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-compress"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "bodewig at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "chtompki at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "damjan at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ebourg at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ggregory at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "grobmeier at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "julius at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sebb at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tcurdt at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bodewig"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "chtompki"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "damjan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ebourg"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ggregory"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "grobmeier"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "julius"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sebb"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tcurdt"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Christian Grobmeier"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Damjan Jovanovic"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Emmanuel Bourg"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Gary Gregory"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Julius Davies"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rob Tompkins"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Sebastian Bazley"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stefan Bodewig"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Torsten Curdt"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "io.github.1tchy.java9modular.org.apache.commons"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Compress"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "parent"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "io.github.1tchy.java9modular"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://commons.apache.org/proper/commons-compress/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.18.1"
+      }, {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "1.18.1"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.18.1"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/io.github.1tchy.java9modular.org.apache.commons/commons-compress@1.18.1",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/io.github.1tchy.java9modular.org.apache.commons/commons-compress@1.18.1?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    }, {
+      "id" : "pkg:maven/org.apache.commons/commons-compress@1.18",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.apache.commons/commons-compress@1.18?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:apache:commons_compress:1.18.1:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aapache&cpe_product=cpe%3A%2F%3Aapache%3Acommons_compress&cpe_version=cpe%3A%2F%3Aapache%3Acommons_compress%3A1.18.1"
+    } ],
+    "vulnerabilities" : [ {
+      "source" : "OSSINDEX",
+      "name" : "CVE-2019-12402",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 7.5,
+        "accessVector" : "N",
+        "accessComplexity" : "L",
+        "authenticationr" : "$enc.json($vuln.cvssV2.authentication)",
+        "confidentialImpact" : "N",
+        "integrityImpact" : "N",
+        "availabilityImpact" : "H",
+        "severity" : "HIGH"
+      },
+      "cwes" : [ "CWE-835" ],
+      "description" : "The file name encoding algorithm used internally in Apache Commons Compress 1.15 to 1.18 can get into an infinite loop when faced with specially crafted inputs. This can lead to a denial of service attack if an attacker can choose the file names inside of an archive created by Compress.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-12402",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-12402"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2019-12402?component-type=maven&component-name=org.apache.commons%2Fcommons-compress&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2019-12402] CWE-835: Loop with Unreachable Exit Condition ('Infinite Loop')"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html#Apache_Commons_Compress_Security_Vulnerabilities",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html#Apache_Commons_Compress_Security_Vulnerabilities"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:org.apache.commons:commons-compress:1.18:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-35515",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-835" ],
+      "description" : "When reading a specially crafted 7Z archive, the construction of the list of codecs that decompress an entry can result in an infinite loop. This could be used to mount a denial of service attack against services that use Compress' sevenz package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rbe91c512c5385181149ab087b6c909825d34299f5c491c6482a2ed57@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [druid] branch master updated: Address CVE-2021-35515 CVE-2021-36090 (#11496)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rab292091eadd1ecc63c516e9541a7f241091cf2e652b8185a6059945@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [GitHub] [druid] suneet-s merged pull request #11496: Address CVE-2021-35515 CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] hanahmily merged pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+        "name" : "[poi-dev] 20210923 Re: [VOTE] Apache POI 5.1.0 release (RC1)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rbaea15ddc5a7c0c6b66660f1d6403b28595e2561bb283eade7d7cd69@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-35515: Apache Commons Compress 1.6 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35515",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35515"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] wu-sheng opened a new pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/1",
+        "name" : "[oss-security] 20210713 CVE-2021-35515: Apache Commons Compress 1.6 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/r19ebfd71770ec0617a9ea180e321ef927b3fefb4c81ec5d1902d20ab%40%3Cuser.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/r19ebfd71770ec0617a9ea180e321ef927b3fefb4c81ec5d1902d20ab%40%3Cuser.commons.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [skywalking] 01/01: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] commented on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210716 [GitHub] [pulsar] lhotari opened a new pull request #11345: [Security] Upgrade commons-compress to 1.21"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20211022-0001/",
+        "name" : "https://security.netapp.com/advisory/ntap-20211022-0001/"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2021-35515?component-type=maven&component-name=org.apache.commons%2Fcommons-compress&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2021-35515] CWE-835: Loop with Unreachable Exit Condition ('Infinite Loop')"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://lists.apache.org/thread.html/rbaea15ddc5a7c0c6b66660f1d6403b28595e2561bb283eade7d7cd69@%3Cannounce.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/rbaea15ddc5a7c0c6b66660f1d6403b28595e2561bb283eade7d7cd69@%3Cannounce.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [skywalking] branch master updated: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090 (#7400)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf2f4d7940371a7c7c5b679f50e28fc7fcc82cd00670ced87e013ac88@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [GitHub] [druid] suneet-s opened a new pull request #11496: Address CVE-2021-35515 CVE-2021-36090"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.6",
+          "versionEndIncluding" : "1.20"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:oncommand_insight:-:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_payments:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_trade_finance:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_treasury_management:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:12.0.0.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_automated_test_suite:1.8.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_service_communication_proxy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_route_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.5"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.7.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "14.0.0",
+          "versionEndIncluding" : "14.3.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:12.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:14.5.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_data_repository:8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.59:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.1.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.3.1:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-35516",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-770" ],
+      "description" : "When reading a specially crafted 7Z archive, Compress can be made to allocate large amounts of memory that finally leads to an out of memory error even for very small inputs. This could be used to mount a denial of service attack against services that use Compress' sevenz package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] commented on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210716 [GitHub] [pulsar] lhotari opened a new pull request #11345: [Security] Upgrade commons-compress to 1.21"
+      }, {
+        "source" : "MISC",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] hanahmily merged pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/rf68442d67eb166f4b6cf0bbbe6c7f99098c12954f37332073c9822ca%40%3Cuser.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/rf68442d67eb166f4b6cf0bbbe6c7f99098c12954f37332073c9822ca%40%3Cuser.commons.apache.org%3E"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20211022-0001/",
+        "name" : "https://security.netapp.com/advisory/ntap-20211022-0001/"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+        "name" : "[poi-dev] 20210923 Re: [VOTE] Apache POI 5.1.0 release (RC1)"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35516",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35516"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://issues.apache.org/jira/browse/COMPRESS-542",
+        "name" : "https://issues.apache.org/jira/browse/COMPRESS-542"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2021-35516?component-type=maven&component-name=org.apache.commons%2Fcommons-compress&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2021-35516] CWE-770: Allocation of Resources Without Limits or Throttling"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf5b1016fb15b7118b9a5e16bb0b78cb4f1dfcf7821eb137ab5757c91@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-35516: Apache Commons Compress 1.6 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] wu-sheng opened a new pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/2",
+        "name" : "[oss-security] 20210713 CVE-2021-35516: Apache Commons Compress 1.6 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [skywalking] branch master updated: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090 (#7400)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [skywalking] 01/01: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.6",
+          "versionEndIncluding" : "1.20"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:oncommand_insight:-:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:12.0.0.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_automated_test_suite:1.8.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_service_communication_proxy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_route_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.5"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.7.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "14.0.0",
+          "versionEndIncluding" : "14.3.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:12.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_data_repository:8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.59:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.1.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-35517",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-770" ],
+      "description" : "When reading a specially crafted TAR archive, Compress can be made to allocate large amounts of memory that finally leads to an out of memory error even for very small inputs. This could be used to mount a denial of service attack against services that use Compress' tar package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/OpenLiberty/open-liberty/issues/18808",
+        "name" : "https://github.com/OpenLiberty/open-liberty/issues/18808"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2021-35517?component-type=maven&component-name=org.apache.commons%2Fcommons-compress&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2021-35517] CWE-770: Allocation of Resources Without Limits or Throttling"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] hanahmily merged pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r54afdab05e01de970649c2d91a993f68a6b00cd73e6e34e16c832d46@%3Cuser.ant.apache.org%3E",
+        "name" : "[ant-user] 20210713 CVE-2021-36373: Apache Ant TAR archive denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+        "name" : "[poi-dev] 20210923 Re: [VOTE] Apache POI 5.1.0 release (RC1)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] wu-sheng opened a new pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://lists.apache.org/thread.html/ra393ffdc7c90a4a37ea023946f390285693795013a642d80fba20203@%3Cannounce.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/ra393ffdc7c90a4a37ea023946f390285693795013a642d80fba20203@%3Cannounce.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [skywalking] 01/01: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] commented on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210716 [GitHub] [pulsar] lhotari opened a new pull request #11345: [Security] Upgrade commons-compress to 1.21"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ra393ffdc7c90a4a37ea023946f390285693795013a642d80fba20203@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-35517: Apache Commons Compress 1.1 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/3",
+        "name" : "[oss-security] 20210713 CVE-2021-35517: Apache Commons Compress 1.1 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/r605d906b710b95f1bbe0036a53ac6968f667f2c249b6fbabada9a940%40%3Cuser.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/r605d906b710b95f1bbe0036a53ac6968f667f2c249b6fbabada9a940%40%3Cuser.commons.apache.org%3E"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/OpenLiberty/open-liberty/pull/17872",
+        "name" : "https://github.com/OpenLiberty/open-liberty/pull/17872"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35517",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35517"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20211022-0001/",
+        "name" : "https://security.netapp.com/advisory/ntap-20211022-0001/"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/5",
+        "name" : "[oss-security] 20210713 CVE-2021-36373: Apache Ant TAR archive denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r31f75743ac173b0a606f8ea6ea53f351f386c44e7bcf78ae04007c29@%3Cissues.flink.apache.org%3E",
+        "name" : "[flink-issues] 20210908 [GitHub] [flink] MartijnVisser opened a new pull request #17194: [FLINK-24034] Upgrade commons-compress to 1.21 and other apache.commons updates"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [skywalking] branch master updated: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090 (#7400)"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://openliberty.io/docs/latest/security-vulnerabilities.html",
+        "name" : "https://openliberty.io/docs/latest/security-vulnerabilities.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r457b2ed564860996b20d938566fe8bd4bfb7c37be8e205448ccb5975@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-36373: Apache Ant TAR archive denial of service vulnerability"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.1",
+          "versionEndIncluding" : "1.20"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:oncommand_insight:-:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_payments:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_trade_finance:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_treasury_management:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:12.0.0.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_service_communication_proxy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_route_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.5"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.7.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "14.0.0",
+          "versionEndIncluding" : "14.3.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:12.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_data_repository:8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.59:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.1.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-36090",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "NVD-CWE-Other" ],
+      "description" : "When reading a specially crafted ZIP archive, Compress can be made to allocate large amounts of memory that finally leads to an out of memory error even for very small inputs. This could be used to mount a denial of service attack against services that use Compress' zip package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r54049b66afbca766b6763c7531e9fe7a20293a112bcb65462a134949@%3Ccommits.drill.apache.org%3E",
+        "name" : "[drill-commits] 20210804 [drill] branch master updated: Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/OpenLiberty/open-liberty/issues/18808",
+        "name" : "https://github.com/OpenLiberty/open-liberty/issues/18808"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rbe91c512c5385181149ab087b6c909825d34299f5c491c6482a2ed57@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [druid] branch master updated: Address CVE-2021-35515 CVE-2021-36090 (#11496)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rab292091eadd1ecc63c516e9541a7f241091cf2e652b8185a6059945@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [GitHub] [druid] suneet-s merged pull request #11496: Address CVE-2021-35515 CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] hanahmily merged pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/6",
+        "name" : "[oss-security] 20210713 CVE-2021-36374: Apache Ant ZIP, and ZIP based, archive denial of service vulerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+        "name" : "[poi-dev] 20210923 Re: [VOTE] Apache POI 5.1.0 release (RC1)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb5fa2ee61828fa2e42361b58468717e84902dd71c4aea8dc0b865df7@%3Cnotifications.james.apache.org%3E",
+        "name" : "[james-notifications] 20210714 [GitHub] [james-project] chibenwa opened a new pull request #537: [UPGRADE] Security upgrade: common-compress to 1.21"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/rc4134026d7d7b053d4f9f2205531122732405012c8804fd850a9b26f%40%3Cuser.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/rc4134026d7d7b053d4f9f2205531122732405012c8804fd850a9b26f%40%3Cuser.commons.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r0e87177f8e78b4ee453cd4d3d8f4ddec6f10d2c27707dd71e12cafc9@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-36374: Apache Ant ZIP, and ZIP based, archive denial of service vulerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] wu-sheng opened a new pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [skywalking] 01/01: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] commented on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://lists.apache.org/thread.html/r0e87177f8e78b4ee453cd4d3d8f4ddec6f10d2c27707dd71e12cafc9@%3Cannounce.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/r0e87177f8e78b4ee453cd4d3d8f4ddec6f10d2c27707dd71e12cafc9@%3Cannounce.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210716 [GitHub] [pulsar] lhotari opened a new pull request #11345: [Security] Upgrade commons-compress to 1.21"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf3f0a09fee197168a813966c5816157f6c600a47313a0d6813148ea6@%3Cissues.drill.apache.org%3E",
+        "name" : "[drill-issues] 20210803 [jira] [Created] (DRILL-7981) Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rbbf42642c3e4167788a7c13763d192ee049604d099681f765385d99d@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210804 [GitHub] [drill] luocooong opened a new pull request #2285: Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-36090",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r3227b1287e5bd8db6523b862c22676b046ad8f4fc96433225f46a2bd@%3Cissues.drill.apache.org%3E",
+        "name" : "[drill-issues] 20210805 [jira] [Commented] (DRILL-7981) Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/OpenLiberty/open-liberty/pull/17872",
+        "name" : "https://github.com/OpenLiberty/open-liberty/pull/17872"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rc7df4c2f0bbe2028a1498a46d322c91184f7a369e3e4c57d9518cacf@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210803 [jira] [Created] (DRILL-7981) Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r25f4c44616045085bc3cf901bb7e68e445eee53d1966fc08998fc456@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210805 [GitHub] [drill] luocooong merged pull request #2285: DRILL-7981: Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20211022-0001/",
+        "name" : "https://security.netapp.com/advisory/ntap-20211022-0001/"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2021-36090?component-type=maven&component-name=org.apache.commons%2Fcommons-compress&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2021-36090] CWE-Other"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rdd5412a5b9a25aed2a02c3317052d38a97128314d50bc1ed36e81d38@%3Cuser.ant.apache.org%3E",
+        "name" : "[ant-user] 20210713 CVE-2021-36374: Apache Ant ZIP, and ZIP based, archive denial of service vulerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r4f03c5de923e3f2a8c316248681258125140514ef3307bfe1538e1ab@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210804 [GitHub] [drill] luocooong merged pull request #2285: DRILL-7981: Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r75ffc7a461e7e7ae77690fa75bd47bb71365c732e0fbcc44da4f8ff5@%3Cdev.tomcat.apache.org%3E",
+        "name" : "[tomcat-dev] 20210811 [GitHub] [tomcat-jakartaee-migration] ebourg commented on issue #23: Vulnerability with Apache Commons Compress v1.20"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9a23d4dbf4e34d498664080bff59f2893b855eb16dae33e4aa92fa53@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-36090: Apache Commons Compress 1.0 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf93b6bb267580e01deb7f3696f7eaca00a290c66189a658cf7230a1a@%3Cissues.drill.apache.org%3E",
+        "name" : "[drill-issues] 20210804 [jira] [Commented] (DRILL-7981) Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/4",
+        "name" : "[oss-security] 20210713 CVE-2021-36090: Apache Commons Compress 1.0 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [skywalking] branch master updated: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090 (#7400)"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://openliberty.io/docs/latest/security-vulnerabilities.html",
+        "name" : "https://openliberty.io/docs/latest/security-vulnerabilities.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf2f4d7940371a7c7c5b679f50e28fc7fcc82cd00670ced87e013ac88@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [GitHub] [druid] suneet-s opened a new pull request #11496: Address CVE-2021-35515 CVE-2021-36090"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.0",
+          "versionEndExcluding" : "1.21"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:oncommand_insight:-:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_payments:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.6.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.7.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.9.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.12.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_trade_finance:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_treasury_management:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:12.0.0.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_automated_test_suite:1.8.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_service_communication_proxy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:8.2.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_element_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.2.0",
+          "versionEndIncluding" : "8.2.4.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_report_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.2.0",
+          "versionEndIncluding" : "8.2.5.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_route_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.5.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.4.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.4.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.5.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_analytical_applications_infrastructure:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.6",
+          "versionEndIncluding" : "8.1.1"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:*:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.7.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "14.0.0",
+          "versionEndIncluding" : "14.3.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:12.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_data_repository:8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.59:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.12.0",
+          "versionEndIncluding" : "17.12.11"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.8.0",
+          "versionEndIncluding" : "18.8.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "19.12.0",
+          "versionEndIncluding" : "19.12.11"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "20.12.0",
+          "versionEndIncluding" : "20.12.7"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.1.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    } ]
+  } ]
+}

--- a/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/scan-results/grype/grype-report.json
+++ b/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/scan-results/grype/grype-report.json
@@ -1,0 +1,552 @@
+{
+ "matches": [
+  {
+   "vulnerability": {
+    "id": "CVE-2021-36090",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2021-36090",
+    "namespace": "nvd:cpe",
+    "severity": "High",
+    "urls": [
+     "http://www.openwall.com/lists/oss-security/2021/07/13/4",
+     "http://www.openwall.com/lists/oss-security/2021/07/13/6",
+     "https://commons.apache.org/proper/commons-compress/security-reports.html",
+     "https://lists.apache.org/thread.html/r0e87177f8e78b4ee453cd4d3d8f4ddec6f10d2c27707dd71e12cafc9@%3Cannounce.apache.org%3E",
+     "https://lists.apache.org/thread.html/r25f4c44616045085bc3cf901bb7e68e445eee53d1966fc08998fc456@%3Cdev.drill.apache.org%3E",
+     "https://lists.apache.org/thread.html/r3227b1287e5bd8db6523b862c22676b046ad8f4fc96433225f46a2bd@%3Cissues.drill.apache.org%3E",
+     "https://lists.apache.org/thread.html/r4f03c5de923e3f2a8c316248681258125140514ef3307bfe1538e1ab@%3Cdev.drill.apache.org%3E",
+     "https://lists.apache.org/thread.html/r54049b66afbca766b6763c7531e9fe7a20293a112bcb65462a134949@%3Ccommits.drill.apache.org%3E",
+     "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+     "https://lists.apache.org/thread.html/r75ffc7a461e7e7ae77690fa75bd47bb71365c732e0fbcc44da4f8ff5@%3Cdev.tomcat.apache.org%3E",
+     "https://lists.apache.org/thread.html/r9a23d4dbf4e34d498664080bff59f2893b855eb16dae33e4aa92fa53@%3Cannounce.apache.org%3E",
+     "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rab292091eadd1ecc63c516e9541a7f241091cf2e652b8185a6059945@%3Ccommits.druid.apache.org%3E",
+     "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+     "https://lists.apache.org/thread.html/rb5fa2ee61828fa2e42361b58468717e84902dd71c4aea8dc0b865df7@%3Cnotifications.james.apache.org%3E",
+     "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rbbf42642c3e4167788a7c13763d192ee049604d099681f765385d99d@%3Cdev.drill.apache.org%3E",
+     "https://lists.apache.org/thread.html/rbe91c512c5385181149ab087b6c909825d34299f5c491c6482a2ed57@%3Ccommits.druid.apache.org%3E",
+     "https://lists.apache.org/thread.html/rc4134026d7d7b053d4f9f2205531122732405012c8804fd850a9b26f%40%3Cuser.commons.apache.org%3E",
+     "https://lists.apache.org/thread.html/rc7df4c2f0bbe2028a1498a46d322c91184f7a369e3e4c57d9518cacf@%3Cdev.drill.apache.org%3E",
+     "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rdd5412a5b9a25aed2a02c3317052d38a97128314d50bc1ed36e81d38@%3Cuser.ant.apache.org%3E",
+     "https://lists.apache.org/thread.html/rf2f4d7940371a7c7c5b679f50e28fc7fcc82cd00670ced87e013ac88@%3Ccommits.druid.apache.org%3E",
+     "https://lists.apache.org/thread.html/rf3f0a09fee197168a813966c5816157f6c600a47313a0d6813148ea6@%3Cissues.drill.apache.org%3E",
+     "https://lists.apache.org/thread.html/rf93b6bb267580e01deb7f3696f7eaca00a290c66189a658cf7230a1a@%3Cissues.drill.apache.org%3E",
+     "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+     "https://security.netapp.com/advisory/ntap-20211022-0001/",
+     "https://www.oracle.com/security-alerts/cpuapr2022.html",
+     "https://www.oracle.com/security-alerts/cpujan2022.html",
+     "https://www.oracle.com/security-alerts/cpujul2022.html",
+     "https://www.oracle.com/security-alerts/cpuoct2021.html"
+    ],
+    "description": "When reading a specially crafted ZIP archive, Compress can be made to allocate large amounts of memory that finally leads to an out of memory error even for very small inputs. This could be used to mount a denial of service attack against services that use Compress' zip package.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+      "metrics": {
+       "baseScore": 5,
+       "exploitabilityScore": 10,
+       "impactScore": 2.9
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "metrics": {
+       "baseScore": 7.5,
+       "exploitabilityScore": 3.9,
+       "impactScore": 3.6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:commons_compress:1.18.1:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "commons-compress",
+       "version": "1.18.1"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2021-36090",
+      "versionConstraint": ">= 1.0, < 1.21 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "02e6046a4285effa",
+    "name": "commons-compress",
+    "version": "1.18.1",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:commons-compress:1.18.1:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons_compress:1.18.1:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons:1.18.1:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/io.github.1tchy.java9modular.org.apache.commons/commons-compress@1.18.1",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "commons-compress",
+     "pomGroupID": "io.github.1tchy.java9modular.org.apache.commons",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2021-35517",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2021-35517",
+    "namespace": "nvd:cpe",
+    "severity": "High",
+    "urls": [
+     "http://www.openwall.com/lists/oss-security/2021/07/13/3",
+     "http://www.openwall.com/lists/oss-security/2021/07/13/5",
+     "https://commons.apache.org/proper/commons-compress/security-reports.html",
+     "https://lists.apache.org/thread.html/r31f75743ac173b0a606f8ea6ea53f351f386c44e7bcf78ae04007c29@%3Cissues.flink.apache.org%3E",
+     "https://lists.apache.org/thread.html/r457b2ed564860996b20d938566fe8bd4bfb7c37be8e205448ccb5975@%3Cannounce.apache.org%3E",
+     "https://lists.apache.org/thread.html/r54afdab05e01de970649c2d91a993f68a6b00cd73e6e34e16c832d46@%3Cuser.ant.apache.org%3E",
+     "https://lists.apache.org/thread.html/r605d906b710b95f1bbe0036a53ac6968f667f2c249b6fbabada9a940%40%3Cuser.commons.apache.org%3E",
+     "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+     "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/ra393ffdc7c90a4a37ea023946f390285693795013a642d80fba20203@%3Cannounce.apache.org%3E",
+     "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+     "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+     "https://security.netapp.com/advisory/ntap-20211022-0001/",
+     "https://www.oracle.com/security-alerts/cpuapr2022.html",
+     "https://www.oracle.com/security-alerts/cpujan2022.html",
+     "https://www.oracle.com/security-alerts/cpujul2022.html",
+     "https://www.oracle.com/security-alerts/cpuoct2021.html"
+    ],
+    "description": "When reading a specially crafted TAR archive, Compress can be made to allocate large amounts of memory that finally leads to an out of memory error even for very small inputs. This could be used to mount a denial of service attack against services that use Compress' tar package.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+      "metrics": {
+       "baseScore": 5,
+       "exploitabilityScore": 10,
+       "impactScore": 2.9
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "metrics": {
+       "baseScore": 7.5,
+       "exploitabilityScore": 3.9,
+       "impactScore": 3.6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:commons_compress:1.18.1:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "commons-compress",
+       "version": "1.18.1"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2021-35517",
+      "versionConstraint": ">= 1.1, <= 1.20 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "02e6046a4285effa",
+    "name": "commons-compress",
+    "version": "1.18.1",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:commons-compress:1.18.1:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons_compress:1.18.1:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons:1.18.1:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/io.github.1tchy.java9modular.org.apache.commons/commons-compress@1.18.1",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "commons-compress",
+     "pomGroupID": "io.github.1tchy.java9modular.org.apache.commons",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2021-35516",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2021-35516",
+    "namespace": "nvd:cpe",
+    "severity": "High",
+    "urls": [
+     "http://www.openwall.com/lists/oss-security/2021/07/13/2",
+     "https://commons.apache.org/proper/commons-compress/security-reports.html",
+     "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+     "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+     "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rf5b1016fb15b7118b9a5e16bb0b78cb4f1dfcf7821eb137ab5757c91@%3Cannounce.apache.org%3E",
+     "https://lists.apache.org/thread.html/rf68442d67eb166f4b6cf0bbbe6c7f99098c12954f37332073c9822ca%40%3Cuser.commons.apache.org%3E",
+     "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+     "https://security.netapp.com/advisory/ntap-20211022-0001/",
+     "https://www.oracle.com/security-alerts/cpuapr2022.html",
+     "https://www.oracle.com/security-alerts/cpujan2022.html",
+     "https://www.oracle.com/security-alerts/cpujul2022.html",
+     "https://www.oracle.com/security-alerts/cpuoct2021.html"
+    ],
+    "description": "When reading a specially crafted 7Z archive, Compress can be made to allocate large amounts of memory that finally leads to an out of memory error even for very small inputs. This could be used to mount a denial of service attack against services that use Compress' sevenz package.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+      "metrics": {
+       "baseScore": 5,
+       "exploitabilityScore": 10,
+       "impactScore": 2.9
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "metrics": {
+       "baseScore": 7.5,
+       "exploitabilityScore": 3.9,
+       "impactScore": 3.6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:commons_compress:1.18.1:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "commons-compress",
+       "version": "1.18.1"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2021-35516",
+      "versionConstraint": ">= 1.6, <= 1.20 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "02e6046a4285effa",
+    "name": "commons-compress",
+    "version": "1.18.1",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:commons-compress:1.18.1:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons_compress:1.18.1:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons:1.18.1:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/io.github.1tchy.java9modular.org.apache.commons/commons-compress@1.18.1",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "commons-compress",
+     "pomGroupID": "io.github.1tchy.java9modular.org.apache.commons",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2021-35515",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2021-35515",
+    "namespace": "nvd:cpe",
+    "severity": "High",
+    "urls": [
+     "http://www.openwall.com/lists/oss-security/2021/07/13/1",
+     "https://commons.apache.org/proper/commons-compress/security-reports.html",
+     "https://lists.apache.org/thread.html/r19ebfd71770ec0617a9ea180e321ef927b3fefb4c81ec5d1902d20ab%40%3Cuser.commons.apache.org%3E",
+     "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+     "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rab292091eadd1ecc63c516e9541a7f241091cf2e652b8185a6059945@%3Ccommits.druid.apache.org%3E",
+     "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+     "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rbaea15ddc5a7c0c6b66660f1d6403b28595e2561bb283eade7d7cd69@%3Cannounce.apache.org%3E",
+     "https://lists.apache.org/thread.html/rbe91c512c5385181149ab087b6c909825d34299f5c491c6482a2ed57@%3Ccommits.druid.apache.org%3E",
+     "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+     "https://lists.apache.org/thread.html/rf2f4d7940371a7c7c5b679f50e28fc7fcc82cd00670ced87e013ac88@%3Ccommits.druid.apache.org%3E",
+     "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+     "https://security.netapp.com/advisory/ntap-20211022-0001/",
+     "https://www.oracle.com/security-alerts/cpuapr2022.html",
+     "https://www.oracle.com/security-alerts/cpujan2022.html",
+     "https://www.oracle.com/security-alerts/cpujul2022.html",
+     "https://www.oracle.com/security-alerts/cpuoct2021.html"
+    ],
+    "description": "When reading a specially crafted 7Z archive, the construction of the list of codecs that decompress an entry can result in an infinite loop. This could be used to mount a denial of service attack against services that use Compress' sevenz package.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+      "metrics": {
+       "baseScore": 5,
+       "exploitabilityScore": 10,
+       "impactScore": 2.9
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "metrics": {
+       "baseScore": 7.5,
+       "exploitabilityScore": 3.9,
+       "impactScore": 3.6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:commons_compress:1.18.1:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "commons-compress",
+       "version": "1.18.1"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2021-35515",
+      "versionConstraint": ">= 1.6, <= 1.20 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "02e6046a4285effa",
+    "name": "commons-compress",
+    "version": "1.18.1",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:commons-compress:1.18.1:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons_compress:1.18.1:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons:1.18.1:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/io.github.1tchy.java9modular.org.apache.commons/commons-compress@1.18.1",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "commons-compress",
+     "pomGroupID": "io.github.1tchy.java9modular.org.apache.commons",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  }
+ ],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:09.447513959+13:00"
+ }
+}

--- a/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/scan-results/snyk/snyk-report.json
+++ b/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/scan-results/snyk/snyk-report.json
@@ -1,0 +1,106 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 1,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": false,
+  "uniqueCount": 0,
+  "projectName": "foo:io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1"
+}

--- a/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/scan-results/steady/steady-report.json
+++ b/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/scan-results/steady/steady-report.json
@@ -1,0 +1,58 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 22:17 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "PROVIDED, TEST" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+			{
+		
+			"bug":{
+				"id":"CVE-2018-11771",
+				"cvssScore": "5.5" ,
+				"cvssVersion": "3.1" 
+			},
+			"filename": "commons-compress-1.18.1.jar",
+			"sha1": "E39931D7155BF6468DCC141DE72B42FFED09AC50",
+			
+			"modules": [
+			
+				{
+			
+				"groupId": "foo",
+				"artifactId": "io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1",
+				"version": "0.0.1",
+				
+				"href": "http://localhost:8033/backend/../apps/#/$space.getSpaceToken()/foo/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/0.0.1",
+				
+				"scope": "COMPILE",
+				"isTransitive": false,
+				
+					"containsVulnerableCode": "unknown",
+				
+						"potentiallyExecutesVulnerableCode": "noLibraryCodeAtAll",
+				
+						"actuallyExecutesVulnerableCode": "noLibraryCodeAtAll"
+				}
+			]
+		}
+		]
+	}
+}

--- a/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/src/test/java/org/apache/commons/compress/archivers/zip/NioZipEncodingTest.java
+++ b/CVE-2019-12402/io.github.1tchy.java9modular.org.apache.commons__commons-compress__1.18.1/src/test/java/org/apache/commons/compress/archivers/zip/NioZipEncodingTest.java
@@ -1,0 +1,37 @@
+package org.apache.commons.compress.archivers.zip;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.temporal.TemporalUnit;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Test from https://github.com/apache/commons-compress/blob/4ad5d80a6272e007f64a6ac66829ca189a8093b9/src/test/java/org/apache/commons/compress/archivers/zip/NioZipEncodingTest.java
+ * as per https://github.com/tuhh-softsec/vul4j .
+ * Irrelevant tests removed, Junit replaced by JUnit5, added timeout to detect infinite loop.
+ * @author jens dietrich
+ */
+
+public class NioZipEncodingTest {
+
+    @Test
+    public void partialSurrogatePair() {
+
+        final NioZipEncoding e = new NioZipEncoding(StandardCharsets.US_ASCII, false);
+        assertTimeoutPreemptively(
+            Duration.ofSeconds(10),
+            () -> {
+                ByteBuffer bb = e.encode("\ud83c");
+                final int off = bb.arrayOffset();
+                byte[] result = Arrays.copyOfRange(bb.array(), off, off + bb.limit() - bb.position());
+                assertEquals(0, result.length);
+            }
+        );
+    }
+}


### PR DESCRIPTION
Version `1.19.0` of this artifact is not vulnerable: OK to disclose.