### PR TITLE
Add the 1 vulnerable artifact found by `shadedetector` for CVE-2016-5394

### DIFF
--- a/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/README.md
+++ b/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/README.md
@@ -1,0 +1,14 @@
+# [CVE-2016-5394 -- sling](https://nvd.nist.gov/vuln/detail/CVE-2016-5394) from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+Project uses `org.apache.sling:org.apache.sling.xss:1.0.8`, tests from https://github.com/apache/sling/commit/7d2365a248943071a44d8495655186e4f14ea294   
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. JUnit version replaced by JUnit5, not using vintage (issues detecting tests) -- also note different argument order for `assertEquals()`!
+2. several additional dependencies
+3. resource `resources/SLING-INF/content/config.xml` added (needed in fixture), some additional code added whether file exists. The location is unusual but better than the original location in `src/main/resources/SLING-INF/content/config.xml`; now referenced as file (not resource)
+
+Note that the tests __fail__ indicating the vulnerability!
+
+Tests pass when replacing the sling dependency by `org.apache.sling:org.apache.sling.xss:1.0.12` which is mentioned
+as the patched version in the [GHSA](https://github.com/advisories/GHSA-xwf4-88xr-hx2j).

--- a/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/pom.xml
+++ b/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>org.apache.sling__org.apache.sling.xss.compat__1.0.0</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2016-5394 POV</description>
+    <name>CVE-2016-5394</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.xss.compat</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.api</artifactId>
+            <version>2.2.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.8.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.5.5</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.5.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.json</artifactId>
+            <version>2.0.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/resources/SLING-INF/content/config.xml
+++ b/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/resources/SLING-INF/content/config.xml
@@ -1,0 +1,2819 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or
+  ~ more contributor license agreements. See the NOTICE file
+  ~ distributed with this work for additional information regarding
+  ~ copyright ownership. The ASF licenses this file to you under the
+  ~ Apache License, Version 2.0 (the "License"); you may not use
+  ~ this file except in compliance with the License. You may obtain
+  ~ a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+  ~ applicable law or agreed to in writing, software distributed
+  ~ under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions
+  ~ and limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<!--
+W3C rules retrieved from:
+http://www.w3.org/TR/html401/struct/global.html
+-->
+<anti-samy-rules xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="antisamy.xsd">
+
+    <directives>
+        <directive name="omitXmlDeclaration" value="true"/>
+        <directive name="omitDoctypeDeclaration" value="true"/>
+        <directive name="maxInputSize" value="200000"/>
+        <directive name="useXHTML" value="true"/>
+        <directive name="formatOutput" value="false"/>
+        <directive name="nofollowAnchors" value="false"/>
+        <directive name="validateParamAsEmbed" value="true"/>
+        <directive name="preserveSpace" value="true"/>
+
+        <!--
+        remember, this won't work for relative URIs - AntiSamy doesn't
+        know anything about the URL or your web structure
+        -->
+        <directive name="embedStyleSheets" value="false"/>
+        <directive name="connectionTimeout" value="5000"/>
+        <directive name="maxStyleSheetImports" value="3"/>
+
+    </directives>
+
+    <common-regexps>
+
+        <!--
+        From W3C:
+        This attribute assigns a class name or set of class names to an
+        element. Any number of elements may be assigned the same class
+        name or names. Multiple class names must be separated by white
+        space characters.
+        -->
+
+        <!-- The 16 colors defined by the HTML Spec (also used by the CSS Spec) -->
+        <regexp name="colorName"
+                value="(aqua|black|blue|fuchsia|gray|grey|green|lime|maroon|navy|olive|purple|red|silver|teal|white|yellow)"/>
+
+        <!-- HTML/CSS Spec allows 3 or 6 digit hex to specify color -->
+        <regexp name="colorCode" value="(#([0-9a-fA-F]{6}|[0-9a-fA-F]{3}))"/>
+
+        <regexp name="anything" value=".*"/>
+        <regexp name="numberOrPercent" value="(\d)+(%{0,1})"/>
+        <regexp name="paragraph" value="([\p{L}\p{N},'\.\s\-_\(\)\?]|&amp;[0-9]{2};)*"/>
+        <regexp name="htmlId" value="[a-zA-Z0-9\:\-_\.]+"/>
+        <regexp name="htmlTitle" value="[\p{L}\p{N}\s\-_',:\[\]!\./\\\(\)&amp;]*"/>
+        <!-- force non-empty with a '+' at the end instead of '*' -->
+        <regexp name="htmlClass" value="[a-zA-Z0-9\s,\-_]+"/>
+
+        <!-- Allow empty URL attributes with a '*'-quantifier instead of '+' for the first part of the regexp -->
+        <regexp name="onsiteURL" value="([\p{L}\p{N}\\\.\#@\$%\+&amp;;\-_~,\?=/!\*\(\)]*|\#(\w)+)"/>
+        <regexp name="offsiteURL"
+                value="(\s)*((ht|f)tp(s?)://|mailto:)[\p{L}\p{N}]+[\p{L}\p{N}\p{Zs}\.\#@\$%\+&amp;;:\-_~,\?=/!\*\(\)]*(\s)*"/>
+
+        <regexp name="boolean" value="(true|false)"/>
+        <regexp name="singlePrintable" value="[a-zA-Z0-9]{1}"/>
+        <!-- \w allows the '_' character -->
+
+        <!-- This is for elements (ex: elemName { ... }) -->
+        <regexp name="cssElementSelector" value="[a-zA-Z0-9\-_]+|\*"/>
+
+        <!--  This is to list out any element names that are *not* valid -->
+        <regexp name="cssElementExclusion" value=""/>
+
+        <!--  This if for classes (ex: .className { ... }) -->
+        <regexp name="cssClassSelector" value="\.[a-zA-Z0-9\-_]+"/>
+
+        <!--  This is to list out any class names that are *not* valid -->
+        <regexp name="cssClassExclusion" value=""/>
+
+        <!--  This is for ID selectors (ex: #myId { ... } -->
+        <regexp name="cssIDSelector" value="#[a-zA-Z0-9\-_]+"/>
+
+        <!--  This is to list out any IDs that are *not* valid - FIXME: What should the default be to avoid div hijacking? *? -->
+        <regexp name="cssIDExclusion" value=""/>
+
+        <!--  This is for pseudo-element selector (ex. foo:pseudo-element { ... } -->
+        <regexp name="cssPseudoElementSelector" value=":[a-zA-Z0-9\-_]+"/>
+
+        <!--  This is to list out any psuedo-element names that are *not* valid -->
+        <regexp name="cssPsuedoElementExclusion" value=""/>
+
+        <!--  This is for attribute selectors (ex. foo[attr=value] { ... } -->
+        <regexp name="cssAttributeSelector" value="\[[a-zA-Z0-9\-_]+((=|~=|\|=){1}[a-zA-Z0-9\-_]+){1}\]"/>
+
+        <!--  This is to list out any attribute names that are *not* valid -->
+        <regexp name="cssAttributeExclusion" value=""/>
+
+        <!--  This is for resources referenced from CSS (such as background images and other imported stylesheets) -->
+        <regexp name="cssOnsiteUri" value="url\(([\p{L}\p{N}\\/\.\?=\#&amp;;\-_~]+|\#(\w)+)\)"/>
+        <regexp name="cssOffsiteUri" value="url\((\s)*((ht|f)tp(s?)://)[\p{L}\p{N}]+[~\p{L}\p{N}\p{Zs}\-_\.@#$%&amp;;:,\?=/\+!]*(\s)*\)"/>
+
+        <!--  This if for CSS Identifiers -->
+        <regexp name="cssIdentifier" value="[a-zA-Z0-9\-_]+"/>
+
+        <!--  This is for comments within CSS (ex. /* comment */) -->
+        <regexp name="cssCommentText" value="[\p{L}\p{N}\-_,\/\\\.\s\(\)!\?\=\$#%\^&amp;:&quot;']+"/>
+
+        <regexp name="integer" value="(-|\+)?[0-9]+"/>
+        <regexp name="positiveInteger" value="(\+)?[0-9]+"/>
+        <regexp name="number" value="(-|\+)?([0-9]+(\.[0-9]+)?)"/>
+        <regexp name="angle" value="(-|\+)?([0-9]+(\.[0-9]+)?)(deg|grads|rad)"/>
+        <regexp name="time" value="([0-9]+(\.[0-9]+)?)(ms|s)"/>
+        <regexp name="frequency" value="([0-9]+(\.[0-9]+)?)(hz|khz)"/>
+        <regexp name="length" value="((-|\+)?0|(-|\+)?([0-9]+(\.[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>
+        <regexp name="positiveLength" value="((\+)?0|(\+)?([0-9]+(\.[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>
+        <regexp name="percentage" value="(-|\+)?([0-9]+(\.[0-9]+)?)%"/>
+        <regexp name="positivePercentage" value="(\+)?([0-9]+(\.[0-9]+)?)%"/>
+
+        <regexp name="absolute-size" value="(xx-small|x-small|small|medium|large|x-large|xx-large)"/>
+        <regexp name="relative-size" value="(larger|smaller)"/>
+
+        <!-- Used for CSS Color specifications (complex regexp expresses integer values of 0-255) -->
+        <regexp name="rgbCode"
+                value="rgb\(([1]?[0-9]{1,2}|2[0-4][0-9]|25[0-5]),([1]?[0-9]{1,2}|2[0-4][0-9]|25[0-5]),([1]?[0-9]{1,2}|2[0-4][0-9]|25[0-5])\)"/>
+
+        <!-- CSS2 Allowed System Color Values -->
+        <regexp name="systemColor"
+                value="(activeborder|activecaption|appworkspace|background|buttonface|buttonhighlight|buttonshadow|buttontext|captiontext|graytext|highlight|highlighttext|inactiveborder|inactivecaption|inactivecaptiontext|infobackground|infotext|menu|menutext|scrollbar|threeddarkshadow|threedface|threedhighlight|threedlightshadow|threedshadow|window|windowframe|windowtext)"/>
+
+        <!-- This is where we specify what Flash src to allow -->
+        <regexp name="flashSites"
+                value="http://(download\.macromedia\.com/pub|www\.macromedia\.com/(go|shockwave)|c\.brightcove\.com/services|gamevideos\.1up\.com/swf|www\.youtube\.com/v|vimeo\.com|www\.gametrailers\.com|videomedia\.ign\.com/ev|image\.com\.com/gamespot|www\.hulu\.com/embed|embed\.break\.com|player\.ordienetworks\.com/flash|www\.adultswim\.com/video/vplayer|www\.dailymotion\.com/swf|www\.ustream\.tv/flash/video|cdn-i\.dmdentertainment\.com|media\.mtvnservices\.com|www\.justin\.tv/widgets|www\.viddler\.com/(player|simple_on_site)|static\.twitter\.com/flash|www\.gamepro\.com/bin|www\.divshare\.com/flash|www\.facebook\.com/v)/.*"/>
+    </common-regexps>
+
+    <!--
+
+    Tag.name = a, b, div, body, etc.
+    Tag.action = filter: remove tags, but keep content, validate: keep content as long as it passes rules, remove: remove tag and contents
+    Attribute.name = id, class, href, align, width, etc.
+    Attribute.onInvalid = what to do when the attribute is invalid, e.g., remove the tag (removeTag), remove the attribute (removeAttribute), filter the tag (filterTag)
+    Attribute.description = What rules in English you want to tell the users they can have for this attribute. Include helpful things so they'll be able to tune their HTML
+
+     -->
+
+    <!--
+    Some attributes are common to all (or most) HTML tags. There aren't many that qualify for this. You have to make sure there's no
+    collisions between any of these attribute names with attribute names of other tags that are for different purposes.
+    -->
+
+    <common-attributes>
+
+
+        <!-- Common to all HTML tags  -->
+
+        <attribute name="target">
+            <regexp-list>
+                <regexp value="[a-zA-Z0-9-_\$]+"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="id" description="The 'id' of any HTML attribute should not contain anything besides letters and numbers">
+            <regexp-list>
+                <regexp name="htmlId"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="classid">
+            <regexp-list>
+                <regexp name="anything"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="codebase">
+            <regexp-list>
+                <regexp name="flashSites"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="class"
+                   description="The 'class' of any HTML attribute is usually a single word, but it can also be a list of class names separated by spaces">
+            <regexp-list>
+                <regexp name="htmlClass"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="lang"
+                   description="The 'lang' attribute tells the browser what language the element's attribute values and content are written in">
+            <regexp-list>
+                <regexp value="[a-zA-Z]{2,20}"/>
+            </regexp-list>
+        </attribute>
+        <attribute name="title"
+                   description="The 'title' attribute provides text that shows up in a 'tooltip' when a user hovers their mouse over the element">
+            <regexp-list>
+                <regexp name="htmlTitle"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="alt"
+                   description="The 'alt' attribute provides alternative text to users when its visual representation is not available">
+            <regexp-list>
+                <regexp name="paragraph"/>
+            </regexp-list>
+        </attribute>
+
+
+        <!-- the "style" attribute will be validated by an inline stylesheet scanner, so no need to define anything here - i hate having to special case this but no other choice -->
+        <attribute name="style"
+                   description="The 'style' attribute provides the ability for users to change many attributes of the tag's contents using a strict syntax"/>
+
+        <attribute name="media">
+            <regexp-list>
+                <regexp value="[a-zA-Z0-9,\-\s]+"/>
+            </regexp-list>
+
+            <literal-list>
+                <literal value="screen"/>
+                <literal value="tty"/>
+                <literal value="tv"/>
+                <literal value="projection"/>
+                <literal value="handheld"/>
+                <literal value="print"/>
+                <literal value="braille"/>
+                <literal value="aural"/>
+                <literal value="all"/>
+            </literal-list>
+
+        </attribute>
+
+
+        <!-- Anchor related -->
+
+        <!--  onInvalid="filterTag" has been removed as per suggestion at OWASP SJ 2007 - just "name" is valid -->
+        <attribute name="href">
+            <regexp-list>
+                <regexp name="onsiteURL"/>
+                <regexp name="offsiteURL"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="name">
+            <regexp-list>
+
+                <regexp value="[a-zA-Z0-9-\_\$]+"/>
+
+                <!--
+                have to allow the $ for .NET controls - although,
+                will users be supplying input that has server-generated
+                .NET control names? methinks not, but i want to pass my
+                test cases
+                -->
+
+            </regexp-list>
+        </attribute>
+
+
+        <attribute name="shape" description="The 'shape' attribute defines the shape of the selectable area">
+            <literal-list>
+                <literal value="default"/>
+                <literal value="rect"/>
+                <literal value="circle"/>
+                <literal value="poly"/>
+            </literal-list>
+        </attribute>
+
+
+        <!--  Table attributes  -->
+
+        <attribute name="border">
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="cellpadding">
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="cellspacing">
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="colspan">
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="rowspan">
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="background">
+            <regexp-list>
+                <regexp name="onsiteURL"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="bgcolor">
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="abbr">
+            <regexp-list>
+                <regexp name="paragraph"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="headers" description="The 'headers' attribute is a space-separated list of cell IDs">
+            <regexp-list>
+                <regexp value="[a-zA-Z0-9\s*]*"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="charoff">
+            <regexp-list>
+                <regexp value="numberOrPercent"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="char">
+            <regexp-list>
+                <regexp value=".{0,1}"/>
+            </regexp-list>
+        </attribute>
+
+
+        <attribute name="axis" description="The 'headers' attribute is a comma-separated list of related header cells">
+            <regexp-list>
+                <regexp value="[a-zA-Z0-9\s*,]*"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="nowrap" description="The 'nowrap' attribute tells the browser not to wrap text that goes over one line">
+            <regexp-list>
+                <regexp name="anything"/>
+                <!-- <regexp value="(nowrap){0,1}"/>  -->
+            </regexp-list>
+        </attribute>
+
+
+        <!--  Common positioning attributes  -->
+
+        <attribute name="width">
+            <regexp-list>
+                <regexp name="numberOrPercent"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="height">
+            <regexp-list>
+                <regexp name="numberOrPercent"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="align"
+                   description="The 'align' attribute of an HTML element is a direction word, like 'left', 'right' or 'center'">
+            <literal-list>
+                <literal value="center"/>
+                <literal value="middle"/>
+                <literal value="left"/>
+                <literal value="right"/>
+                <literal value="justify"/>
+                <literal value="char"/>
+            </literal-list>
+        </attribute>
+
+        <attribute name="valign"
+                   description="The 'valign' attribute of an HTML attribute is a direction word, like 'baseline','bottom','middle' or 'top'">
+            <literal-list>
+                <literal value="baseline"/>
+                <literal value="bottom"/>
+                <literal value="middle"/>
+                <literal value="top"/>
+            </literal-list>
+        </attribute>
+
+
+        <!-- Intrinsic JavaScript Events -->
+
+        <attribute name="onFocus" description="The 'onFocus' event is executed when the control associated with the tag gains focus">
+            <literal-list>
+                <literal value="javascript:void(0)"/>
+                <literal value="javascript:history.go(-1)"/>
+            </literal-list>
+        </attribute>
+
+        <attribute name="onBlur" description="The 'onBlur' event is executed when the control associated with the tag loses focus">
+            <literal-list>
+                <literal value="javascript:void(0)"/>
+                <literal value="javascript:history.go(-1)"/>
+            </literal-list>
+        </attribute>
+
+        <attribute name="onClick" description="The 'onClick' event is executed when the control associated with the tag is clicked">
+            <literal-list>
+                <literal value="javascript:void(0)"/>
+                <literal value="javascript:history.go(-1)"/>
+            </literal-list>
+        </attribute>
+
+        <attribute name="onDblClick"
+                   description="The 'onDblClick' event is executed when the control associated with the tag is clicked twice immediately">
+            <literal-list>
+                <literal value="javascript:void(0)"/>
+                <literal value="javascript:history.go(-1)"/>
+            </literal-list>
+        </attribute>
+
+        <attribute name="onMouseDown"
+                   description="The 'onMouseDown' event is executed when the control associated with the tag is clicked but not yet released">
+            <literal-list>
+                <literal value="javascript:void(0)"/>
+                <literal value="javascript:history.go(-1)"/>
+            </literal-list>
+        </attribute>
+
+        <attribute name="onMouseUp"
+                   description="The 'onMouseUp' event is executed when the control associated with the tag is clicked after the button is released">
+            <literal-list>
+                <literal value="javascript:void(0)"/>
+                <literal value="javascript:history.go(-1)"/>
+            </literal-list>
+        </attribute>
+
+        <attribute name="onMouseOver"
+                   description="The 'onMouseOver' event is executed when the user's mouse hovers over the control associated with the tag">
+            <literal-list>
+                <literal value="javascript:void(0)"/>
+                <literal value="javascript:history.go(-1)"/>
+            </literal-list>
+        </attribute>
+
+        <attribute name="scope" description="The 'scope' attribute defines what's covered by the header cells">
+            <literal-list>
+                <literal value="row"/>
+                <literal value="col"/>
+                <literal value="rowgroup"/>
+                <literal value="colgroup"/>
+            </literal-list>
+        </attribute>
+
+
+        <!-- If you want users to be able to mess with tabindex, uncomment this -->
+        <!--
+        <attribute name="tabindex" description="...">
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </attribute>
+         -->
+
+
+        <!-- Input/form related common attributes -->
+
+        <attribute name="disabled">
+            <regexp-list>
+                <regexp name="anything"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="readonly">
+            <regexp-list>
+                <regexp name="anything"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="accesskey">
+            <regexp-list>
+                <regexp name="anything"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="size">
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </attribute>
+
+
+        <attribute name="autocomplete">
+            <literal-list>
+                <literal value="on"/>
+                <literal value="off"/>
+            </literal-list>
+        </attribute>
+
+        <attribute name="rows">
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </attribute>
+
+        <attribute name="cols">
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </attribute>
+
+    </common-attributes>
+
+
+    <!--
+    This requires normal updates as browsers continue to diverge from the W3C and each other. As long as the browser wars continue
+    this is going to continue. I'm not sure war is the right word for what's going on. Doesn't somebody have to win a war after
+    a while? Even wars of attrition, surely?
+     -->
+
+    <global-tag-attributes>
+        <!-- Not valid in base, head, html, meta, param, script, style, and title elements. -->
+        <attribute name="id"/>
+        <attribute name="style"/>
+        <attribute name="title"/>
+        <attribute name="class"/>
+        <!-- Not valid in base, br, frame, frameset, hr, iframe, param, and script elements.  -->
+        <attribute name="lang"/>
+    </global-tag-attributes>
+
+    <tags-to-encode>
+        <tag>g</tag>
+        <tag>grin</tag>
+    </tags-to-encode>
+
+    <tag-rules>
+
+        <!-- You can mess with this stuff if you know what you're doing -->
+
+        <tag name="html" action="validate"/>
+
+        <tag name="body" action="validate">
+            <attribute name="bgcolor"/>
+        </tag>
+
+        <tag name="meta" action="filter"/>
+
+        <tag name="head" action="validate"/>
+
+        <!-- since we're validating the style sheets this is safe to have - switch to "truncate" if the user's html will appear in the html body -->
+        <tag name="title" action="truncate"/>
+
+
+        <!-- Tags related to JavaScript -->
+
+        <tag name="script" action="remove"/>
+        <tag name="noscript" action="validate"/>
+        <!-- although no javascript can fire inside a noscript tag, css is still a viable attack vector -->
+
+
+        <!-- Frame & related tags -->
+
+        <tag name="iframe" action="remove"/>
+        <tag name="frameset" action="remove"/>
+        <tag name="frame" action="remove"/>
+
+
+        <!-- Form related tags -->
+
+        <tag name="label" action="validate">
+            <attribute name="for">
+                <regexp-list>
+                    <regexp name="htmlId"/>
+                </regexp-list>
+            </attribute>
+        </tag>
+
+
+        <!--
+            If you wish to enable any of the form related tags, change the tag's action below from "filter" or "remove" to "validate". The attributes have been
+            hardened so this is safe to do, if it's something you want to allow. Beware the <><ing possibilities!
+         -->
+
+        <tag name="form" action="validate">
+
+            <attribute name="action">
+                <regexp-list>
+                    <regexp name="onsiteURL"/>
+                    <regexp name="offsiteURL"/>
+                </regexp-list>
+            </attribute>
+
+            <attribute name="name"/>
+
+            <attribute name="autocomplete"/>
+
+            <attribute name="method">
+                <literal-list>
+                    <literal value="post"/>
+                    <literal value="get"/>
+                </literal-list>
+            </attribute>
+
+        </tag>
+
+        <tag name="button" action="validate">
+            <attribute name="name"/>
+            <attribute name="value">
+                <regexp-list>
+                    <regexp name="anything"/>
+                </regexp-list>
+            </attribute>
+
+            <attribute name="disabled"/>
+            <attribute name="accesskey"/>
+            <attribute name="type">
+                <literal-list>
+                    <literal value="submit"/>
+                    <literal value="reset"/>
+                    <literal value="button"/>
+                </literal-list>
+            </attribute>
+        </tag>
+
+        <tag name="input" action="validate">
+
+            <attribute name="name"/>
+
+            <attribute name="size"/>
+
+            <attribute name="maxlength">
+                <regexp-list>
+                    <regexp name="number"/>
+                </regexp-list>
+            </attribute>
+
+            <attribute name="autocomplete"/>
+
+            <attribute name="checked">
+                <regexp-list>
+                    <regexp name="anything"/>
+                </regexp-list>
+            </attribute>
+
+            <attribute name="alt"/>
+
+            <attribute name="src">
+                <regexp-list>
+                    <regexp name="onsiteURL"/>
+                    <regexp name="offsiteURL"/>
+                </regexp-list>
+            </attribute>
+
+            <attribute name="usemap">
+                <regexp-list>
+                    <regexp name="onsiteURL"/>
+                </regexp-list>
+            </attribute>
+
+            <attribute name="type">
+                <literal-list>
+                    <literal value="hidden"/>
+                    <literal value="text"/>
+                    <literal value="password"/>
+                    <literal value="radio"/>
+                    <literal value="checkbox"/>
+                    <literal value="submit"/>
+                    <literal value="button"/>
+                    <literal value="image"/>
+                    <literal value="file"/>
+                    <literal value="reset"/>
+                </literal-list>
+            </attribute>
+
+            <attribute name="value">
+                <regexp-list>
+                    <regexp name="anything"/>
+                </regexp-list>
+            </attribute>
+
+            <attribute name="disabled"/>
+            <attribute name="readonly"/>
+            <attribute name="accesskey"/>
+
+            <attribute name="border"/>
+
+        </tag>
+
+        <tag name="select" action="validate">
+
+            <attribute name="name"/>
+            <attribute name="disabled"/>
+
+            <attribute name="multiple">
+                <regexp-list>
+                    <regexp name="anything"/>
+                </regexp-list>
+            </attribute>
+
+            <attribute name="size"/>
+
+        </tag>
+
+        <tag name="option" action="validate">
+
+            <attribute name="disabled"/>
+
+            <attribute name="value">
+                <regexp-list>
+                    <regexp name="anything"/>
+                </regexp-list>
+            </attribute>
+
+            <attribute name="label">
+                <regexp-list>
+                    <regexp name="anything"/>
+                </regexp-list>
+            </attribute>
+
+            <attribute name="selected">
+                <regexp-list>
+                    <regexp name="anything"/>
+                </regexp-list>
+            </attribute>
+        </tag>
+
+        <tag name="textarea" action="validate">
+            <attribute name="rows"/>
+            <attribute name="cols"/>
+            <attribute name="name"/>
+            <attribute name="disabled"/>
+            <attribute name="readonly"/>
+            <attribute name="accesskey"/>
+        </tag>
+
+
+        <!-- All formatting tags -->
+
+        <tag name="h1" action="validate"/>
+        <tag name="h2" action="validate"/>
+        <tag name="h3" action="validate"/>
+        <tag name="h4" action="validate"/>
+        <tag name="h5" action="validate"/>
+        <tag name="h6" action="validate"/>
+
+        <tag name="p" action="validate">
+            <attribute name="align"/>
+        </tag>
+
+        <tag name="i" action="validate"/>
+        <tag name="b" action="validate"/>
+        <tag name="u" action="validate"/>
+        <tag name="strong" action="validate"/>
+
+        <tag name="em" action="validate"/>
+        <tag name="small" action="validate"/>
+        <tag name="big" action="validate"/>
+        <tag name="pre" action="validate"/>
+        <tag name="code" action="validate"/>
+        <tag name="cite" action="validate"/>
+        <tag name="samp" action="validate"/>
+        <tag name="sub" action="validate"/>
+        <tag name="sup" action="validate"/>
+        <tag name="strike" action="validate"/>
+        <tag name="s" action="validate"/>
+        <tag name="center" action="validate"/>
+        <tag name="blockquote" action="validate"/>
+
+        <tag name="hr" action="validate"/>
+        <tag name="br" action="validate"/>
+
+        <tag name="col" action="validate"/>
+
+        <tag name="font" action="validate">
+            <attribute name="color">
+                <regexp-list>
+                    <regexp name="colorName"/>
+                    <regexp name="colorCode"/>
+                </regexp-list>
+            </attribute>
+
+            <attribute name="face">
+                <regexp-list>
+                    <regexp value="[\w;, \-]+"/>
+                </regexp-list>
+            </attribute>
+
+            <attribute name="size">
+                <regexp-list>
+                    <regexp value="(\+|-){0,1}(\d)+"/>
+                </regexp-list>
+            </attribute>
+        </tag>
+
+
+        <!-- Anchor and anchor related tags -->
+
+        <tag name="a" action="validate">
+
+            <!--  onInvalid="filterTag" has been removed as per suggestion at OWASP SJ 2007 - just "name" is valid -->
+            <attribute name="href"/>
+            <attribute name="onFocus"/>
+            <attribute name="onBlur"/>
+            <attribute name="nohref">
+                <regexp-list>
+                    <regexp name="anything"/>
+                </regexp-list>
+            </attribute>
+            <attribute name="rel">
+                <literal-list>
+                    <literal value="nofollow"/>
+                </literal-list>
+            </attribute>
+            <attribute name="name"/>
+            <attribute name="target"/>
+
+        </tag>
+
+        <tag name="map" action="validate"/>
+
+        <!-- base tag removed per demo - this could be enabled with literal-list values you allow -->
+        <!--
+        <tag name="base" action="validate">
+            <attribute name="href"/>
+        </tag>
+        -->
+
+
+        <!-- Stylesheet Tags -->
+
+        <tag name="style" action="validate">
+            <attribute name="type">
+                <literal-list>
+                    <literal value="text/css"/>
+                </literal-list>
+            </attribute>
+            <attribute name="media"/>
+        </tag>
+
+        <tag name="span" action="validate"/>
+
+        <tag name="div" action="validate">
+            <attribute name="align"/>
+        </tag>
+
+
+        <!-- Image & image related tags -->
+
+        <tag name="img" action="validate">
+            <attribute name="src" onInvalid="removeTag">
+                <regexp-list>
+                    <regexp name="onsiteURL"/>
+                    <regexp name="offsiteURL"/>
+                </regexp-list>
+            </attribute>
+            <attribute name="name"/>
+            <attribute name="alt"/>
+            <attribute name="height"/>
+            <attribute name="width"/>
+            <attribute name="border"/>
+            <attribute name="align"/>
+
+            <attribute name="hspace">
+                <regexp-list>
+                    <regexp name="number"/>
+                </regexp-list>
+            </attribute>
+
+            <attribute name="vspace">
+                <regexp-list>
+                    <regexp name="number"/>
+                </regexp-list>
+            </attribute>
+        </tag>
+
+        <!-- no way to do this safely without hooking up the same code to @import to embed the remote stylesheet (malicious user could change offsite resource to be malicious after validation -->
+        <!-- <attribute name="href" onInvalid="removeTag"/>  -->
+
+        <tag name="link" action="validate">
+
+            <!-- <attribute name="href" onInvalid="removeTag"/>  -->
+
+            <attribute name="media"/>
+
+            <attribute name="type" onInvalid="removeTag">
+                <literal-list>
+                    <literal value="text/css"/>
+                    <literal value="application/rss+xml"/>
+                    <literal value="image/x-icon"/>
+                </literal-list>
+            </attribute>
+
+            <attribute name="rel">
+                <literal-list>
+                    <literal value="stylesheet"/>
+                    <literal value="shortcut icon"/>
+                    <literal value="search"/>
+                    <literal value="copyright"/>
+                    <literal value="top"/>
+                    <literal value="alternate"/>
+                </literal-list>
+            </attribute>
+        </tag>
+
+
+        <!-- List tags -->
+
+        <tag name="ul" action="validate"/>
+        <tag name="ol" action="validate"/>
+        <tag name="li" action="validate"/>
+
+
+        <!-- Dictionary tags -->
+
+        <tag name="dd" action="truncate"/>
+        <tag name="dl" action="truncate"/>
+        <tag name="dt" action="truncate"/>
+
+
+        <!-- Table tags (tbody, thead, tfoot)-->
+
+        <tag name="caption" action="validate"/>
+
+        <tag name="thead" action="validate">
+            <attribute name="align"/>
+            <attribute name="char"/>
+            <attribute name="charoff"/>
+            <attribute name="valign"/>
+        </tag>
+
+        <tag name="tbody" action="validate">
+            <attribute name="align"/>
+            <attribute name="char"/>
+            <attribute name="charoff"/>
+            <attribute name="valign"/>
+        </tag>
+
+        <tag name="tfoot" action="validate">
+            <attribute name="align"/>
+            <attribute name="char"/>
+            <attribute name="charoff"/>
+            <attribute name="valign"/>
+        </tag>
+
+        <tag name="table" action="validate">
+            <attribute name="height"/>
+            <attribute name="width"/>
+            <attribute name="border"/>
+            <attribute name="bgcolor"/>
+            <attribute name="cellpadding"/>
+            <attribute name="cellspacing"/>
+            <attribute name="background"/>
+            <attribute name="align"/>
+            <attribute name="noresize">
+                <literal-list>
+                    <literal value="noresize"/>
+                    <literal value=""/>
+                </literal-list>
+            </attribute>
+        </tag>
+
+        <tag name="td" action="validate">
+            <attribute name="background"/>
+            <attribute name="bgcolor"/>
+            <attribute name="abbr"/>
+            <attribute name="axis"/>
+            <attribute name="headers"/>
+            <attribute name="scope"/>
+            <attribute name="nowrap"/>
+            <attribute name="height"/>
+            <attribute name="width"/>
+            <attribute name="align"/>
+            <attribute name="char"/>
+            <attribute name="charoff"/>
+            <attribute name="valign"/>
+            <attribute name="colspan"/>
+            <attribute name="rowspan"/>
+        </tag>
+
+        <tag name="th" action="validate">
+            <attribute name="abbr"/>
+            <attribute name="axis"/>
+            <attribute name="headers"/>
+            <attribute name="scope"/>
+            <attribute name="nowrap"/>
+            <attribute name="bgcolor"/>
+            <attribute name="height"/>
+            <attribute name="width"/>
+            <attribute name="align"/>
+            <attribute name="char"/>
+            <attribute name="charoff"/>
+            <attribute name="valign"/>
+            <attribute name="colspan"/>
+            <attribute name="rowspan"/>
+        </tag>
+
+        <tag name="tr" action="validate">
+            <attribute name="height"/>
+            <attribute name="width"/>
+            <attribute name="align"/>
+            <attribute name="valign"/>
+            <attribute name="char"/>
+            <attribute name="charoff"/>
+            <attribute name="background"/>
+        </tag>
+
+        <tag name="colgroup" action="validate">
+
+            <attribute name="span">
+                <regexp-list>
+                    <regexp name="number"/>
+                </regexp-list>
+            </attribute>
+            <attribute name="width"/>
+            <attribute name="align"/>
+            <attribute name="char"/>
+            <attribute name="charoff"/>
+            <attribute name="valign"/>
+        </tag>
+
+        <tag name="col" action="validate">
+            <attribute name="align"/>
+            <attribute name="char"/>
+            <attribute name="charoff"/>
+            <attribute name="valign"/>
+            <attribute name="span">
+                <regexp-list>
+                    <regexp name="number"/>
+                </regexp-list>
+            </attribute>
+            <attribute name="width"/>
+        </tag>
+
+        <tag name="fieldset" action="validate"/>
+        <tag name="legend" action="validate"/>
+
+
+        <!-- tags for popular Flash embeds -->
+
+        <tag name="object" action="validate">
+            <attribute name="id"/>
+            <attribute name="classid"/>
+            <attribute name="codebase"/>
+            <attribute name="type" onInvalid="removeTag">
+                <literal-list>
+                    <literal value="application/x-shockwave-flash"/>
+                </literal-list>
+            </attribute>
+            <attribute name="data" onInvalid="removeTag">
+                <regexp-list>
+                    <regexp name="flashSites"/>
+                </regexp-list>
+            </attribute>
+            <attribute name="align"/>
+            <attribute name="height"/>
+            <attribute name="width"/>
+            <attribute name="alt"/>
+            <attribute name="bgcolor">
+                <regexp-list>
+                    <regexp name="colorCode"/>
+                </regexp-list>
+            </attribute>
+        </tag>
+
+        <!-- with validateParamAsEmbed=true, this tag rule also covers <param> name/value pairs -->
+        <tag name="embed" action="validate">
+            <attribute name="src" onInvalid="removeTag">
+                <regexp-list>
+                    <regexp name="flashSites"/>
+                </regexp-list>
+            </attribute>
+            <attribute name="movie" onInvalid="removeTag">
+                <regexp-list>
+                    <regexp name="flashSites"/>
+                </regexp-list>
+            </attribute>
+            <attribute name="pluginspage">
+                <regexp-list>
+                    <regexp name="flashSites"/>
+                </regexp-list>
+            </attribute>
+            <attribute name="bgcolor">
+                <regexp-list>
+                    <regexp name="colorCode"/>
+                </regexp-list>
+            </attribute>
+            <attribute name="base">
+                <literal-list>
+                    <literal value="http://admin.brightcove.com"/>
+                </literal-list>
+            </attribute>
+            <attribute name="type">
+                <literal-list>
+                    <literal value="application/x-shockwave-flash"/>
+                </literal-list>
+            </attribute>
+            <attribute name="name">
+                <regexp-list>
+                    <regexp name="anything"/>
+                </regexp-list>
+            </attribute>
+            <attribute name="flashvars">
+                <regexp-list>
+                    <regexp name="anything"/>
+                    <!-- we could put something complex in here, but this is prolly fine for now-->
+                </regexp-list>
+            </attribute>
+            <attribute name="align"/>
+            <attribute name="height"/>
+            <attribute name="width"/>
+            <attribute name="allowfullscreen">
+                <regexp-list>
+                    <regexp name="boolean"/>
+                </regexp-list>
+            </attribute>
+            <attribute name="quality">
+                <literal-list>
+                    <literal value="high"/>
+                </literal-list>
+            </attribute>
+            <attribute name="allowscriptaccess">
+                <literal-list>
+                    <literal value="always"/>
+                    <literal value="samedomain"/>
+                </literal-list>
+            </attribute>
+            <attribute name="seamlesstabbing">
+                <regexp-list>
+                    <regexp name="boolean"/>
+                </regexp-list>
+            </attribute>
+            <attribute name="swliveconnect">
+                <regexp-list>
+                    <regexp name="boolean"/>
+                </regexp-list>
+            </attribute>
+            <attribute name="wmode">
+                <literal-list>
+                    <literal value="transparent"/>
+                    <literal value="window"/>
+                </literal-list>
+            </attribute>
+            <attribute name="allownetworking">
+                <literal-list>
+                    <literal value="all"/>
+                </literal-list>
+            </attribute>
+        </tag>
+
+    </tag-rules>
+
+
+    <!--  CSS validation processing rules  -->
+
+    <css-rules>
+
+        <property name="azimuth"
+                  description="This property is most likely to be implemented by mixing the same signal into different channels at differing volumes.">
+            <literal-list>
+                <literal value="left-side"/>
+                <literal value="far-left"/>
+                <literal value="left"/>
+                <literal value="center-left"/>
+                <literal value="center"/>
+                <literal value="center-right"/>
+                <literal value="right"/>
+                <literal value="far-right"/>
+                <literal value="right-side"/>
+                <literal value="behind"/>
+                <literal value="leftwards"/>
+                <literal value="rightwards"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="angle"/>
+            </regexp-list>
+        </property>
+
+        <property name="background"
+                  description="The 'background' property is a shorthand property for setting the individual background properties (i.e., 'background-color', 'background-image', 'background-repeat', 'background-attachment' and 'background-position') at the same place in the style sheet.">
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="background-color"/>
+                <shorthand name="background-image"/>
+                <shorthand name="background-repeat"/>
+                <shorthand name="background-attachment"/>
+                <shorthand name="background-position"/>
+            </shorthand-list>
+        </property>
+
+        <property name="background-attachment"
+                  description="If a background image is specified, this property specifies whether it is fixed with regard to the viewport ('fixed') or scrolls along with the document ('scroll').">
+            <literal-list>
+                <literal value="scroll"/>
+                <literal value="fixed"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+
+        <property name="background-color"
+                  description="This property sets the background color of an element, either a &lt;color&gt; value or the keyword 'transparent', to make the underlying colors shine through.">
+            <literal-list>
+                <literal value="transparent"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+            </regexp-list>
+        </property>
+
+        <property name="background-image" description="This property sets the background image of an element.">
+            <literal-list>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="cssOffsiteUri"/>
+                <regexp name="cssOnsiteUri"/>
+            </regexp-list>
+        </property>
+
+        <property name="background-position"
+                  description="If a background image has been specified, this property specifies its initial position.">
+            <literal-list>
+                <literal value="top"/>
+                <literal value="center"/>
+                <literal value="bottom"/>
+                <literal value="left"/>
+                <literal value="center"/>
+                <literal value="right"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="percentage"/>
+                <regexp name="length"/>
+            </regexp-list>
+        </property>
+
+        <property name="background-repeat"
+                  description="If a background image is specified, this property specifies whether the image is repeated (tiled), and how.">
+            <literal-list>
+                <literal value="repeat"/>
+                <literal value="repeat-x"/>
+                <literal value="repeat-y"/>
+                <literal value="no-repeat"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+
+        <!-- Begin simple properties -->
+        <property name="border-collapse" default="collapse" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="collapse"/>
+                <literal value="separate"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="border-color" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="transparent"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+            </regexp-list>
+        </property>
+        <property name="border-top-color" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+            </regexp-list>
+        </property>
+        <property name="border-right-color" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+            </regexp-list>
+        </property>
+        <property name="border-bottom-color" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+            </regexp-list>
+        </property>
+        <property name="border-left-color" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+            </regexp-list>
+        </property>
+        <property name="bottom" default="auto" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="caption-side" default="top" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="top"/>
+                <literal value="bottom"/>
+                <literal value="left"/>
+                <literal value="right"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="clear" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="none"/>
+                <literal value="left"/>
+                <literal value="right"/>
+                <literal value="both"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="color" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+            </regexp-list>
+        </property>
+        <property name="cue-after" default="none" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="cssOffsiteUri"/>
+                <regexp name="cssOnsiteUri"/>
+            </regexp-list>
+        </property>
+        <property name="cue-before" default="none" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="cssOffsiteUri"/>
+                <regexp name="cssOnsiteUri"/>
+            </regexp-list>
+        </property>
+        <property name="direction" default="ltr" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="ltr"/>
+                <literal value="rtl"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="display" default="inline" description="">
+            <category-list>
+                <category value="all"/>
+            </category-list>
+            <literal-list>
+                <literal value="inline"/>
+                <literal value="block"/>
+                <literal value="list-item"/>
+                <literal value="run-in"/>
+                <literal value="compact"/>
+                <literal value="marker"/>
+                <literal value="table"/>
+                <literal value="inline-table"/>
+                <literal value="table-row-group"/>
+                <literal value="table-header-group"/>
+                <literal value="table-footer-group"/>
+                <literal value="table-row"/>
+                <literal value="table-column-group"/>
+                <literal value="table-column"/>
+                <literal value="table-cell"/>
+                <literal value="table-caption"/>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="elevation" default="level" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="below"/>
+                <literal value="level"/>
+                <literal value="above"/>
+                <literal value="higher"/>
+                <literal value="lower"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="angle"/>
+            </regexp-list>
+        </property>
+        <property name="empty-cells" default="show" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="show"/>
+                <literal value="hide"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="float" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="left"/>
+                <literal value="right"/>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="font-size" default="medium" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="absolute-size"/>
+                <regexp name="relative-size"/>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="font-size-adjust" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </property>
+        <property name="font-stretch" default="normal" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="normal"/>
+                <literal value="wider"/>
+                <literal value="narrower"/>
+                <literal value="ultra-condensed"/>
+                <literal value="extra-condensed"/>
+                <literal value="condensed"/>
+                <literal value="semi-condensed"/>
+                <literal value="semi-expanded"/>
+                <literal value="expanded"/>
+                <literal value="extra-expanded"/>
+                <literal value="ultra-expanded"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="font-style" default="normal" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="normal"/>
+                <literal value="italic"/>
+                <literal value="oblique"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="font-variant" default="normal" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="normal"/>
+                <literal value="small-caps"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="font-weight" default="normal" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="normal"/>
+                <literal value="bold"/>
+                <literal value="bolder"/>
+                <literal value="lighter"/>
+                <literal value="100"/>
+                <literal value="200"/>
+                <literal value="300"/>
+                <literal value="400"/>
+                <literal value="500"/>
+                <literal value="600"/>
+                <literal value="700"/>
+                <literal value="800"/>
+                <literal value="900"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="height" default="auto" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="left" default="auto" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="letter-spacing" default="normal" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="normal"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+            </regexp-list>
+        </property>
+        <property name="line-height" default="normal" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="normal"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="number"/>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="list-style-image" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="cssOffsiteUri"/>
+                <regexp name="cssOnsiteUri"/>
+            </regexp-list>
+        </property>
+        <property name="list-style-position" default="outside" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inside"/>
+                <literal value="outside"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="list-style-type" default="disc" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="disc"/>
+                <literal value="circle"/>
+                <literal value="square"/>
+                <literal value="decimal"/>
+                <literal value="decimal-leading-zero"/>
+                <literal value="lower-roman"/>
+                <literal value="upper-roman"/>
+                <literal value="lower-greek"/>
+                <literal value="lower-alpha"/>
+                <literal value="lower-latin"/>
+                <literal value="upper-alpha"/>
+                <literal value="upper-latin"/>
+                <literal value="hebrew"/>
+                <literal value="armenian"/>
+                <literal value="georgian"/>
+                <literal value="cjk-ideographic"/>
+                <literal value="hiragana"/>
+                <literal value="katakana"/>
+                <literal value="hiragana-iroha"/>
+                <literal value="katakana-iroha"/>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="marker-offset" default="auto" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+            </regexp-list>
+        </property>
+        <property name="max-height" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="max-width" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="min-height" default="0" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="min-width" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="orphans" default="2" description="">
+            <category-list>
+                <category value="visual"/>
+                <category value="paged"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="integer"/>
+            </regexp-list>
+        </property>
+        <property name="outline-color" default="invert" description="">
+            <category-list>
+                <category value="visual"/>
+                <category value="interactive"/>
+            </category-list>
+            <literal-list>
+                <literal value="invert"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+            </regexp-list>
+        </property>
+        <property name="overflow" default="visible" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="visible"/>
+                <literal value="hidden"/>
+                <literal value="scroll"/>
+                <literal value="auto"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="page-break-after" default="auto" description="">
+            <category-list>
+                <category value="visual"/>
+                <category value="paged"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="always"/>
+                <literal value="avoid"/>
+                <literal value="left"/>
+                <literal value="right"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="page-break-before" default="auto" description="">
+            <category-list>
+                <category value="visual"/>
+                <category value="paged"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="always"/>
+                <literal value="avoid"/>
+                <literal value="left"/>
+                <literal value="right"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="page-break-inside" default="auto" description="">
+            <category-list>
+                <category value="visual"/>
+                <category value="paged"/>
+            </category-list>
+            <literal-list>
+                <literal value="avoid"/>
+                <literal value="auto"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="pause-after" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="time"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="pause-before" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="time"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="pitch" default="medium" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="x-low"/>
+                <literal value="low"/>
+                <literal value="medium"/>
+                <literal value="high"/>
+                <literal value="x-high"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="frequency"/>
+            </regexp-list>
+        </property>
+        <property name="pitch-range" default="50" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </property>
+        <property name="position" default="static" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="static"/>
+                <!-- possible to perform phishing attacks with the following -->
+                <!--
+                <literal value="relative"/>
+                <literal value="absolute"/>
+                <literal value="fixed"/>
+                 -->
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="richness" default="50" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </property>
+        <property name="right" default="auto" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="size" default="auto" description="">
+            <category-list>
+                <category value="visual"/>
+                <category value="paged"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="portrait"/>
+                <literal value="landscape"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+            </regexp-list>
+        </property>
+        <property name="speak" default="normal" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="normal"/>
+                <literal value="none"/>
+                <literal value="spell-out"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="speak-header" default="once" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="once"/>
+                <literal value="always"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="speak-numeral" default="continuous" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="digits"/>
+                <literal value="continuous"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="speak-punctuation" default="none" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="code"/>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="speech-rate" default="medium" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="x-slow"/>
+                <literal value="slow"/>
+                <literal value="medium"/>
+                <literal value="fast"/>
+                <literal value="x-fast"/>
+                <literal value="faster"/>
+                <literal value="slower"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </property>
+        <property name="stress" default="50" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="number"/>
+            </regexp-list>
+        </property>
+        <property name="table-layout" default="auto" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="fixed"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="text-indent" default="0" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="text-transform" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="capitalize"/>
+                <literal value="uppercase"/>
+                <literal value="lowercase"/>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="top" default="auto" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="unicode-bidi" default="normal" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="normal"/>
+                <literal value="embed"/>
+                <literal value="bidi-override"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="vertical-align" default="baseline" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="baseline"/>
+                <literal value="sub"/>
+                <literal value="super"/>
+                <literal value="top"/>
+                <literal value="text-top"/>
+                <literal value="middle"/>
+                <literal value="bottom"/>
+                <literal value="text-bottom"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="percentage"/>
+                <regexp name="length"/>
+            </regexp-list>
+        </property>
+        <property name="visibility" default="inherit" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="visible"/>
+                <literal value="hidden"/>
+                <literal value="collapse"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="volume" default="medium" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="silent"/>
+                <literal value="x-soft"/>
+                <literal value="soft"/>
+                <literal value="medium"/>
+                <literal value="loud"/>
+                <literal value="x-loud"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="number"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="white-space" default="normal" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="normal"/>
+                <literal value="pre"/>
+                <literal value="nowrap"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="widows" default="2" description="">
+            <category-list>
+                <category value="visual"/>
+                <category value="paged"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="integer"/>
+            </regexp-list>
+        </property>
+        <property name="width" default="auto" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="word-spacing" default="normal" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="normal"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+            </regexp-list>
+        </property>
+
+        <!-- end simple properties -->
+
+        <!-- begin medium properties -->
+        <property name="border-style" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+                <literal value="none"/>
+                <literal value="hidden"/>
+                <literal value="dotted"/>
+                <literal value="dashed"/>
+                <literal value="solid"/>
+                <literal value="double"/>
+                <literal value="groove"/>
+                <literal value="ridge"/>
+                <literal value="inset"/>
+                <literal value="outset"/>
+            </literal-list>
+        </property>
+        <property name="border-top-style" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="border-right-style" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="border-style"/>
+            </shorthand-list>
+        </property>
+        <property name="border-bottom-style" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="border-style"/>
+            </shorthand-list>
+        </property>
+        <property name="border-left-style" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="border-style"/>
+            </shorthand-list>
+        </property>
+        <property name="border-top-width" default="medium" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="border-width"/>
+            </shorthand-list>
+        </property>
+        <property name="border-right-width" default="medium" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="border-width"/>
+            </shorthand-list>
+        </property>
+        <property name="border-bottom-width" default="medium" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="border-width"/>
+            </shorthand-list>
+        </property>
+        <property name="border-left-width" default="medium" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="border-width"/>
+            </shorthand-list>
+        </property>
+        <property name="border-width" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+                <literal value="thin"/>
+                <literal value="medium"/>
+                <literal value="thick"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+            </regexp-list>
+        </property>
+        <property name="margin" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+                <literal value="auto"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="positiveLength"/>
+                <regexp name="positivePercentage"/>
+            </regexp-list>
+        </property>
+        <property name="margin-top" default="0" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="margin"/>
+            </shorthand-list>
+        </property>
+        <property name="margin-right" default="0" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="margin"/>
+            </shorthand-list>
+        </property>
+        <property name="margin-bottom" default="0" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="margin"/>
+            </shorthand-list>
+        </property>
+        <property name="margin-left" default="0" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="margin"/>
+            </shorthand-list>
+        </property>
+        <property name="outline-style" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+                <category value="interactive"/>
+            </category-list>
+
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="border-style"/>
+            </shorthand-list>
+        </property>
+        <property name="outline-width" default="medium" description="">
+            <category-list>
+                <category value="visual"/>
+                <category value="interactive"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="border-width"/>
+            </shorthand-list>
+        </property>
+        <property name="padding" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="padding-top" default="0" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="padding"/>
+            </shorthand-list>
+        </property>
+        <property name="padding-right" default="0" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="padding"/>
+            </shorthand-list>
+        </property>
+        <property name="padding-bottom" default="0" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="padding"/>
+            </shorthand-list>
+        </property>
+        <property name="padding-left" default="0" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="padding"/>
+            </shorthand-list>
+        </property>
+        <!-- end medium properties -->
+
+        <!-- begin hard properties -->
+        <property name="border" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+            </regexp-list>
+            <shorthand-list>
+                <shorthand name="border-width"/>
+                <shorthand name="border-style"/>
+            </shorthand-list>
+        </property>
+        <property name="border-top" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+            </regexp-list>
+            <shorthand-list>
+                <shorthand name="border-top-width"/>
+                <shorthand name="border-style"/>
+            </shorthand-list>
+        </property>
+        <property name="border-right" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+            </regexp-list>
+            <shorthand-list>
+                <shorthand name="border-top-width"/>
+                <shorthand name="border-style"/>
+            </shorthand-list>
+        </property>
+        <property name="border-bottom" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+            </regexp-list>
+            <shorthand-list>
+                <shorthand name="border-top-width"/>
+                <shorthand name="border-style"/>
+            </shorthand-list>
+        </property>
+        <property name="border-left" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+            </regexp-list>
+            <shorthand-list>
+                <shorthand name="border-top-width"/>
+                <shorthand name="border-style"/>
+            </shorthand-list>
+        </property>
+        <property name="cue" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="cue-before"/>
+                <shorthand name="cue-after"/>
+            </shorthand-list>
+        </property>
+        <property name="list-style" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="list-style-type"/>
+                <shorthand name="list-style-position"/>
+                <shorthand name="list-style-image"/>
+            </shorthand-list>
+        </property>
+        <property name="marks" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+                <category value="paged"/>
+            </category-list>
+            <literal-list>
+                <literal value="crop"/>
+                <literal value="cross"/>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="outline" description="">
+            <category-list>
+                <category value="visual"/>
+                <category value="interactive"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="outline-color"/>
+                <shorthand name="outline-style"/>
+                <shorthand name="outline-width"/>
+            </shorthand-list>
+        </property>
+        <property name="pause" description="">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="time"/>
+                <regexp name="percentage"/>
+            </regexp-list>
+        </property>
+        <property name="text-decoration" default="none" description="">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="none"/>
+                <literal value="underline"/>
+                <literal value="overline"/>
+                <literal value="line-through"/>
+                <literal value="blink"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <!-- end hard properties -->
+        <!--  begin manual properties -->
+        <property name="border-spacing" default="0"
+                  description="The lengths specify the distance that separates adjacent cell borders. If one length is specified, it gives both the horizontal and vertical spacing. If two are specified, the first gives the horizontal spacing and the second the vertical spacing. Lengths may not be negative.">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+            </regexp-list>
+        </property>
+        <property name="clip" default="auto"
+                  description="The 'clip' property applies to elements that have a 'overflow' property with a value other than 'visible'.">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+            </regexp-list>
+        </property>
+        <property name="counter-increment" default="none"
+                  description="The 'counter-increment' property accepts one or more names of counters (identifiers), each one optionally followed by an integer.">
+            <category-list>
+                <category value="all"/>
+            </category-list>
+            <literal-list>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="cssIdentifier"/>
+                <regexp name="integer"/>
+            </regexp-list>
+        </property>
+        <property name="clip" default="auto"
+                  description="The 'clip' property applies to elements that have a 'overflow' property with a value other than 'visible'.">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="length"/>
+            </regexp-list>
+        </property>
+        <property name="cursor" default="auto"
+                  description="This property specifies the type of cursor to be displayed for the pointing device.">
+            <category-list>
+                <category value="visual"/>
+                <category value="interactive"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+                <literal value="inherit"/>
+                <literal value="crosshair"/>
+                <literal value="default"/>
+                <literal value="pointer"/>
+                <literal value="move"/>
+                <literal value="e-resize"/>
+                <literal value="ne-resize"/>
+                <literal value="nw-resize"/>
+                <literal value="n-resize"/>
+                <literal value="se-resize"/>
+                <literal value="sw-resize"/>
+                <literal value="s-resize"/>
+                <literal value="w-resize| text"/>
+                <literal value="wait"/>
+                <literal value="help"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="cssOffsiteUri"/>
+                <regexp name="cssOnsiteUri"/>
+            </regexp-list>
+        </property>
+
+        <property name="text-shadow" default="none"
+                  description="This property accepts a comma-separated list of shadow effects to be applied to the text of the element.">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="none"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="colorName"/>
+                <regexp name="colorCode"/>
+                <regexp name="rgbCode"/>
+                <regexp name="systemColor"/>
+                <regexp name="length"/>
+            </regexp-list>
+        </property>
+
+        <property name="font"
+                  description="The 'font' property is, except as described below, a shorthand property for setting 'font-style', 'font-variant', 'font-weight', 'font-size', 'line-height', and 'font-family', at the same place in the style sheet.">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <literal-list>
+                <literal value="/"/>
+                <literal value="caption"/>
+                <literal value="icon"/>
+                <literal value="menu"/>
+                <literal value="message-box"/>
+                <literal value="small-caption"/>
+                <literal value="status-bar"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <shorthand-list>
+                <shorthand name="font-style"/>
+                <shorthand name="font-variant"/>
+                <shorthand name="font-weight"/>
+                <shorthand name="font-size"/>
+                <shorthand name="line-height"/>
+                <shorthand name="font-family"/>
+            </shorthand-list>
+        </property>
+
+        <property name="font-family"
+                  description="This property specifies a prioritized list of font family names and/or generic family names.">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <!-- allowing only generic font families -->
+            <literal-list>
+                <literal value="serif"/>
+                <literal value="arial"/>
+                <literal value="lucida console"/>
+                <literal value="sans-serif"/>
+                <literal value="cursive"/>
+                <literal value="verdana"/>
+                <literal value="fantasy"/>
+                <literal value="monospace"/>
+            </literal-list>
+
+
+            <regexp-list>
+                <regexp value="[\w,\-&apos;&quot; ]+"/>
+            </regexp-list>
+
+        </property>
+        <property name="page"
+                  description="The 'page' property can be used to specify a particular type of page where an element should be displayed.">
+            <category-list>
+                <category value="visual"/>
+                <category value="paged"/>
+            </category-list>
+            <literal-list>
+                <literal value="auto"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="cssIdentifier"/>
+            </regexp-list>
+        </property>
+        <property name="play-during" default="auto"
+                  description="Similar to the 'cue-before' and 'cue-after' properties, this property specifies a sound to be played as a background while an element's content is spoken.">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <literal-list>
+                <literal value="mix"/>
+                <literal value="repeat"/>
+                <literal value="none"/>
+                <literal value="auto"/>
+                <literal value="inherit"/>
+            </literal-list>
+            <regexp-list>
+                <regexp name="cssOffsiteUri"/>
+                <regexp name="cssOnsiteUri"/>
+            </regexp-list>
+        </property>
+        <property name="text-align" description="This property describes how inline content of a block is aligned.">
+            <category-list>
+                <category value="visual"/>
+            </category-list>
+            <!--  For safety, ignoring string alignment which can be used to line table cells on characters -->
+            <literal-list>
+                <literal value="left"/>
+                <literal value="right"/>
+                <literal value="center"/>
+                <literal value="justify"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <property name="voice-family"
+                  description="The value is a comma-separated, prioritized list of voice family names (compare with 'font-family').">
+            <category-list>
+                <category value="aural"/>
+            </category-list>
+            <!--  Allowing only generic voice family -->
+            <literal-list>
+                <literal value="male"/>
+                <literal value="female"/>
+                <literal value="child"/>
+                <literal value="inherit"/>
+            </literal-list>
+        </property>
+        <!--  end manual properties -->
+    </css-rules>
+
+
+    <allowed-empty-tags>
+        <literal-list>
+            <literal value="br"/>
+            <literal value="hr"/>
+            <literal value="a"/>
+            <literal value="img"/>
+            <literal value="link"/>
+            <literal value="iframe"/>
+            <literal value="script"/>
+            <literal value="object"/>
+            <literal value="applet"/>
+            <literal value="frame"/>
+            <literal value="base"/>
+            <literal value="param"/>
+            <literal value="meta"/>
+            <literal value="input"/>
+            <literal value="textarea"/>
+            <literal value="embed"/>
+            <literal value="basefont"/>
+            <literal value="col"/>
+            <literal value="div"/>
+        </literal-list>
+    </allowed-empty-tags>
+
+</anti-samy-rules>

--- a/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,2623 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2016-5394",
+    "groupID" : "foo",
+    "artifactID" : "org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:16:50.738548Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "javax.servlet-api-4.0.1.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/javax/servlet/javax.servlet-api/4.0.1/javax.servlet-api-4.0.1.jar",
+    "md5" : "b80414033bf3397de334b95e892a2f44",
+    "sha1" : "a27082684a2ff0bf397666c3943496c44541d1ca",
+    "sha256" : "83a03dd877d3674576f0da7b90755c8524af099ccf0607fc61aa971535ad7c60",
+    "description" : "Java(TM) Servlet 4.0 API Design Specification",
+    "license" : "CDDL + GPLv2 with classpath exception: https://oss.oracle.com/licenses/CDDL+GPL-1.1",
+    "projectReferences" : [ "CVE-2016-5394:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "javax"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "servlet"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "https://javaee.github.io"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "extension-name",
+        "value" : "javax.servlet"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Vendor",
+        "value" : "GlassFish Community"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Implementation-Vendor-Id",
+        "value" : "org.glassfish"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "specification-vendor",
+        "value" : "Oracle Corporation"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "edburns"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "shingwaichan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Ed Burns"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Shing Wai Chan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Oracle"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "javax.servlet"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Java Servlet API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "organization name",
+        "value" : "GlassFish Community"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "organization url",
+        "value" : "https://javaee.github.io"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "jvnet-parent"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "net.java"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://javaee.github.io/servlet-spec/"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom (hint)",
+        "name" : "developer org",
+        "value" : "sun"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "javax"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "servlet"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "https://javaee.github.io"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "Java Servlet API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "extension-name",
+        "value" : "javax.servlet"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "edburns"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "shingwaichan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Ed Burns"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Shing Wai Chan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Oracle"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "javax.servlet"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Java Servlet API"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "organization name",
+        "value" : "GlassFish Community"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "organization url",
+        "value" : "https://javaee.github.io"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "jvnet-parent"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "net.java"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://javaee.github.io/servlet-spec/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "4.0.1"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Version",
+        "value" : "4.0.1"
+      }, {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "4.0.1"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "4.0.1"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/javax.servlet/javax.servlet-api@4.0.1",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/javax.servlet/javax.servlet-api@4.0.1?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:oracle:java_se:4.0.1:*:*:*:*:*:*:*",
+      "confidence" : "MEDIUM",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aoracle&cpe_product=cpe%3A%2F%3Aoracle%3Ajava_se&cpe_version=cpe%3A%2F%3Aoracle%3Ajava_se%3A4.0.1"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "org.apache.sling.api-2.2.0.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/org/apache/sling/org.apache.sling.api/2.2.0/org.apache.sling.api-2.2.0.jar",
+    "md5" : "e4f63cd7cf73e66f25564c12d7d06ae4",
+    "sha1" : "bcd3526bb75faa458b23467d2bd34ad17ec77199",
+    "sha256" : "f06e163c61f194e12f72fe8465e987807103992011a4c0ea164b5e0d0c99afe6",
+    "description" : "\n        The Apache Sling API defines an extension to the Servlet\n        API 2.4 to provide access to content and unified access\n        to request parameters hiding the differences between the\n        different methods of transferring parameters from client\n        to server. Note that the Apache Sling API bundle does not\n        include the Servlet API but instead requires the API to\n        be provided by the Servlet container in which the Apache\n        Sling framework is running or by another bundle.\n    ",
+    "license" : "http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2016-5394:provided" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.apache.sling.api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "request"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "sling"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "sling"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://sling.apache.org/site/sling-api.html"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "org.apache.sling.api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "apache.sling.api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.apache.sling.api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.sling"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Sling API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "sling"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.apache.sling.api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "request"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "sling"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "sling"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://sling.apache.org/site/sling-api.html"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "Apache Sling API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "org.apache.sling.api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "apache.sling.api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.apache.sling.api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.sling"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Sling API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "sling"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "2.2.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Bundle-Version",
+        "value" : "2.2.0"
+      }, {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "2.2.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "2.2.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aapache&cpe_product=cpe%3A%2F%3Aapache%3Asling&cpe_version=cpe%3A%2F%3Aapache%3Asling%3A2.2.0"
+    }, {
+      "id" : "cpe:2.3:a:apache:sling_api:2.2.0:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aapache&cpe_product=cpe%3A%2F%3Aapache%3Asling_api&cpe_version=cpe%3A%2F%3Aapache%3Asling_api%3A2.2.0"
+    } ],
+    "vulnerabilities" : [ {
+      "source" : "NVD",
+      "name" : "CVE-2022-45064",
+      "severity" : "CRITICAL",
+      "cvssv3" : {
+        "baseScore" : 9.0,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "LOW",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "HIGH",
+        "integrityImpact" : "HIGH",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "CRITICAL",
+        "exploitabilityScore" : "2.3",
+        "impactScore" : "6.0",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "The SlingRequestDispatcher doesn't correctly implement the RequestDispatcher API resulting in a generic type of include-based cross-site scripting issues on the Apache Sling level. The vulnerability is exploitable by an attacker that is able to include a resource with specific content-type and control the include path (i.e. writing content). The impact of a successful attack is privilege escalation to administrative power.\n\n\n\n\nPlease update to Apache Sling Engine >= 2.14.0 and enable the \"Check Content-Type overrides\" configuration option.\n\n\n\n\n",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread/hhp611hltby3whk03vx2mv7cmy3vs0ok",
+        "name" : "https://lists.apache.org/thread/hhp611hltby3whk03vx2mv7cmy3vs0ok"
+      }, {
+        "source" : "MISC",
+        "url" : "http://www.openwall.com/lists/oss-security/2023/04/18/6",
+        "name" : "http://www.openwall.com/lists/oss-security/2023/04/18/6"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "2.14.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2022-32549",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 5.3,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "1.4",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-116" ],
+      "description" : "Apache Sling Commons Log <= 5.4.0 and Apache Sling API <= 2.25.0 are vulnerable to log injection. The ability to forge logs may allow an attacker to cover tracks by injecting fake logs and potentially corrupt log files.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://lists.apache.org/thread/7z6h3806mwcov5kx6l96pq839sn0po1v",
+        "name" : "N/A"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling_api:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "2.25.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling_commons_log:*:*:*:*:*:*:*:*",
+          "versionEndIncluding" : "5.4.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2015-2944",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "Multiple cross-site scripting (XSS) vulnerabilities in Apache Sling API before 2.2.2 and Apache Sling Servlets Post before 2.1.2 allow remote attackers to inject arbitrary web script or HTML via the URI, related to (1) org/apache/sling/api/servlets/HtmlResponse and (2) org/apache/sling/servlets/post/HtmlResponse.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r04237d561f3e5bced0a26287454450a34275162aa6b1dbae1b707b31@%3Cdev.sling.apache.org%3E",
+        "name" : "[sling-dev] 20210409 [jira] [Resolved] (SLING-10284) Dependency check fails on CVE-2015-2944 for Sling Resource Merger 1.4.0"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd2a352858630721e7b1655bbdf85e692d6156fcfe68109e12b017b16@%3Cdev.sling.apache.org%3E",
+        "name" : "[sling-dev] 20210409 [jira] [Created] (SLING-10284) Dependency check fails on CVE-2015-2944 for Sling Resource Merger 1.4.0"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://issues.apache.org/jira/browse/SLING-2082",
+        "name" : "https://issues.apache.org/jira/browse/SLING-2082"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://issues.apache.org/jira/browse/SLING-2082",
+        "name" : "https://issues.apache.org/jira/browse/SLING-2082"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r93d68359eb0ea8c0f26d71ca3998143f99209a24db7b4dacfc688cea@%3Cdev.sling.apache.org%3E",
+        "name" : "[sling-dev] 20210409 [jira] [Commented] (SLING-10284) Dependency check fails on CVE-2015-2944 for Sling Resource Merger 1.4.0"
+      }, {
+        "source" : "JVNDB",
+        "url" : "http://jvndb.jvn.jp/jvndb/JVNDB-2015-000069",
+        "name" : "JVNDB-2015-000069"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-2944",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-2944"
+      }, {
+        "source" : "JVN",
+        "url" : "http://jvn.jp/en/jp/JVN61328139/index.html",
+        "name" : "JVN#61328139"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r4f41dd891a52133abdbf7f74ad1dde80c46f157c1f1cf8c23ba60a70@%3Cdev.sling.apache.org%3E",
+        "name" : "[sling-dev] 20210409 [jira] [Comment Edited] (SLING-10284) Dependency check fails on CVE-2015-2944 for Sling Resource Merger 1.4.0"
+      }, {
+        "source" : "BID",
+        "url" : "http://www.securityfocus.com/bid/74839",
+        "name" : "74839"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2015-2944?component-type=maven&component-name=org.apache.sling%2Forg.apache.sling.api&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2015-2944] CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling_api:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "2.2.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling_servlets_post:*:*:*:*:*:*:*:*",
+          "versionEndIncluding" : "2.1.0"
+        }
+      } ]
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "org.apache.sling.xss.compat-1.0.0.jar (shaded: org.owasp.antisamy:antisamy:1.5.2)",
+    "filePath" : "/home/wtwhite/.m2/repository/org/apache/sling/org.apache.sling.xss.compat/1.0.0/org.apache.sling.xss.compat-1.0.0.jar/META-INF/maven/org.owasp.antisamy/antisamy/pom.xml",
+    "md5" : "9a2690977d745ea82ba29742774b120d",
+    "sha1" : "1e247f9ed4dc0f18708c617c80121153625a48a8",
+    "sha256" : "40d5cc25d88a143b4f7a5848f84ad33eb8288dccf0439a948c1880a1e2a69412",
+    "projectReferences" : [ "CVE-2016-5394:compile" ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "antisamy"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.owasp.antisamy"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "OWASP AntiSamy"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "antisamy-project"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "antisamy"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.owasp.antisamy"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "OWASP AntiSamy"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "antisamy-project"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.5.2"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.owasp.antisamy/antisamy@1.5.2",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.owasp.antisamy/antisamy@1.5.2?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:antisamy_project:antisamy:1.5.2:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aantisamy_project&cpe_product=cpe%3A%2F%3Aantisamy_project%3Aantisamy&cpe_version=cpe%3A%2F%3Aantisamy_project%3Aantisamy%3A1.5.2"
+    } ],
+    "vulnerabilities" : [ {
+      "source" : "NVD",
+      "name" : "CVE-2022-28366",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "NVD-CWE-noinfo" ],
+      "description" : "Certain Neko-related HTML parsers allow a denial of service via crafted Processing Instruction (PI) input that causes excessive heap memory consumption. In particular, this issue exists in HtmlUnit-Neko through 2.26, and is fixed in 2.27. This issue also exists in CyberNeko HTML through 1.9.22 (also affecting OWASP AntiSamy before 1.6.6), but 1.9.22 is the last version of CyberNeko HTML. NOTE: this may be related to CVE-2022-24839.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://github.com/nahsra/antisamy/releases/tag/v1.6.6",
+        "name" : "https://github.com/nahsra/antisamy/releases/tag/v1.6.6"
+      }, {
+        "source" : "MISC",
+        "url" : "https://sourceforge.net/projects/htmlunit/files/htmlunit/2.27/",
+        "name" : "https://sourceforge.net/projects/htmlunit/files/htmlunit/2.27/"
+      }, {
+        "source" : "MISC",
+        "url" : "https://search.maven.org/artifact/net.sourceforge.htmlunit/neko-htmlunit",
+        "name" : "https://search.maven.org/artifact/net.sourceforge.htmlunit/neko-htmlunit"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:antisamy_project:antisamy:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "1.6.6"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:cyberneko_html_project:cyberneko_html:*:*:*:*:*:*:*:*",
+          "versionEndIncluding" : "1.9.22"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:htmlunit_project:htmlunit:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "2.27"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2016-10006",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "In OWASP AntiSamy before 1.5.5, by submitting a specially crafted input (a tag that supports style with active content), you could bypass the library protections and supply executable code. The impact is XSS.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "BID",
+        "url" : "http://www.securityfocus.com/bid/95101",
+        "name" : "95101"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://github.com/nahsra/antisamy/issues/2",
+        "name" : "https://github.com/nahsra/antisamy/issues/2"
+      }, {
+        "source" : "SECTRACK",
+        "url" : "http://www.securitytracker.com/id/1037532",
+        "name" : "1037532"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:antisamy_project:antisamy:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "1.5.5"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2017-14735",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.0"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "OWASP AntiSamy before 1.5.7 allows XSS via HTML5 entities, as demonstrated by use of &colon; to construct a javascript: URL.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/nahsra/antisamy/issues/10",
+        "name" : "https://github.com/nahsra/antisamy/issues/10"
+      }, {
+        "source" : "BID",
+        "url" : "http://www.securityfocus.com/bid/105656",
+        "name" : "105656"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuApr2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuApr2021.html"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-14735",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-14735"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+        "name" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+        "name" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+        "name" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://github.com/nahsra/antisamy/issues/10",
+        "name" : "https://github.com/nahsra/antisamy/issues/10"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com//security-alerts/cpujul2021.html",
+        "name" : "N/A"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2020.html",
+        "name" : "N/A"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2017-14735?component-type=maven&component-name=org.owasp.antisamy%2Fantisamy&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2017-14735] CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:antisamy_project:antisamy:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "1.5.7"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-35043",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "OWASP AntiSamy before 1.6.4 allows XSS via HTML attributes when using the HTML output serializer (XHTML is not affected). This was demonstrated by a javascript: URL with &#00058 as the replacement for the : character.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2021-35043?component-type=maven&component-name=org.owasp.antisamy%2Fantisamy&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2021-35043] CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/nahsra/antisamy/pull/87",
+        "name" : "https://github.com/nahsra/antisamy/pull/87"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/nahsra/antisamy/releases/tag/v1.6.4",
+        "name" : "https://github.com/nahsra/antisamy/releases/tag/v1.6.4"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35043",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35043"
+      }, {
+        "source" : "MISC",
+        "url" : "https://github.com/nahsra/antisamy/pull/87",
+        "name" : "https://github.com/nahsra/antisamy/pull/87"
+      }, {
+        "source" : "MISC",
+        "url" : "https://github.com/nahsra/antisamy/releases/tag/v1.6.4",
+        "name" : "https://github.com/nahsra/antisamy/releases/tag/v1.6.4"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:antisamy_project:antisamy:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "1.6.4"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.6.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.10.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.12.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_managment:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "2.3.0",
+          "versionEndIncluding" : "2.4.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "2.3.0",
+          "versionEndIncluding" : "2.4.1"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.6.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.7.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:middleware_common_libraries_and_tools:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:middleware_common_libraries_and_tools:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_back_office:14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_back_office:14.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_central_office:14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_central_office:14.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_returns_management:14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_returns_management:14.1:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2022-28367",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "OWASP AntiSamy before 1.6.6 allows XSS via HTML tag smuggling on STYLE content with crafted input. The output serializer does not properly encode the supposed Cascading Style Sheets (CSS) content.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/nahsra/antisamy/pull/162",
+        "name" : "https://github.com/nahsra/antisamy/pull/162"
+      }, {
+        "source" : "MISC",
+        "url" : "https://github.com/nahsra/antisamy/commit/0199e7e194dba5e7d7197703f43ebe22401e61ae",
+        "name" : "https://github.com/nahsra/antisamy/commit/0199e7e194dba5e7d7197703f43ebe22401e61ae"
+      }, {
+        "source" : "MISC",
+        "url" : "https://github.com/nahsra/antisamy/releases/tag/v1.6.6",
+        "name" : "https://github.com/nahsra/antisamy/releases/tag/v1.6.6"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2022-28367?component-type=maven&component-name=org.owasp.antisamy%2Fantisamy&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2022-28367] CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/nahsra/antisamy/releases/tag/v1.6.6",
+        "name" : "https://github.com/nahsra/antisamy/releases/tag/v1.6.6"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-28367",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-28367"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:antisamy_project:antisamy:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "1.6.6"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2022-29577",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "OWASP AntiSamy before 1.6.7 allows XSS via HTML tag smuggling on STYLE content with crafted input. The output serializer does not properly encode the supposed Cascading Style Sheets (CSS) content. NOTE: this issue exists because of an incomplete fix for CVE-2022-28367.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://github.com/nahsra/antisamy/commit/32e273507da0e964b58c50fd8a4c94c9d9363af0",
+        "name" : "https://github.com/nahsra/antisamy/commit/32e273507da0e964b58c50fd8a4c94c9d9363af0"
+      }, {
+        "source" : "MISC",
+        "url" : "https://github.com/nahsra/antisamy/releases/tag/v1.6.7",
+        "name" : "https://github.com/nahsra/antisamy/releases/tag/v1.6.7"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:antisamy_project:antisamy:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "1.6.7"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:enterprise_manager_base_platform:13.4.0.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:enterprise_manager_base_platform:13.5.0.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:14.1.1.0.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "org.apache.sling.xss.compat-1.0.0.jar (shaded: org.owasp.encoder:encoder:1.1.1)",
+    "filePath" : "/home/wtwhite/.m2/repository/org/apache/sling/org.apache.sling.xss.compat/1.0.0/org.apache.sling.xss.compat-1.0.0.jar/META-INF/maven/org.owasp.encoder/encoder/pom.xml",
+    "md5" : "25d038eefb2fc54853c3a5169fdd09bd",
+    "sha1" : "7d5108b66b690d884bbf57af429f2aa0d2541353",
+    "sha256" : "ec69803ba96a994497513614715d47a67364b7c7b06c8ebaa7a1b9c303c55ac2",
+    "description" : "\n    The OWASP Encoders package is a collection of high-performance low-overhead\n    contextual encoders, that when utilized correctly, is an effective tool in\n    preventing Web Application security vulnerabilities such as Cross-Site\n    Scripting.\n    ",
+    "projectReferences" : [ "CVE-2016-5394:compile" ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "encoder"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.owasp.encoder"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "OWASP Encoders"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "encoder-parent"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "encoder"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.owasp.encoder"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "OWASP Encoders"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "encoder-parent"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.1.1"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.owasp.encoder/encoder@1.1.1",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.owasp.encoder/encoder@1.1.1?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "org.apache.sling.xss.compat-1.0.0.jar (shaded: org.owasp.esapi:esapi:2.1.0)",
+    "filePath" : "/home/wtwhite/.m2/repository/org/apache/sling/org.apache.sling.xss.compat/1.0.0/org.apache.sling.xss.compat-1.0.0.jar/META-INF/maven/org.owasp.esapi/esapi/pom.xml",
+    "md5" : "fa198a53f56821c2888522cea8dc343c",
+    "sha1" : "051fb581ea0b43ee990670dd0fc6de28c1fb570e",
+    "sha256" : "e64d378346c9bfc5880d563f4539b58f37d6832d8b654b3e467d7d8a96103b7d",
+    "description" : "The Enterprise Security API (ESAPI) project is an OWASP project\n        to create simple strong security controls for every web platform.\n        Security controls are not simple to build. You can read about the\n        hundreds of pitfalls for unwary developers on the OWASP web site. By\n        providing developers with a set of strong controls, we aim to\n        eliminate some of the complexity of creating secure web applications.\n        This can result in significant cost savings across the SDLC.\n    ",
+    "license" : "BSD: http://www.opensource.org/licenses/bsd-license.php\nCreative Commons 3.0 BY-SA: http://creativecommons.org/licenses/by-sa/3.0/",
+    "projectReferences" : [ "CVE-2016-5394:compile" ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "esapi"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Chris Schmidt"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Jeff Williams"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Jim Manico"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Kevin W. Wall"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Aspect Security"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Wells Fargo"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.owasp.esapi"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "ESAPI"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "organization name",
+        "value" : "The Open Web Application Security Project (OWASP)"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "organization url",
+        "value" : "http://www.owasp.org/index.php"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://www.esapi.org/"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "esapi"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Chris Schmidt"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Jeff Williams"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Jim Manico"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Kevin W. Wall"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Aspect Security"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Wells Fargo"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.owasp.esapi"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "ESAPI"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "organization name",
+        "value" : "The Open Web Application Security Project (OWASP)"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "organization url",
+        "value" : "http://www.owasp.org/index.php"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://www.esapi.org/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "2.1.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.owasp.esapi/esapi@2.1.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.owasp.esapi/esapi@2.1.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilities" : [ {
+      "source" : "OSSINDEX",
+      "name" : "CVE-2022-23457",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 9.8,
+        "accessVector" : "N",
+        "accessComplexity" : "L",
+        "authenticationr" : "$enc.json($vuln.cvssV2.authentication)",
+        "confidentialImpact" : "H",
+        "integrityImpact" : "H",
+        "availabilityImpact" : "H",
+        "severity" : "HIGH"
+      },
+      "cwes" : [ "CWE-22" ],
+      "description" : "ESAPI (The OWASP Enterprise Security API) is a free, open source, web application security control library. Prior to version 2.3.0.0, the default implementation of `Validator.getValidDirectoryPath(String, String, File, boolean)` may incorrectly treat the tested input string as a child of the specified parent directory. This potentially could allow control-flow bypass checks to be defeated if an attack can specify the entire string representing the 'input' path. This vulnerability is patched in release 2.3.0.0 of ESAPI. As a workaround, it is possible to write one's own implementation of the Validator interface. However, maintainers do not recommend this.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/ESAPI/esapi-java-legacy/blob/develop/documentation/esapi4java-core-2.3.0.0-release-notes.txt",
+        "name" : "https://github.com/ESAPI/esapi-java-legacy/blob/develop/documentation/esapi4java-core-2.3.0.0-release-notes.txt"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2022-23457?component-type=maven&component-name=org.owasp.esapi%2Fesapi&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2022-23457] CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-23457",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-23457"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://securitylab.github.com/advisories/GHSL-2022-008_The_OWASP_Enterprise_Security_API/",
+        "name" : "https://securitylab.github.com/advisories/GHSL-2022-008_The_OWASP_Enterprise_Security_API/"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:org.owasp.esapi:esapi:2.1.0:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true"
+        }
+      } ]
+    }, {
+      "source" : "OSSINDEX",
+      "name" : "CVE-2022-24891",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 6.1,
+        "accessVector" : "N",
+        "accessComplexity" : "L",
+        "authenticationr" : "$enc.json($vuln.cvssV2.authentication)",
+        "confidentialImpact" : "L",
+        "integrityImpact" : "L",
+        "availabilityImpact" : "N",
+        "severity" : "MEDIUM"
+      },
+      "cwes" : [ "CWE-Other" ],
+      "description" : "ESAPI (The OWASP Enterprise Security API) is a free, open source, web application security control library. Prior to version 2.3.0.0, there is a potential for a cross-site scripting vulnerability in ESAPI caused by a incorrect regular expression for \"onsiteURL\" in the **antisamy-esapi.xml** configuration file that can cause \"javascript:\" URLs to fail to be correctly sanitized. This issue is patched in ESAPI 2.3.0.0. As a workaround, manually edit the **antisamy-esapi.xml** configuration files to change the \"onsiteURL\" regular expression. More information about remediation of the vulnerability, including the workaround, is available in the maintainers' release notes and security bulletin.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2022-24891?component-type=maven&component-name=org.owasp.esapi%2Fesapi&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2022-24891] CWE-Other"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/ESAPI/esapi-java-legacy/blob/develop/documentation/ESAPI-security-bulletin8.pdf",
+        "name" : "https://github.com/ESAPI/esapi-java-legacy/blob/develop/documentation/ESAPI-security-bulletin8.pdf"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-24891",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-24891"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/ESAPI/esapi-java-legacy/security/advisories/GHSA-q77q-vx4q-xx6q",
+        "name" : "https://github.com/ESAPI/esapi-java-legacy/security/advisories/GHSA-q77q-vx4q-xx6q"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:org.owasp.esapi:esapi:2.1.0:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true"
+        }
+      } ]
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "org.apache.sling.xss.compat-1.0.0.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/org/apache/sling/org.apache.sling.xss.compat/1.0.0/org.apache.sling.xss.compat-1.0.0.jar",
+    "md5" : "49761a2966763bbf3c5bed0f7afe541c",
+    "sha1" : "faa555729b10d1d27ae85a0ef2b2bd0cd492d36f",
+    "sha256" : "3b9b77a47b8bfc5ca62a0ed157c4a54b45949154734c0dcdfbe37bfd682ca3cd",
+    "description" : "\n        Apache Sling XSS Protection Compat Bundle providing XSS protection based on the OWASP AntiSamy and OWASP Java Encoder libraries.\n    ",
+    "license" : "http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2016-5394:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.apache.sling.xss.compat"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "antisamy"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "encoder"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "owasp"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "sling"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xss"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "sling"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://sling.apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-requiredexecutionenvironment",
+        "value" : "JavaSE-1.6"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "org.apache.sling.xss.compat"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "service-component",
+        "value" : "OSGI-INF/org.apache.sling.xss.impl.XSSFilterImpl.xml,OSGI-INF/org.apache.sling.xss.impl.XSSAPIAdapterFactory.xml,OSGI-INF/org.apache.sling.xss.impl.XSSAPIImpl.xml"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "sling-initial-content",
+        "value" : "SLING-INF/content;path:=/libs/sling/xss;overwrite:=true;ignoreImportProviders:=xml"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "apache.sling.xss.compat"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.apache.sling.xss.compat"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.sling"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Sling XSS Protection Compat Bundle"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "sling"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.apache.sling.xss.compat"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "antisamy"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "encoder"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "impl"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "owasp"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "sling"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xml"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xss"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "sling"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://sling.apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "Apache Sling XSS Protection Compat Bundle"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-requiredexecutionenvironment",
+        "value" : "JavaSE-1.6"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "org.apache.sling.xss.compat"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "service-component",
+        "value" : "OSGI-INF/org.apache.sling.xss.impl.XSSFilterImpl.xml,OSGI-INF/org.apache.sling.xss.impl.XSSAPIAdapterFactory.xml,OSGI-INF/org.apache.sling.xss.impl.XSSAPIImpl.xml"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "sling-initial-content",
+        "value" : "SLING-INF/content;path:=/libs/sling/xss;overwrite:=true;ignoreImportProviders:=xml"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "apache.sling.xss.compat"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.apache.sling.xss.compat"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.sling"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Sling XSS Protection Compat Bundle"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "sling"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.0.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Bundle-Version",
+        "value" : "1.0.0"
+      }, {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "1.0.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.0.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.apache.sling/org.apache.sling.xss.compat@1.0.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.apache.sling/org.apache.sling.xss.compat@1.0.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aapache&cpe_product=cpe%3A%2F%3Aapache%3Asling&cpe_version=cpe%3A%2F%3Aapache%3Asling%3A1.0.0"
+    }, {
+      "id" : "cpe:2.3:a:apache:sling_api:1.0.0:*:*:*:*:*:*:*",
+      "confidence" : "LOW"
+    }, {
+      "id" : "cpe:2.3:a:apache:sling_xss_protection_api:1.0.0:*:*:*:*:*:*:*",
+      "confidence" : "LOW"
+    }, {
+      "id" : "cpe:2.3:a:apache:sling_xss_protection_api_compat:1.0.0:*:*:*:*:*:*:*",
+      "confidence" : "LOW"
+    } ],
+    "vulnerabilities" : [ {
+      "source" : "NVD",
+      "name" : "CVE-2016-6798",
+      "severity" : "CRITICAL",
+      "cvssv2" : {
+        "score" : 7.5,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "PARTIAL",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "HIGH",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "6.4"
+      },
+      "cvssv3" : {
+        "baseScore" : 9.8,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "HIGH",
+        "integrityImpact" : "HIGH",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "CRITICAL",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "5.9",
+        "version" : "3.0"
+      },
+      "cwes" : [ "CWE-611" ],
+      "description" : "In the XSS Protection API module before 1.0.12 in Apache Sling, the method XSS.getValidXML() uses an insecure SAX parser to validate the input string, which allows for XXE attacks in all scripts which use this method to validate user input, potentially allowing an attacker to read sensitive data on the filesystem, perform same-site-request-forgery (SSRF), port-scanning behind the firewall or DoS the application.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "BID",
+        "url" : "http://www.securityfocus.com/bid/99873",
+        "name" : "99873"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/b72c3a511592ec70729b3ec2d29302b6ce87bbeab62d4745617a6bd0@%3Cdev.sling.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/b72c3a511592ec70729b3ec2d29302b6ce87bbeab62d4745617a6bd0@%3Cdev.sling.apache.org%3E"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "1.0.10"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2022-45064",
+      "severity" : "CRITICAL",
+      "cvssv3" : {
+        "baseScore" : 9.0,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "LOW",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "HIGH",
+        "integrityImpact" : "HIGH",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "CRITICAL",
+        "exploitabilityScore" : "2.3",
+        "impactScore" : "6.0",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "The SlingRequestDispatcher doesn't correctly implement the RequestDispatcher API resulting in a generic type of include-based cross-site scripting issues on the Apache Sling level. The vulnerability is exploitable by an attacker that is able to include a resource with specific content-type and control the include path (i.e. writing content). The impact of a successful attack is privilege escalation to administrative power.\n\n\n\n\nPlease update to Apache Sling Engine >= 2.14.0 and enable the \"Check Content-Type overrides\" configuration option.\n\n\n\n\n",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread/hhp611hltby3whk03vx2mv7cmy3vs0ok",
+        "name" : "https://lists.apache.org/thread/hhp611hltby3whk03vx2mv7cmy3vs0ok"
+      }, {
+        "source" : "MISC",
+        "url" : "http://www.openwall.com/lists/oss-security/2023/04/18/6",
+        "name" : "http://www.openwall.com/lists/oss-security/2023/04/18/6"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "2.14.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2016-5394",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "In the XSS Protection API module before 1.0.12 in Apache Sling, the encoding done by the XSSAPI.encodeForJSString() method is not restrictive enough and for some input patterns allows script tags to pass through unencoded, leading to potential XSS vulnerabilities.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "BID",
+        "url" : "http://www.securityfocus.com/bid/99870",
+        "name" : "99870"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/332166037a54b97cf41e2b616aaed38439de94b19b204841478e4525@%3Cdev.sling.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/332166037a54b97cf41e2b616aaed38439de94b19b204841478e4525@%3Cdev.sling.apache.org%3E"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "1.0.12"
+        }
+      } ]
+    }, {
+      "source" : "OSSINDEX",
+      "name" : "CVE-2017-15717",
+      "severity" : "MEDIUM",
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "N",
+        "attackComplexity" : "L",
+        "privilegesRequired" : "N",
+        "userInteraction" : "R",
+        "scope" : "C",
+        "confidentialityImpact" : "L",
+        "integrityImpact" : "L",
+        "availabilityImpact" : "N",
+        "baseSeverity" : "MEDIUM"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "A flaw in the way URLs are escaped and encoded in the org.apache.sling.xss.impl.XSSAPIImpl#getValidHref and org.apache.sling.xss.impl.XSSFilterImpl#isValidHref allows special crafted URLs to pass as valid, although they carry XSS payloads. The affected versions are Apache Sling XSS Protection API 1.0.4 to 1.0.18, Apache Sling XSS Protection API Compat 1.1.0 and Apache Sling XSS Protection API 2.0.0.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2017-15717 for details",
+      "notes" : "",
+      "references" : [ {
+        "source" : "OSSIndex",
+        "url" : "https://issues.apache.org/jira/browse/SLING-7323",
+        "name" : "https://issues.apache.org/jira/browse/SLING-7323"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-15717",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-15717"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2017-15717?component-type=maven&component-name=org.apache.sling%2Forg.apache.sling.xss.compat&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2017-15717] CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:org.apache.sling:org.apache.sling.xss.compat:1.0.0:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2022-32549",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 5.3,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "1.4",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-116" ],
+      "description" : "Apache Sling Commons Log <= 5.4.0 and Apache Sling API <= 2.25.0 are vulnerable to log injection. The ability to forge logs may allow an attacker to cover tracks by injecting fake logs and potentially corrupt log files.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://lists.apache.org/thread/7z6h3806mwcov5kx6l96pq839sn0po1v",
+        "name" : "N/A"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling_api:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "2.25.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling_commons_log:*:*:*:*:*:*:*:*",
+          "versionEndIncluding" : "5.4.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2015-2944",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "Multiple cross-site scripting (XSS) vulnerabilities in Apache Sling API before 2.2.2 and Apache Sling Servlets Post before 2.1.2 allow remote attackers to inject arbitrary web script or HTML via the URI, related to (1) org/apache/sling/api/servlets/HtmlResponse and (2) org/apache/sling/servlets/post/HtmlResponse.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r04237d561f3e5bced0a26287454450a34275162aa6b1dbae1b707b31@%3Cdev.sling.apache.org%3E",
+        "name" : "[sling-dev] 20210409 [jira] [Resolved] (SLING-10284) Dependency check fails on CVE-2015-2944 for Sling Resource Merger 1.4.0"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd2a352858630721e7b1655bbdf85e692d6156fcfe68109e12b017b16@%3Cdev.sling.apache.org%3E",
+        "name" : "[sling-dev] 20210409 [jira] [Created] (SLING-10284) Dependency check fails on CVE-2015-2944 for Sling Resource Merger 1.4.0"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://issues.apache.org/jira/browse/SLING-2082",
+        "name" : "https://issues.apache.org/jira/browse/SLING-2082"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r93d68359eb0ea8c0f26d71ca3998143f99209a24db7b4dacfc688cea@%3Cdev.sling.apache.org%3E",
+        "name" : "[sling-dev] 20210409 [jira] [Commented] (SLING-10284) Dependency check fails on CVE-2015-2944 for Sling Resource Merger 1.4.0"
+      }, {
+        "source" : "JVNDB",
+        "url" : "http://jvndb.jvn.jp/jvndb/JVNDB-2015-000069",
+        "name" : "JVNDB-2015-000069"
+      }, {
+        "source" : "JVN",
+        "url" : "http://jvn.jp/en/jp/JVN61328139/index.html",
+        "name" : "JVN#61328139"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r4f41dd891a52133abdbf7f74ad1dde80c46f157c1f1cf8c23ba60a70@%3Cdev.sling.apache.org%3E",
+        "name" : "[sling-dev] 20210409 [jira] [Comment Edited] (SLING-10284) Dependency check fails on CVE-2015-2944 for Sling Resource Merger 1.4.0"
+      }, {
+        "source" : "BID",
+        "url" : "http://www.securityfocus.com/bid/74839",
+        "name" : "74839"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling_api:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "2.2.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling_servlets_post:*:*:*:*:*:*:*:*",
+          "versionEndIncluding" : "2.1.0"
+        }
+      } ]
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "org.osgi.compendium-4.1.0.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/org/osgi/org.osgi.compendium/4.1.0/org.osgi.compendium-4.1.0.jar",
+    "md5" : "d5d6b2f7a724409184524de3633095b6",
+    "sha1" : "ca4b2d8f88b6d06cd49d99cd1f67e58293703aaa",
+    "sha256" : "6af2f4e80093b4d8de6221412c46b1d9917cfe1e458f43e97a86df1e04f22edc",
+    "description" : "OSGi Service Platform Release 4 Compendium Interfaces and Classes.",
+    "projectReferences" : [ "CVE-2016-5394:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.osgi.compendium"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "osgi"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "osgi"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-copyright",
+        "value" : "Copyright (c) OSGi Alliance (2000, 2007). All Rights Reserved."
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://www.osgi.org/"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "osgi.compendium"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "cvs-header",
+        "value" : "$Header: /cvshome/build/osgi/osgi.cmpn.mf,v 1.5 2007/01/27 03:03:33 hargrave Exp $"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.osgi.compendium"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "osgi.compendium"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.osgi"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.osgi.compendium"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "http"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "osgi"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "service"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "osgi"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-copyright",
+        "value" : "Copyright (c) OSGi Alliance (2000, 2007). All Rights Reserved."
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://www.osgi.org/"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "osgi.compendium"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "osgi.compendium"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "cvs-header",
+        "value" : "$Header: /cvshome/build/osgi/osgi.cmpn.mf,v 1.5 2007/01/27 03:03:33 hargrave Exp $"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.osgi.compendium"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "osgi.compendium"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.osgi"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "4.1.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "4.1.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.osgi/org.osgi.compendium@4.1.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.osgi/org.osgi.compendium@4.1.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "org.osgi.core-4.1.0.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/org/osgi/org.osgi.core/4.1.0/org.osgi.core-4.1.0.jar",
+    "md5" : "2f53de1a2939934088d4899e25967697",
+    "sha1" : "b88cd082b5b6774e9db939e28c0e3dc526c92d89",
+    "sha256" : "1073de173c659fc1aba698a41faee196cdab9a5b2455e83429d1f7393093934a",
+    "description" : "OSGi Service Platform Release 4 Core Interface and Classes.",
+    "projectReferences" : [ "CVE-2016-5394:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.osgi.core"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "osgi"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "osgi"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-copyright",
+        "value" : "Copyright (c) OSGi Alliance (2000, 2007). All Rights Reserved."
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://www.osgi.org/"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "osgi.core"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "cvs-header",
+        "value" : "$Header: /cvshome/build/osgi/osgi.core.mf,v 1.6 2007/01/27 03:03:33 hargrave Exp $"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.osgi.core"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "osgi.core"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.osgi"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.osgi.core"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "osgi"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "service"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "osgi"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-copyright",
+        "value" : "Copyright (c) OSGi Alliance (2000, 2007). All Rights Reserved."
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://www.osgi.org/"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "osgi.core"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "osgi.core"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "cvs-header",
+        "value" : "$Header: /cvshome/build/osgi/osgi.core.mf,v 1.6 2007/01/27 03:03:33 hargrave Exp $"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.osgi.core"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "osgi.core"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.osgi"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "4.1.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "4.1.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.osgi/org.osgi.core@4.1.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.osgi/org.osgi.core@4.1.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  } ]
+}

--- a/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/grype/grype-report.json
+++ b/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/grype/grype-report.json
@@ -1,0 +1,1387 @@
+{
+ "matches": [
+  {
+   "vulnerability": {
+    "id": "CVE-2022-45064",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-45064",
+    "namespace": "nvd:cpe",
+    "severity": "Critical",
+    "urls": [
+     "http://www.openwall.com/lists/oss-security/2023/04/18/6",
+     "https://lists.apache.org/thread/hhp611hltby3whk03vx2mv7cmy3vs0ok"
+    ],
+    "description": "The SlingRequestDispatcher doesn't correctly implement the RequestDispatcher API resulting in a generic type of include-based cross-site scripting issues on the Apache Sling level. The vulnerability is exploitable by an attacker that is able to include a resource with specific content-type and control the include path (i.e. writing content). The impact of a successful attack is privilege escalation to administrative power.\n\n\n\n\nPlease update to Apache Sling Engine >= 2.14.0 and enable the \"Check Content-Type overrides\" configuration option.\n\n\n\n\n",
+    "cvss": [
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 9,
+       "exploitabilityScore": 2.3,
+       "impactScore": 6
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 8,
+       "exploitabilityScore": 1.3,
+       "impactScore": 6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.api",
+       "version": "2.2.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2022-45064",
+      "versionConstraint": "<= 2.14.0 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "0ed136dfd42c2fe5",
+    "name": "org.apache.sling.api",
+    "version": "2.2.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.api:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:api:2.2.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.api",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2016-0956",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2016-0956",
+    "namespace": "nvd:cpe",
+    "severity": "High",
+    "urls": [
+     "http://packetstormsecurity.com/files/135720/Apache-Sling-Framework-2.3.6-Information-Disclosure.html",
+     "http://seclists.org/fulldisclosure/2016/Feb/48",
+     "http://www.securityfocus.com/archive/1/537498/100/0/threaded",
+     "https://helpx.adobe.com/security/products/experience-manager/apsb16-05.html",
+     "https://www.exploit-db.com/exploits/39435/"
+    ],
+    "description": "The Servlets Post component 2.3.6 in Apache Sling, as used in Adobe Experience Manager 5.6.1, 6.0.0, and 6.1.0, allows remote attackers to obtain sensitive information via unspecified vectors.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:L/Au:N/C:C/I:N/A:N",
+      "metrics": {
+       "baseScore": 7.8,
+       "exploitabilityScore": 10,
+       "impactScore": 6.9
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.0",
+      "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "metrics": {
+       "baseScore": 7.5,
+       "exploitabilityScore": 3.9,
+       "impactScore": 3.6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.api",
+       "version": "2.2.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2016-0956",
+      "versionConstraint": "none (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "0ed136dfd42c2fe5",
+    "name": "org.apache.sling.api",
+    "version": "2.2.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.api:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:api:2.2.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.api",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "GHSA-rxvx-44w5-44r7",
+    "dataSource": "https://github.com/advisories/GHSA-rxvx-44w5-44r7",
+    "namespace": "github:language:java",
+    "severity": "Medium",
+    "urls": [
+     "https://github.com/advisories/GHSA-rxvx-44w5-44r7"
+    ],
+    "description": "Improper Neutralization of Input During Web Page Generation in Apache Sling",
+    "cvss": [],
+    "fix": {
+     "versions": [
+      "2.2.2"
+     ],
+     "state": "fixed"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [
+    {
+     "id": "CVE-2015-2944",
+     "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2015-2944",
+     "namespace": "nvd:cpe",
+     "severity": "Medium",
+     "urls": [
+      "http://jvn.jp/en/jp/JVN61328139/index.html",
+      "http://jvndb.jvn.jp/jvndb/JVNDB-2015-000069",
+      "http://www.securityfocus.com/bid/74839",
+      "https://issues.apache.org/jira/browse/SLING-2082",
+      "https://lists.apache.org/thread.html/r04237d561f3e5bced0a26287454450a34275162aa6b1dbae1b707b31@%3Cdev.sling.apache.org%3E",
+      "https://lists.apache.org/thread.html/r4f41dd891a52133abdbf7f74ad1dde80c46f157c1f1cf8c23ba60a70@%3Cdev.sling.apache.org%3E",
+      "https://lists.apache.org/thread.html/r93d68359eb0ea8c0f26d71ca3998143f99209a24db7b4dacfc688cea@%3Cdev.sling.apache.org%3E",
+      "https://lists.apache.org/thread.html/rd2a352858630721e7b1655bbdf85e692d6156fcfe68109e12b017b16@%3Cdev.sling.apache.org%3E"
+     ],
+     "description": "Multiple cross-site scripting (XSS) vulnerabilities in Apache Sling API before 2.2.2 and Apache Sling Servlets Post before 2.1.2 allow remote attackers to inject arbitrary web script or HTML via the URI, related to (1) org/apache/sling/api/servlets/HtmlResponse and (2) org/apache/sling/servlets/post/HtmlResponse.",
+     "cvss": [
+      {
+       "version": "2.0",
+       "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+       "metrics": {
+        "baseScore": 4.3,
+        "exploitabilityScore": 8.6,
+        "impactScore": 2.9
+       },
+       "vendorMetadata": {}
+      }
+     ]
+    }
+   ],
+   "matchDetails": [
+    {
+     "type": "exact-direct-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "language": "java",
+      "namespace": "github:language:java",
+      "package": {
+       "name": "org.apache.sling.api",
+       "version": "2.2.0"
+      }
+     },
+     "found": {
+      "versionConstraint": "<=2.2.1 (unknown)",
+      "vulnerabilityID": "GHSA-rxvx-44w5-44r7"
+     }
+    }
+   ],
+   "artifact": {
+    "id": "0ed136dfd42c2fe5",
+    "name": "org.apache.sling.api",
+    "version": "2.2.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.api:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:api:2.2.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.api",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "GHSA-qmx3-m648-hr74",
+    "dataSource": "https://github.com/advisories/GHSA-qmx3-m648-hr74",
+    "namespace": "github:language:java",
+    "severity": "Medium",
+    "urls": [
+     "https://github.com/advisories/GHSA-qmx3-m648-hr74"
+    ],
+    "description": "Log Injection in Apache Sling Commons Log and Apache Sling API",
+    "cvss": [],
+    "fix": {
+     "versions": [],
+     "state": "not-fixed"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [
+    {
+     "id": "CVE-2022-32549",
+     "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-32549",
+     "namespace": "nvd:cpe",
+     "severity": "Medium",
+     "urls": [
+      "https://lists.apache.org/thread/7z6h3806mwcov5kx6l96pq839sn0po1v"
+     ],
+     "description": "Apache Sling Commons Log <= 5.4.0 and Apache Sling API <= 2.25.0 are vulnerable to log injection. The ability to forge logs may allow an attacker to cover tracks by injecting fake logs and potentially corrupt log files.",
+     "cvss": [
+      {
+       "version": "2.0",
+       "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+       "metrics": {
+        "baseScore": 5,
+        "exploitabilityScore": 10,
+        "impactScore": 2.9
+       },
+       "vendorMetadata": {}
+      },
+      {
+       "version": "3.1",
+       "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+       "metrics": {
+        "baseScore": 5.3,
+        "exploitabilityScore": 3.9,
+        "impactScore": 1.4
+       },
+       "vendorMetadata": {}
+      }
+     ]
+    }
+   ],
+   "matchDetails": [
+    {
+     "type": "exact-direct-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "language": "java",
+      "namespace": "github:language:java",
+      "package": {
+       "name": "org.apache.sling.api",
+       "version": "2.2.0"
+      }
+     },
+     "found": {
+      "versionConstraint": "<=2.25.0 (unknown)",
+      "vulnerabilityID": "GHSA-qmx3-m648-hr74"
+     }
+    }
+   ],
+   "artifact": {
+    "id": "0ed136dfd42c2fe5",
+    "name": "org.apache.sling.api",
+    "version": "2.2.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.api:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:api:2.2.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.api",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "GHSA-cxwh-vmhg-39r2",
+    "dataSource": "https://github.com/advisories/GHSA-cxwh-vmhg-39r2",
+    "namespace": "github:language:java",
+    "severity": "Medium",
+    "urls": [
+     "https://github.com/advisories/GHSA-cxwh-vmhg-39r2"
+    ],
+    "description": "Improper Restriction of Operations within the Bounds of a Memory Buffer in Apache Sling",
+    "cvss": [],
+    "fix": {
+     "versions": [
+      "2.4.0"
+     ],
+     "state": "fixed"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [
+    {
+     "id": "CVE-2013-2254",
+     "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2013-2254",
+     "namespace": "nvd:cpe",
+     "severity": "Medium",
+     "urls": [
+      "http://mail-archives.apache.org/mod_mbox/sling-dev/201310.mbox/%3CCAKkCf4pue6PnESsP1KTdEDJm1gpkANFaK%2BvUd9mzEVT7tXL%2B3A%40mail.gmail.com%3E",
+      "http://www.securityfocus.com/bid/62903",
+      "https://exchange.xforce.ibmcloud.com/vulnerabilities/87765",
+      "https://issues.apache.org/jira/browse/SLING-2913"
+     ],
+     "description": "The deepGetOrCreateNode function in impl/operations/AbstractCreateOperation.java in org.apache.sling.servlets.post.bundle 2.2.0 and 2.3.0 in Apache Sling does not properly handle a NULL value that returned when the session does not have permissions to the root node, which allows remote attackers to cause a denial of service (infinite loop) via unspecified vectors.",
+     "cvss": [
+      {
+       "version": "2.0",
+       "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+       "metrics": {
+        "baseScore": 5,
+        "exploitabilityScore": 10,
+        "impactScore": 2.9
+       },
+       "vendorMetadata": {}
+      }
+     ]
+    }
+   ],
+   "matchDetails": [
+    {
+     "type": "exact-direct-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "language": "java",
+      "namespace": "github:language:java",
+      "package": {
+       "name": "org.apache.sling.api",
+       "version": "2.2.0"
+      }
+     },
+     "found": {
+      "versionConstraint": "<=2.3.0 (unknown)",
+      "vulnerabilityID": "GHSA-cxwh-vmhg-39r2"
+     }
+    }
+   ],
+   "artifact": {
+    "id": "0ed136dfd42c2fe5",
+    "name": "org.apache.sling.api",
+    "version": "2.2.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.api:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:api:2.2.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.api",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2013-4390",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2013-4390",
+    "namespace": "nvd:cpe",
+    "severity": "Medium",
+    "urls": [
+     "http://mail-archives.apache.org/mod_mbox/sling-dev/201310.mbox/%3CCAKkCf4qdFxEW9NXBJoMsrBama8LFNyir%2B61A0Vfzp4njEpeU%3Dw%40mail.gmail.com%3E",
+     "http://www.securityfocus.com/bid/63241",
+     "https://issues.apache.org/jira/browse/SLING-3141"
+    ],
+    "description": "Open redirect vulnerability in the AbstractAuthenticationFormServlet in the Auth Core (org.apache.sling.auth.core) bundle before 1.1.4 in Apache Sling allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the resource parameter, related to \"a custom login form and XSS.\"",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+      "metrics": {
+       "baseScore": 5.8,
+       "exploitabilityScore": 8.6,
+       "impactScore": 4.9
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.api",
+       "version": "2.2.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2013-4390",
+      "versionConstraint": "none (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "0ed136dfd42c2fe5",
+    "name": "org.apache.sling.api",
+    "version": "2.2.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.api:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:api:2.2.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.api",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2022-45064",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-45064",
+    "namespace": "nvd:cpe",
+    "severity": "Critical",
+    "urls": [
+     "http://www.openwall.com/lists/oss-security/2023/04/18/6",
+     "https://lists.apache.org/thread/hhp611hltby3whk03vx2mv7cmy3vs0ok"
+    ],
+    "description": "The SlingRequestDispatcher doesn't correctly implement the RequestDispatcher API resulting in a generic type of include-based cross-site scripting issues on the Apache Sling level. The vulnerability is exploitable by an attacker that is able to include a resource with specific content-type and control the include path (i.e. writing content). The impact of a successful attack is privilege escalation to administrative power.\n\n\n\n\nPlease update to Apache Sling Engine >= 2.14.0 and enable the \"Check Content-Type overrides\" configuration option.\n\n\n\n\n",
+    "cvss": [
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 9,
+       "exploitabilityScore": 2.3,
+       "impactScore": 6
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 8,
+       "exploitabilityScore": 1.3,
+       "impactScore": 6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:2.0.6:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.commons.json",
+       "version": "2.0.6"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2022-45064",
+      "versionConstraint": "<= 2.14.0 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "3340f3da9089f983",
+    "name": "org.apache.sling.commons.json",
+    "version": "2.0.6",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.commons.json:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:json:2.0.6:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.commons.json@2.0.6",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.commons.json",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2016-0956",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2016-0956",
+    "namespace": "nvd:cpe",
+    "severity": "High",
+    "urls": [
+     "http://packetstormsecurity.com/files/135720/Apache-Sling-Framework-2.3.6-Information-Disclosure.html",
+     "http://seclists.org/fulldisclosure/2016/Feb/48",
+     "http://www.securityfocus.com/archive/1/537498/100/0/threaded",
+     "https://helpx.adobe.com/security/products/experience-manager/apsb16-05.html",
+     "https://www.exploit-db.com/exploits/39435/"
+    ],
+    "description": "The Servlets Post component 2.3.6 in Apache Sling, as used in Adobe Experience Manager 5.6.1, 6.0.0, and 6.1.0, allows remote attackers to obtain sensitive information via unspecified vectors.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:L/Au:N/C:C/I:N/A:N",
+      "metrics": {
+       "baseScore": 7.8,
+       "exploitabilityScore": 10,
+       "impactScore": 6.9
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.0",
+      "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "metrics": {
+       "baseScore": 7.5,
+       "exploitabilityScore": 3.9,
+       "impactScore": 3.6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:2.0.6:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.commons.json",
+       "version": "2.0.6"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2016-0956",
+      "versionConstraint": "none (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "3340f3da9089f983",
+    "name": "org.apache.sling.commons.json",
+    "version": "2.0.6",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.commons.json:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:json:2.0.6:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.commons.json@2.0.6",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.commons.json",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2013-4390",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2013-4390",
+    "namespace": "nvd:cpe",
+    "severity": "Medium",
+    "urls": [
+     "http://mail-archives.apache.org/mod_mbox/sling-dev/201310.mbox/%3CCAKkCf4qdFxEW9NXBJoMsrBama8LFNyir%2B61A0Vfzp4njEpeU%3Dw%40mail.gmail.com%3E",
+     "http://www.securityfocus.com/bid/63241",
+     "https://issues.apache.org/jira/browse/SLING-3141"
+    ],
+    "description": "Open redirect vulnerability in the AbstractAuthenticationFormServlet in the Auth Core (org.apache.sling.auth.core) bundle before 1.1.4 in Apache Sling allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the resource parameter, related to \"a custom login form and XSS.\"",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+      "metrics": {
+       "baseScore": 5.8,
+       "exploitabilityScore": 8.6,
+       "impactScore": 4.9
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:2.0.6:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.commons.json",
+       "version": "2.0.6"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2013-4390",
+      "versionConstraint": "none (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "3340f3da9089f983",
+    "name": "org.apache.sling.commons.json",
+    "version": "2.0.6",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.commons.json:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:json:2.0.6:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.commons.json@2.0.6",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.commons.json",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2022-45064",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-45064",
+    "namespace": "nvd:cpe",
+    "severity": "Critical",
+    "urls": [
+     "http://www.openwall.com/lists/oss-security/2023/04/18/6",
+     "https://lists.apache.org/thread/hhp611hltby3whk03vx2mv7cmy3vs0ok"
+    ],
+    "description": "The SlingRequestDispatcher doesn't correctly implement the RequestDispatcher API resulting in a generic type of include-based cross-site scripting issues on the Apache Sling level. The vulnerability is exploitable by an attacker that is able to include a resource with specific content-type and control the include path (i.e. writing content). The impact of a successful attack is privilege escalation to administrative power.\n\n\n\n\nPlease update to Apache Sling Engine >= 2.14.0 and enable the \"Check Content-Type overrides\" configuration option.\n\n\n\n\n",
+    "cvss": [
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 9,
+       "exploitabilityScore": 2.3,
+       "impactScore": 6
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 8,
+       "exploitabilityScore": 1.3,
+       "impactScore": 6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.xss.compat",
+       "version": "1.0.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2022-45064",
+      "versionConstraint": "<= 2.14.0 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "29ca35dad3dd4ea3",
+    "name": "org.apache.sling.xss.compat",
+    "version": "1.0.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.xss.compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:xss:1.0.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.xss.compat@1.0.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.xss.compat",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2016-6798",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2016-6798",
+    "namespace": "nvd:cpe",
+    "severity": "Critical",
+    "urls": [
+     "http://www.securityfocus.com/bid/99873",
+     "https://lists.apache.org/thread.html/b72c3a511592ec70729b3ec2d29302b6ce87bbeab62d4745617a6bd0@%3Cdev.sling.apache.org%3E"
+    ],
+    "description": "In the XSS Protection API module before 1.0.12 in Apache Sling, the method XSS.getValidXML() uses an insecure SAX parser to validate the input string, which allows for XXE attacks in all scripts which use this method to validate user input, potentially allowing an attacker to read sensitive data on the filesystem, perform same-site-request-forgery (SSRF), port-scanning behind the firewall or DoS the application.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+      "metrics": {
+       "baseScore": 7.5,
+       "exploitabilityScore": 10,
+       "impactScore": 6.4
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.0",
+      "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 9.8,
+       "exploitabilityScore": 3.9,
+       "impactScore": 5.9
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.xss.compat",
+       "version": "1.0.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2016-6798",
+      "versionConstraint": "<= 1.0.10 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "29ca35dad3dd4ea3",
+    "name": "org.apache.sling.xss.compat",
+    "version": "1.0.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.xss.compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:xss:1.0.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.xss.compat@1.0.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.xss.compat",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2016-0956",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2016-0956",
+    "namespace": "nvd:cpe",
+    "severity": "High",
+    "urls": [
+     "http://packetstormsecurity.com/files/135720/Apache-Sling-Framework-2.3.6-Information-Disclosure.html",
+     "http://seclists.org/fulldisclosure/2016/Feb/48",
+     "http://www.securityfocus.com/archive/1/537498/100/0/threaded",
+     "https://helpx.adobe.com/security/products/experience-manager/apsb16-05.html",
+     "https://www.exploit-db.com/exploits/39435/"
+    ],
+    "description": "The Servlets Post component 2.3.6 in Apache Sling, as used in Adobe Experience Manager 5.6.1, 6.0.0, and 6.1.0, allows remote attackers to obtain sensitive information via unspecified vectors.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:L/Au:N/C:C/I:N/A:N",
+      "metrics": {
+       "baseScore": 7.8,
+       "exploitabilityScore": 10,
+       "impactScore": 6.9
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.0",
+      "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "metrics": {
+       "baseScore": 7.5,
+       "exploitabilityScore": 3.9,
+       "impactScore": 3.6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.xss.compat",
+       "version": "1.0.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2016-0956",
+      "versionConstraint": "none (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "29ca35dad3dd4ea3",
+    "name": "org.apache.sling.xss.compat",
+    "version": "1.0.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.xss.compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:xss:1.0.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.xss.compat@1.0.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.xss.compat",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2016-5394",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2016-5394",
+    "namespace": "nvd:cpe",
+    "severity": "Medium",
+    "urls": [
+     "http://www.securityfocus.com/bid/99870",
+     "https://lists.apache.org/thread.html/332166037a54b97cf41e2b616aaed38439de94b19b204841478e4525@%3Cdev.sling.apache.org%3E"
+    ],
+    "description": "In the XSS Protection API module before 1.0.12 in Apache Sling, the encoding done by the XSSAPI.encodeForJSString() method is not restrictive enough and for some input patterns allows script tags to pass through unencoded, leading to potential XSS vulnerabilities.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+      "metrics": {
+       "baseScore": 4.3,
+       "exploitabilityScore": 8.6,
+       "impactScore": 2.9
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+      "metrics": {
+       "baseScore": 6.1,
+       "exploitabilityScore": 2.8,
+       "impactScore": 2.7
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.xss.compat",
+       "version": "1.0.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2016-5394",
+      "versionConstraint": "< 1.0.12 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "29ca35dad3dd4ea3",
+    "name": "org.apache.sling.xss.compat",
+    "version": "1.0.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.xss.compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:xss:1.0.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.xss.compat@1.0.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.xss.compat",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2013-4390",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2013-4390",
+    "namespace": "nvd:cpe",
+    "severity": "Medium",
+    "urls": [
+     "http://mail-archives.apache.org/mod_mbox/sling-dev/201310.mbox/%3CCAKkCf4qdFxEW9NXBJoMsrBama8LFNyir%2B61A0Vfzp4njEpeU%3Dw%40mail.gmail.com%3E",
+     "http://www.securityfocus.com/bid/63241",
+     "https://issues.apache.org/jira/browse/SLING-3141"
+    ],
+    "description": "Open redirect vulnerability in the AbstractAuthenticationFormServlet in the Auth Core (org.apache.sling.auth.core) bundle before 1.1.4 in Apache Sling allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the resource parameter, related to \"a custom login form and XSS.\"",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+      "metrics": {
+       "baseScore": 5.8,
+       "exploitabilityScore": 8.6,
+       "impactScore": 4.9
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.xss.compat",
+       "version": "1.0.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2013-4390",
+      "versionConstraint": "none (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "29ca35dad3dd4ea3",
+    "name": "org.apache.sling.xss.compat",
+    "version": "1.0.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.xss.compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:xss:1.0.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.xss.compat@1.0.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.xss.compat",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  }
+ ],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:05.441719821+13:00"
+ }
+}

--- a/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/snyk/snyk-report.json
+++ b/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/snyk/snyk-report.json
@@ -1,0 +1,488 @@
+{
+  "vulnerabilities": [
+    {
+      "id": "SNYK-JAVA-ORGAPACHESLING-2934398",
+      "title": "Log Manipulation",
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+      "credit": [
+        "Alex Collignon"
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,2.25.4)"
+        ]
+      },
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.25.4"
+      ],
+      "patches": [],
+      "insights": {
+        "triageAdvice": null
+      },
+      "language": "java",
+      "severity": "medium",
+      "cvssScore": 5.3,
+      "functions": [],
+      "malicious": false,
+      "isDisputed": false,
+      "moduleName": "org.apache.sling:org.apache.sling.api",
+      "references": [
+        {
+          "url": "https://lists.apache.org/thread/7z6h3806mwcov5kx6l96pq839sn0po1v",
+          "title": "Apache Advisory"
+        },
+        {
+          "url": "https://github.com/apache/sling-org-apache-sling-api/commit/8754cd20cb047498e1cf53fde1e5c0357232e6b9",
+          "title": "GitHub Commit"
+        },
+        {
+          "url": "https://github.com/apache/sling-org-apache-sling-commons-log/commit/6b1e8372cc0ecfc4bec8b8749dc317533aeb2b2f",
+          "title": "GitHub Commit"
+        }
+      ],
+      "cvssDetails": [
+        {
+          "assigner": "NVD",
+          "severity": "medium",
+          "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "cvssV3BaseScore": 5.3,
+          "modificationTime": "2022-06-30T01:11:40.368579Z"
+        }
+      ],
+      "description": "## Overview\n\nAffected versions of this package are vulnerable to Log Manipulation when an attacker injects falsified log lines.\n## Remediation\nUpgrade `org.apache.sling:org.apache.sling.api` to version 2.25.4 or higher.\n## References\n- [Apache Advisory](https://lists.apache.org/thread/7z6h3806mwcov5kx6l96pq839sn0po1v)\n- [GitHub Commit](https://github.com/apache/sling-org-apache-sling-api/commit/8754cd20cb047498e1cf53fde1e5c0357232e6b9)\n- [GitHub Commit](https://github.com/apache/sling-org-apache-sling-commons-log/commit/6b1e8372cc0ecfc4bec8b8749dc317533aeb2b2f)\n",
+      "epssDetails": {
+        "percentile": "0.36548",
+        "probability": "0.00088",
+        "modelVersion": "v2023.03.01"
+      },
+      "identifiers": {
+        "CVE": [
+          "CVE-2022-32549"
+        ],
+        "CWE": [
+          "CWE-117"
+        ]
+      },
+      "packageName": "org.apache.sling:org.apache.sling.api",
+      "proprietary": false,
+      "creationTime": "2022-06-23T07:45:26.323765Z",
+      "functions_new": [],
+      "alternativeIds": [],
+      "disclosureTime": "2022-06-23T05:15:24Z",
+      "packageManager": "maven",
+      "mavenModuleName": {
+        "groupId": "org.apache.sling",
+        "artifactId": "org.apache.sling.api"
+      },
+      "publicationTime": "2022-06-23T14:32:09.459273Z",
+      "modificationTime": "2022-06-30T01:11:40.368579Z",
+      "socialTrendAlert": false,
+      "severityWithCritical": "medium",
+      "from": [
+        "foo:org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1",
+        "org.apache.sling:org.apache.sling.api@2.2.0"
+      ],
+      "upgradePath": [
+        false,
+        "org.apache.sling:org.apache.sling.api@2.25.4"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.apache.sling:org.apache.sling.api",
+      "version": "2.2.0"
+    },
+    {
+      "id": "SNYK-JAVA-ORGAPACHESLING-30727",
+      "title": "Cross-site Scripting (XSS)",
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+      "credit": [
+        "Unknown"
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,2.2.2)"
+        ]
+      },
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.2.2"
+      ],
+      "patches": [],
+      "insights": {
+        "triageAdvice": null
+      },
+      "language": "java",
+      "severity": "medium",
+      "cvssScore": 4.3,
+      "functions": [],
+      "malicious": false,
+      "isDisputed": false,
+      "moduleName": "org.apache.sling:org.apache.sling.api",
+      "references": [
+        {
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-2944",
+          "title": "NVD"
+        }
+      ],
+      "cvssDetails": [
+        {
+          "assigner": "NVD",
+          "severity": "medium",
+          "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+          "cvssV3BaseScore": 4.3,
+          "modificationTime": "2023-02-09T11:24:02.410222Z"
+        }
+      ],
+      "description": "## Overview\n[`org.apache.sling:org.apache.sling.api`](https://sling.apache.org/) is a framework for RESTful web-applications based on an extensible content tree.\n\nMultiple cross-site scripting (XSS) vulnerabilities in Apache Sling API before 2.2.2 and Apache Sling Servlets Post before 2.1.2 allow remote attackers to inject arbitrary web script or HTML via the URI, related to (1) org/apache/sling/api/servlets/HtmlResponse and (2) org/apache/sling/servlets/post/HtmlResponse.\n\n## Details\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-2944)\n",
+      "epssDetails": {
+        "percentile": "0.66610",
+        "probability": "0.00325",
+        "modelVersion": "v2023.03.01"
+      },
+      "identifiers": {
+        "CVE": [
+          "CVE-2015-2944"
+        ],
+        "CWE": [
+          "CWE-79"
+        ]
+      },
+      "packageName": "org.apache.sling:org.apache.sling.api",
+      "proprietary": false,
+      "creationTime": "2017-02-22T07:28:22.765000Z",
+      "functions_new": [],
+      "alternativeIds": [],
+      "disclosureTime": "2015-06-02T14:59:00Z",
+      "packageManager": "maven",
+      "mavenModuleName": {
+        "groupId": "org.apache.sling",
+        "artifactId": "org.apache.sling.api"
+      },
+      "publicationTime": "2015-06-03T16:21:02Z",
+      "modificationTime": "2023-02-09T11:24:02.410222Z",
+      "socialTrendAlert": false,
+      "severityWithCritical": "medium",
+      "from": [
+        "foo:org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1",
+        "org.apache.sling:org.apache.sling.api@2.2.0"
+      ],
+      "upgradePath": [
+        false,
+        "org.apache.sling:org.apache.sling.api@2.2.2"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.apache.sling:org.apache.sling.api",
+      "version": "2.2.0"
+    },
+    {
+      "id": "SNYK-JAVA-ORGAPACHESLING-31627",
+      "title": "Cross-site Scripting (XSS)",
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+      "credit": [
+        "Unknown"
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,2.0.4)"
+        ]
+      },
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.0.4"
+      ],
+      "patches": [],
+      "insights": {
+        "triageAdvice": null
+      },
+      "language": "java",
+      "severity": "medium",
+      "cvssScore": 6.1,
+      "functions": [],
+      "malicious": false,
+      "isDisputed": false,
+      "moduleName": "org.apache.sling:org.apache.sling.xss.compat",
+      "references": [
+        {
+          "url": "https://s.apache.org/CVE-2017-15717",
+          "title": "Apache Mail Archives"
+        },
+        {
+          "url": "https://github.com/apache/sling-org-apache-sling-xss/commit/ec6764d165abc4df8cffd8439761bb2228887db9",
+          "title": "GitHub Commit"
+        },
+        {
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-15717",
+          "title": "NVD"
+        }
+      ],
+      "cvssDetails": [
+        {
+          "assigner": "NVD",
+          "severity": "medium",
+          "cvssV3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "cvssV3BaseScore": 6.1,
+          "modificationTime": "2022-01-03T16:21:09.816750Z"
+        }
+      ],
+      "description": "## Overview\n[org.apache.sling:org.apache.sling.xss](https://sling.apache.org/) is a framework for RESTful web-applications based on an extensible content tree.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS).\nA flaw in the way URLs are escaped and encoded allows special crafted URLs to pass as valid, although they carry XSS payloads.\n\n## Details\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n\n## Remediation\nUpgrade `org.apache.sling:org.apache.sling.xss` to version  or higher.\n\n## References\n- [Apache Mail Archives](https://s.apache.org/CVE-2017-15717)\n- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2017-15717)\n",
+      "epssDetails": {
+        "percentile": "0.54700",
+        "probability": "0.00186",
+        "modelVersion": "v2023.03.01"
+      },
+      "identifiers": {
+        "CVE": [
+          "CVE-2017-15717"
+        ],
+        "CWE": [
+          "CWE-79"
+        ]
+      },
+      "packageName": "org.apache.sling:org.apache.sling.xss.compat",
+      "proprietary": false,
+      "creationTime": "2018-02-05T17:51:08.112000Z",
+      "functions_new": [],
+      "alternativeIds": [],
+      "disclosureTime": "2018-01-10T17:51:08.112000Z",
+      "packageManager": "maven",
+      "mavenModuleName": {
+        "groupId": "org.apache.sling",
+        "artifactId": "org.apache.sling.xss.compat"
+      },
+      "publicationTime": "2018-02-06T14:22:50.659000Z",
+      "modificationTime": "2022-01-03T16:21:09.816750Z",
+      "socialTrendAlert": false,
+      "severityWithCritical": "medium",
+      "from": [
+        "foo:org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1",
+        "org.apache.sling:org.apache.sling.xss.compat@1.0.0"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.sling:org.apache.sling.xss.compat",
+      "version": "1.0.0"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 5,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "3 vulnerable dependency paths",
+  "remediation": {
+    "unresolved": [
+      {
+        "id": "SNYK-JAVA-ORGAPACHESLING-31627",
+        "title": "Cross-site Scripting (XSS)",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+        "credit": [
+          "Unknown"
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,2.0.4)"
+          ]
+        },
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.0.4"
+        ],
+        "patches": [],
+        "insights": {
+          "triageAdvice": null
+        },
+        "language": "java",
+        "severity": "medium",
+        "cvssScore": 6.1,
+        "functions": [],
+        "malicious": false,
+        "isDisputed": false,
+        "moduleName": "org.apache.sling:org.apache.sling.xss.compat",
+        "references": [
+          {
+            "url": "https://s.apache.org/CVE-2017-15717",
+            "title": "Apache Mail Archives"
+          },
+          {
+            "url": "https://github.com/apache/sling-org-apache-sling-xss/commit/ec6764d165abc4df8cffd8439761bb2228887db9",
+            "title": "GitHub Commit"
+          },
+          {
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-15717",
+            "title": "NVD"
+          }
+        ],
+        "cvssDetails": [
+          {
+            "assigner": "NVD",
+            "severity": "medium",
+            "cvssV3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "cvssV3BaseScore": 6.1,
+            "modificationTime": "2022-01-03T16:21:09.816750Z"
+          }
+        ],
+        "description": "## Overview\n[org.apache.sling:org.apache.sling.xss](https://sling.apache.org/) is a framework for RESTful web-applications based on an extensible content tree.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS).\nA flaw in the way URLs are escaped and encoded allows special crafted URLs to pass as valid, although they carry XSS payloads.\n\n## Details\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n\n## Remediation\nUpgrade `org.apache.sling:org.apache.sling.xss` to version  or higher.\n\n## References\n- [Apache Mail Archives](https://s.apache.org/CVE-2017-15717)\n- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2017-15717)\n",
+        "epssDetails": {
+          "percentile": "0.54700",
+          "probability": "0.00186",
+          "modelVersion": "v2023.03.01"
+        },
+        "identifiers": {
+          "CVE": [
+            "CVE-2017-15717"
+          ],
+          "CWE": [
+            "CWE-79"
+          ]
+        },
+        "packageName": "org.apache.sling:org.apache.sling.xss.compat",
+        "proprietary": false,
+        "creationTime": "2018-02-05T17:51:08.112000Z",
+        "functions_new": [],
+        "alternativeIds": [],
+        "disclosureTime": "2018-01-10T17:51:08.112000Z",
+        "packageManager": "maven",
+        "mavenModuleName": {
+          "groupId": "org.apache.sling",
+          "artifactId": "org.apache.sling.xss.compat"
+        },
+        "publicationTime": "2018-02-06T14:22:50.659000Z",
+        "modificationTime": "2022-01-03T16:21:09.816750Z",
+        "socialTrendAlert": false,
+        "packagePopularityRank": 0,
+        "from": [
+          "foo:org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1",
+          "org.apache.sling:org.apache.sling.xss.compat@1.0.0"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "isRuntime": false,
+        "name": "org.apache.sling:org.apache.sling.xss.compat",
+        "version": "1.0.0",
+        "severityWithCritical": "medium"
+      }
+    ],
+    "upgrade": {
+      "org.apache.sling:org.apache.sling.api@2.2.0": {
+        "upgradeTo": "org.apache.sling:org.apache.sling.api@2.25.4",
+        "upgrades": [
+          "org.apache.sling:org.apache.sling.api@2.2.0",
+          "org.apache.sling:org.apache.sling.api@2.2.0"
+        ],
+        "vulns": [
+          "SNYK-JAVA-ORGAPACHESLING-2934398",
+          "SNYK-JAVA-ORGAPACHESLING-30727"
+        ]
+      }
+    },
+    "patch": {},
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 3,
+  "projectName": "foo:org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0"
+}

--- a/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/steady/steady-report.json
+++ b/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/steady/steady-report.json
@@ -1,0 +1,186 @@
+{
+	"vulasReport": {
+		"generatedAt": "03.10.2023 14:41 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "TEST, PROVIDED" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+			{
+		
+			"bug":{
+				"id":"CVE-2012-0881",
+				"cvssScore": "7.5" ,
+				"cvssVersion": "3.0" 
+			},
+			"filename": "org.apache.sling.xss.compat-1.0.0.jar",
+			"sha1": "FAA555729B10D1D27AE85A0EF2B2BD0CD492D36F",
+			
+			"modules": [
+			
+				{
+			
+				"groupId": "foo",
+				"artifactId": "org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+				"version": "0.0.1",
+				
+				"href": "http://localhost:8033/backend/../apps/#/$space.getSpaceToken()/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0/0.0.1",
+				
+				"scope": "COMPILE",
+				"isTransitive": false,
+				
+					"containsVulnerableCode": "unknown",
+				
+						"potentiallyExecutesVulnerableCode": "noLibraryCodeAtAll",
+				
+						"actuallyExecutesVulnerableCode": "noLibraryCodeAtAll"
+				}
+			]
+		}
+			,
+			{
+		
+			"bug":{
+				"id":"CVE-2013-4002",
+				"cvssScore": "7.1" ,
+				"cvssVersion": "2.0" 
+			},
+			"filename": "org.apache.sling.xss.compat-1.0.0.jar",
+			"sha1": "FAA555729B10D1D27AE85A0EF2B2BD0CD492D36F",
+			
+			"modules": [
+			
+				{
+			
+				"groupId": "foo",
+				"artifactId": "org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+				"version": "0.0.1",
+				
+				"href": "http://localhost:8033/backend/../apps/#/$space.getSpaceToken()/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0/0.0.1",
+				
+				"scope": "COMPILE",
+				"isTransitive": false,
+				
+					"containsVulnerableCode": "unknown",
+				
+						"potentiallyExecutesVulnerableCode": "noLibraryCodeAtAll",
+				
+						"actuallyExecutesVulnerableCode": "noLibraryCodeAtAll"
+				}
+			]
+		}
+			,
+			{
+		
+			"bug":{
+				"id":"CVE-2014-0114",
+				"cvssScore": "7.5" ,
+				"cvssVersion": "2.0" 
+			},
+			"filename": "org.apache.sling.xss.compat-1.0.0.jar",
+			"sha1": "FAA555729B10D1D27AE85A0EF2B2BD0CD492D36F",
+			
+			"modules": [
+			
+				{
+			
+				"groupId": "foo",
+				"artifactId": "org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+				"version": "0.0.1",
+				
+				"href": "http://localhost:8033/backend/../apps/#/$space.getSpaceToken()/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0/0.0.1",
+				
+				"scope": "COMPILE",
+				"isTransitive": false,
+				
+					"containsVulnerableCode": "unknown",
+				
+						"potentiallyExecutesVulnerableCode": "noLibraryCodeAtAll",
+				
+						"actuallyExecutesVulnerableCode": "noLibraryCodeAtAll"
+				}
+			]
+		}
+			,
+			{
+		
+			"bug":{
+				"id":"CVE-2016-10006",
+				"cvssScore": "6.1" ,
+				"cvssVersion": "3.1" 
+			},
+			"filename": "org.apache.sling.xss.compat-1.0.0.jar",
+			"sha1": "FAA555729B10D1D27AE85A0EF2B2BD0CD492D36F",
+			
+			"modules": [
+			
+				{
+			
+				"groupId": "foo",
+				"artifactId": "org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+				"version": "0.0.1",
+				
+				"href": "http://localhost:8033/backend/../apps/#/$space.getSpaceToken()/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0/0.0.1",
+				
+				"scope": "COMPILE",
+				"isTransitive": false,
+				
+					"containsVulnerableCode": "unknown",
+				
+						"potentiallyExecutesVulnerableCode": "noLibraryCodeAtAll",
+				
+						"actuallyExecutesVulnerableCode": "noLibraryCodeAtAll"
+				}
+			]
+		}
+			,
+			{
+		
+			"bug":{
+				"id":"CVE-2019-10086",
+				"cvssScore": "7.3" ,
+				"cvssVersion": "3.1" 
+			},
+			"filename": "org.apache.sling.xss.compat-1.0.0.jar",
+			"sha1": "FAA555729B10D1D27AE85A0EF2B2BD0CD492D36F",
+			
+			"modules": [
+			
+				{
+			
+				"groupId": "foo",
+				"artifactId": "org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+				"version": "0.0.1",
+				
+				"href": "http://localhost:8033/backend/../apps/#/$space.getSpaceToken()/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0/0.0.1",
+				
+				"scope": "COMPILE",
+				"isTransitive": false,
+				
+					"containsVulnerableCode": "unknown",
+				
+						"potentiallyExecutesVulnerableCode": "noLibraryCodeAtAll",
+				
+						"actuallyExecutesVulnerableCode": "noLibraryCodeAtAll"
+				}
+			]
+		}
+		]
+	}
+}

--- a/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/src/test/java/org/apache/sling/xss/impl/XSSAPIImplTest.java
+++ b/CVE-2016-5394/org.apache.sling__org.apache.sling.xss.compat__1.0.0/src/test/java/org/apache/sling/xss/impl/XSSAPIImplTest.java
@@ -1,0 +1,697 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one or
+ * more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the
+ * Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+ * applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ ******************************************************************************/
+package org.apache.sling.xss.impl;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.xss.XSSAPI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.owasp.validator.html.AntiSamy;
+import org.owasp.validator.html.Policy;
+import org.owasp.validator.html.model.Attribute;
+import org.powermock.reflect.Whitebox;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class XSSAPIImplTest {
+
+    public static final String RUBBISH = "rubbish";
+    public static final String RUBBISH_JSON = "[\"rubbish\"]";
+    public static final String RUBBISH_XML = "<rubbish/>";
+
+    private XSSAPI xssAPI;
+
+    @BeforeEach
+    public void setup() {
+        try {
+            XSSFilterImpl xssFilter = new XSSFilterImpl();
+            // changed path
+            setDefaultHandler(xssFilter, "resources/SLING-INF/content/config.xml");
+
+            xssAPI = new XSSAPIImpl();
+
+            System.out.println("xssAPI set");
+
+            Whitebox.invokeMethod(xssAPI, "activate");
+            Field filterField = XSSAPIImpl.class.getDeclaredField("xssFilter");
+            filterField.setAccessible(true);
+            filterField.set(xssAPI, xssFilter);
+
+            ResourceResolver mockResolver = mock(ResourceResolver.class);
+            when(mockResolver.map(anyString())).thenAnswer(new Answer() {
+                public Object answer(InvocationOnMock invocation) {
+                    Object[] args = invocation.getArguments();
+                    String url = (String) args[0];
+                    return url.replaceAll("jcr:", "_jcr_");
+                }
+            });
+
+            SlingHttpServletRequest mockRequest = mock(SlingHttpServletRequest.class);
+            when(mockRequest.getResourceResolver()).thenReturn(mockResolver);
+
+            xssAPI = xssAPI.getRequestSpecificAPI(mockRequest);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void setDefaultHandler(XSSFilterImpl xssFilter, String filename) throws Exception {
+
+
+        File configFile = new File(filename);
+        if (!configFile.exists()) {
+            throw new IllegalArgumentException("config file missing: " + configFile.getAbsolutePath());
+        }
+
+        InputStream policyStream = new FileInputStream(configFile);
+        Policy policy = Policy.getInstance(policyStream);
+        AntiSamy antiSamy = new AntiSamy(policy);
+
+        PolicyHandler mockPolicyHandler = mock(PolicyHandler.class);
+        when(mockPolicyHandler.getPolicy()).thenReturn(policy);
+        when(mockPolicyHandler.getAntiSamy()).thenReturn(antiSamy);
+
+        Whitebox.invokeMethod(xssFilter, "setDefaultHandler", mockPolicyHandler);
+    }
+
+//    @Test
+//    public void testEncodeForHTML() {
+//        String[][] testData = {
+//            //         Source                            Expected Result
+//            //
+//            {null, null},
+//            {null, null},
+//            {"simple", "simple"},
+//
+//            {"<script>", "&lt;script&gt;"},
+//            {"<b>", "&lt;b&gt;"},
+//
+//            {"günter", "günter"},
+//            {"\u30e9\u30c9\u30af\u30ea\u30d5\u3001\u30de\u30e9\u30bd\u30f3\u4e94\u8f2a\u4ee3\u8868\u306b1\u4e07m\u51fa\u5834\u306b\u3082\u542b\u307f", "\u30e9\u30c9\u30af\u30ea\u30d5\u3001\u30de\u30e9\u30bd\u30f3\u4e94\u8f2a\u4ee3\u8868\u306b1\u4e07m\u51fa\u5834\u306b\u3082\u542b\u307f"}
+//        };
+//
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            String expected = aTestData[1];
+//
+//            TestCase.assertEquals("HTML Encoding '" + source + "'", expected, xssAPI.encodeForHTML(source));
+//        }
+//    }
+
+//    @Test
+//    public void testEncodeForHTMLAttr() {
+//        String[][] testData = {
+//            //         Source                            Expected Result
+//            //
+//            {null, null},
+//            {"simple", "simple"},
+//
+//            {"<script>", "&lt;script>"},
+//            {"\" <script>alert('pwned');</script>", "&#34; &lt;script>alert(&#39;pwned&#39;);&lt;/script>"},
+//            {"günter", "günter"},
+//            {"\u30e9\u30c9\u30af\u30ea\u30d5\u3001\u30de\u30e9\u30bd\u30f3\u4e94\u8f2a\u4ee3\u8868\u306b1\u4e07m\u51fa\u5834\u306b\u3082\u542b\u307f", "\u30e9\u30c9\u30af\u30ea\u30d5\u3001\u30de\u30e9\u30bd\u30f3\u4e94\u8f2a\u4ee3\u8868\u306b1\u4e07m\u51fa\u5834\u306b\u3082\u542b\u307f"}
+//        };
+//
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            String expected = aTestData[1];
+//
+//            TestCase.assertEquals("HTML Encoding '" + source + "'", expected, xssAPI.encodeForHTMLAttr(source));
+//        }
+//    }
+
+//    @Test
+//    public void testEncodeForXML() {
+//        String[][] testData = {
+//            //         Source                            Expected Result
+//            //
+//            {null, null},
+//            {"simple", "simple"},
+//
+//            {"<script>", "&lt;script&gt;"},
+//            {"<b>", "&lt;b&gt;"},
+//
+//            {"günter", "günter"}
+//        };
+//
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            String expected = aTestData[1];
+//
+//            TestCase.assertEquals("XML Encoding '" + source + "'", expected, xssAPI.encodeForXML(source));
+//        }
+//    }
+
+//    @Test
+//    public void testEncodeForXMLAttr() {
+//        String[][] testData = {
+//            //         Source                            Expected Result
+//            //
+//            {null, null},
+//            {"simple", "simple"},
+//
+//            {"<script>", "&lt;script>"},
+//            {"<b>", "&lt;b>"},
+//
+//            {"günter", "günter"},
+//            {"\"xss:expression(alert('XSS'))", "&#34;xss:expression(alert(&#39;XSS&#39;))"}
+//        };
+//
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            String expected = aTestData[1];
+//
+//            TestCase.assertEquals("XML Encoding '" + source + "'", expected, xssAPI.encodeForXMLAttr(source));
+//        }
+//    }
+
+//    @Test
+//    public void testFilterHTML() {
+//        String[][] testData = {
+//            //         Source                            Expected Result
+//            {null, ""},
+//            {"", ""},
+//            {"simple", "simple"},
+//
+//            {"<script>ugly</script>", ""},
+//            {"<b>wow!</b>", "<b>wow!</b>"},
+//
+//            {"<p onmouseover='ugly'>nice</p>", "<p>nice</p>"},
+//
+//            {"<img src='javascript:ugly'/>", ""},
+//            {"<img src='nice.jpg'/>", "<img src=\"nice.jpg\" />"},
+//
+//            {"<ul><li>1</li><li>2</li></ul>", "<ul><li>1</li><li>2</li></ul>"},
+//
+//            {"günter", "günter"},
+//
+//
+//            {"<strike>strike</strike>", "<strike>strike</strike>"},
+//            {"<s>s</s>", "<s>s</s>"},
+//
+//            {"<a href=\"\">empty href</a>", "<a href=\"\">empty href</a>"}
+//        };
+//
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            String expected = aTestData[1];
+//
+//            TestCase.assertEquals("Filtering '" + source + "'", expected, xssAPI.filterHTML(source));
+//        }
+//    }
+
+//    @Test
+//    public void testGetValidHref() {
+//        String[][] testData = {
+//            //         Href                                        Expected Result
+//            //
+//            {null, ""},
+//            {"", ""},
+//            {"simple", "simple"},
+//
+//            {"../parent", "../parent"},
+//            {"repo/günter", "repo/günter"},
+//
+//            // JCR namespaces:
+//            {"my/page/jcr:content.feed", "my/page/_jcr_content.feed"},
+//            {"my/jcr:content/page/jcr:content", "my/_jcr_content/page/_jcr_content"},
+//
+//            {"\" onClick=ugly", "%22%20onClick=ugly"},
+//            {"javascript:ugly", ""},
+//            {"http://localhost:4502", "http://localhost:4502"},
+//            {"http://localhost:4502/test", "http://localhost:4502/test"},
+//            {"http://localhost:4502/jcr:content/test", "http://localhost:4502/_jcr_content/test"},
+//            {"http://localhost:4502/test.html?a=b&b=c", "http://localhost:4502/test.html?a=b&b=c"},
+//
+//            // space
+//            {"/test/ab cd", "/test/ab%20cd"},
+//            {"http://localhost:4502/test/ab cd", "http://localhost:4502/test/ab%20cd"},
+//            {"/test/ab attr=c", "/test/ab%20attr=c"},
+//            {"http://localhost:4502/test/ab attr=c", "http://localhost:4502/test/ab%20attr=c"},
+//            // "
+//            {"/test/ab\"cd", "/test/ab%22cd"},
+//            {"http://localhost:4502/test/ab\"cd", "http://localhost:4502/test/ab%22cd"},
+//            // '
+//            {"/test/ab'cd", "/test/ab%27cd"},
+//            {"http://localhost:4502/test/ab'cd", "http://localhost:4502/test/ab%27cd"},
+//            // =
+//            {"/test/ab=cd", "/test/ab=cd"},
+//            {"http://localhost:4502/test/ab=cd", "http://localhost:4502/test/ab=cd"},
+//            // >
+//            {"/test/ab>cd", "/test/ab%3Ecd"},
+//            {"http://localhost:4502/test/ab>cd", "http://localhost:4502/test/ab%3Ecd"},
+//            // <
+//            {"/test/ab<cd", "/test/ab%3Ccd"},
+//            {"http://localhost:4502/test/ab<cd", "http://localhost:4502/test/ab%3Ccd"},
+//            // `
+//            {"/test/ab`cd", "/test/ab%60cd"},
+//            {"http://localhost:4502/test/ab`cd", "http://localhost:4502/test/ab%60cd"},
+//            // colons in query string
+//            {"/test/search.html?0_tag:id=test", "/test/search.html?0_tag%3Aid=test"},
+//            { // JCR namespaces and colons in query string
+//                "/test/jcr:content/search.html?0_tag:id=test",
+//                "/test/_jcr_content/search.html?0_tag%3Aid=test"
+//            },
+//            { // ? in query string
+//                "/test/search.html?0_tag:id=test?ing&1_tag:id=abc",
+//                "/test/search.html?0_tag%3Aid=test?ing&1_tag%3Aid=abc",
+//            }
+//        };
+//
+//        for (String[] aTestData : testData) {
+//            String href = aTestData[0];
+//            String expected = aTestData[1];
+//
+//            TestCase.assertEquals("Requested '" + href + "'", expected, xssAPI.getValidHref(href));
+//        }
+//    }
+
+//    @Test
+//    public void testGetValidHrefWithoutHrefConfig() throws Exception {
+//        // Load AntiSamy configuration without href filter
+//        XSSFilterImpl xssFilter = Whitebox.getInternalState(xssAPI, "xssFilter");
+//        setDefaultHandler(xssFilter, "./src/test/resources/configWithoutHref.xml");
+//
+//        Attribute hrefAttribute = Whitebox.getInternalState(xssFilter, "hrefAttribute");
+//        Assert.assertEquals(hrefAttribute, XSSFilterImpl.DEFAULT_HREF_ATTRIBUTE);
+//
+//        // Run same tests again to check default configuration
+//        testGetValidHref();
+//    }
+
+//    @Test
+//    public void testGetValidInteger() {
+//        String[][] testData = {
+//            //         Source                                        Expected Result
+//            //
+//            {null, "123"},
+//            {"100", "100"},
+//            {"0", "0"},
+//
+//            {"junk", "123"},
+//            {"100.5", "123"},
+//            {"", "123"},
+//            {"null", "123"}
+//        };
+//
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            Integer expected = (aTestData[1] != null) ? new Integer(aTestData[1]) : null;
+//
+//            TestCase.assertEquals("Validating integer '" + source + "'", expected, xssAPI.getValidInteger(source, 123));
+//        }
+//    }
+
+//    @Test
+//    public void testGetValidLong() {
+//        String[][] testData = {
+//            //         Source                                        Expected Result
+//            //
+//            {null, "123"},
+//            {"100", "100"},
+//            {"0", "0"},
+//
+//            {"junk", "123"},
+//            {"100.5", "123"},
+//            {"", "123"},
+//            {"null", "123"}
+//        };
+//
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            Long expected = (aTestData[1] != null) ? new Long(aTestData[1]) : null;
+//
+//            TestCase.assertEquals("Validating long '" + source + "'", expected, xssAPI.getValidLong(source, 123));
+//        }
+//    }
+
+//    @Test
+//    public void testGetValidDouble() {
+//        String[][] testData = {
+//            //         Source                                        Expected Result
+//            //
+//            {null, "123"},
+//            {"100.5", "100.5"},
+//            {"0", "0"},
+//
+//            {"junk", "123"},
+//            {"", "123"},
+//            {"null", "123"}
+//        };
+//
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            Double expected = (aTestData[1] != null) ? new Double(aTestData[1]) : null;
+//
+//            TestCase.assertEquals("Validating double '" + source + "'", expected, xssAPI.getValidDouble(source, 123));
+//        }
+//    }
+
+//    @Test
+//    public void testGetValidDimension() {
+//        String[][] testData = {
+//            //         Source                                        Expected Result
+//            //
+//            {null, "123"},
+//            {"", "123"},
+//            {"100", "100"},
+//            {"0", "0"},
+//
+//            {"junk", "123"},
+//            {"100.5", "123"},
+//            {"", "123"},
+//            {"null", "123"},
+//
+//            {"\"auto\"", "\"auto\""},
+//            {"'auto'", "\"auto\""},
+//            {"auto", "\"auto\""},
+//
+//            {"autox", "123"}
+//        };
+//
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            String expected = aTestData[1];
+//
+//            TestCase.assertEquals("Validating dimension '" + source + "'", expected, xssAPI.getValidDimension(source, "123"));
+//        }
+//    }
+
+    @Test
+    public void testEncodeForJSString() {
+        String[][] testData = {
+            //         Source                            Expected Result
+            //
+            {null, null},
+            {"simple", "simple"},
+
+            {"break\"out", "break\\x22out"},
+            {"break'out", "break\\x27out"},
+
+            {"</script>", "<\\/script>"},
+
+            {"'alert(document.cookie)", "\\x27alert(document.cookie)"},
+            {"2014-04-22T10:11:24.002+01:00", "2014\\u002D04\\u002D22T10:11:24.002+01:00"}
+        };
+
+        for (String[] aTestData : testData) {
+            String source = aTestData[0];
+            String expected = aTestData[1];
+
+            assertEquals(expected, xssAPI.encodeForJSString(source), "Encoding '" + source + "'");
+        }
+    }
+
+    @Test
+    public void testGetValidJSToken() {
+        String[][] testData = {
+            //         Source                            Expected Result
+            //
+            {null, RUBBISH},
+            {"", RUBBISH},
+            {"simple", "simple"},
+            {"clickstreamcloud.thingy", "clickstreamcloud.thingy"},
+
+            {"break out", RUBBISH},
+            {"break,out", RUBBISH},
+
+            {"\"literal string\"", "\"literal string\""},
+            {"'literal string'", "'literal string'"},
+            {"\"bad literal'", RUBBISH},
+            {"'literal'); junk'", "'literal\\x27); junk'"},
+
+            {"1200", "1200"},
+            {"3.14", "3.14"},
+            {"1,200", RUBBISH},
+            {"1200 + 1", RUBBISH}
+        };
+
+        for (String[] aTestData : testData) {
+            String source = aTestData[0];
+            String expected = aTestData[1];
+
+            assertEquals(expected, xssAPI.getValidJSToken(source, RUBBISH), "Validating Javascript token '" + source + "'");
+        }
+    }
+
+//    @Test
+//    public void testEncodeForCSSString() {
+//        String[][] testData = {
+//            // Source   Expected result
+//            {null, null},
+//            {"test"   , "test"},
+//            {"\\"     , "\\5c"},
+//            {"'"      , "\\27"},
+//            {"\""     , "\\22"}
+//        };
+//
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            String expected = aTestData[1];
+//
+//            String result = xssAPI.encodeForCSSString(source);
+//            TestCase.assertEquals("Encoding '" + source + "'", expected, result);
+//        }
+//    }
+
+//    @Test
+//    public void testGetValidStyleToken() {
+//        String[][] testData = {
+//            // Source                           Expected result
+//            {null                               , RUBBISH},
+//            {""                                 , RUBBISH},
+//
+//            // CSS close
+//            {"}"                                , RUBBISH},
+//
+//            // line break
+//            {"br\neak"                          , RUBBISH},
+//
+//            // no javascript:
+//            {"javascript:alert(1)"              , RUBBISH},
+//            {"'javascript:alert(1)'"            , RUBBISH},
+//            {"\"javascript:alert('XSS')\""      , RUBBISH},
+//            {"url(javascript:alert(1))"         , RUBBISH},
+//            {"url('javascript:alert(1)')"       , RUBBISH},
+//            {"url(\"javascript:alert('XSS')\")" , RUBBISH},
+//
+//            // no expression
+//            {"expression(alert(1))"             , RUBBISH},
+//            {"expression  (alert(1))"           , RUBBISH},
+//            {"expression(this.location='a.co')" , RUBBISH},
+//
+//            // html tags
+//            {"</style><script>alert(1)</script>", RUBBISH},
+//
+//            // usual CSS stuff
+//            {"background-color"                 , "background-color"},
+//            {"-moz-box-sizing"                  , "-moz-box-sizing"},
+//            {".42%"                             , ".42%"},
+//            {"#fff"                             , "#fff"},
+//
+//            // valid strings
+//            {"'literal string'"                 , "'literal string'"},
+//            {"\"literal string\""               , "\"literal string\""},
+//            {"'it\\'s here'"                    , "'it\\'s here'"},
+//            {"\"it\\\"s here\""                 , "\"it\\\"s here\""},
+//
+//            // invalid strings
+//            {"\"bad string"                     , RUBBISH},
+//            {"'it's here'"                      , RUBBISH},
+//            {"\"it\"s here\""                   , RUBBISH},
+//
+//            // valid parenthesis
+//            {"rgb(255, 255, 255)"               , "rgb(255, 255, 255)"},
+//
+//            // invalid parenthesis
+//            {"rgb(255, 255, 255"               , RUBBISH},
+//            {"255, 255, 255)"                  , RUBBISH},
+//
+//            // valid tokens
+//            {"url(http://example.com/test.png)", "url(http://example.com/test.png)"},
+//            {"url('image/test.png')"           , "url('image/test.png')"},
+//
+//            // invalid tokens
+//            {"color: red"                      , RUBBISH}
+//        };
+//
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            String expected = aTestData[1];
+//
+//            String result = xssAPI.getValidStyleToken(source, RUBBISH);
+//            if (!result.equals(expected)) {
+//                fail("Validating style token '" + source + "', expecting '" + expected + "', but got '" + result + "'");
+//            }
+//        }
+//    }
+
+//    @Test
+//    public void testGetValidCSSColor() {
+//        String[][] testData = {
+//            //      Source                          Expected Result
+//            //
+//            {null, RUBBISH},
+//            {"", RUBBISH},
+//
+//            {"rgb(0,+0,-0)", "rgb(0,+0,-0)"},
+//            {"rgba ( 0\f%, 0%,\t0%,\n100%\r)", "rgba ( 0\f%, 0%,\t0%,\n100%\r)",},
+//
+//            {"#ddd", "#ddd"},
+//            {"#eeeeee", "#eeeeee",},
+//
+//            {"hsl(0,1,2)", "hsl(0,1,2)"},
+//            {"hsla(0,1,2,3)", "hsla(0,1,2,3)"},
+//            {"currentColor", "currentColor"},
+//            {"transparent", "transparent"},
+//
+//            {"\f\r\n\t MenuText\f\r\n\t ", "MenuText"},
+//            {"expression(99,99,99)", RUBBISH},
+//            {"blue;", RUBBISH},
+//            {"url(99,99,99)", RUBBISH}
+//        };
+//
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            String expected = aTestData[1];
+//
+//            String result = xssAPI.getValidCSSColor(source, RUBBISH);
+//            if (!result.equals(expected)) {
+//                fail("Validating CSS Color '" + source + "', expecting '" + expected + "', but got '" + result + "'");
+//            }
+//        }
+//    }
+
+//    @Test
+//    public void testGetValidMultiLineComment() {
+//        String[][] testData = {
+//            //Source            Expected Result
+//
+//            {null               , RUBBISH},
+//            {"blah */ hack"     , RUBBISH},
+//
+//            {"Valid comment"    , "Valid comment"}
+//        };
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            String expected = aTestData[1];
+//
+//            String result = xssAPI.getValidMultiLineComment(source, RUBBISH);
+//            if (!result.equals(expected)) {
+//                fail("Validating multiline comment '" + source + "', expecting '" + expected + "', but got '" + result + "'");
+//            }
+//        }
+//    }
+
+//    @Test
+//    public void testGetValidJSON() {
+//        String[][] testData = {
+//            {null,      RUBBISH_JSON},
+//            {"",        ""},
+//            {"1]",      RUBBISH_JSON},
+//            {"{}",      "{}"},
+//            {"{1}",     RUBBISH_JSON},
+//            {
+//                "{test: 'test'}",
+//                "{\"test\":\"test\"}"
+//            },
+//            {
+//                "{test:\"test}",
+//                RUBBISH_JSON
+//            },
+//            {
+//                "{test1:'test1', test2: {test21: 'test21', test22: 'test22'}}",
+//                "{\"test1\":\"test1\",\"test2\":{\"test21\":\"test21\",\"test22\":\"test22\"}}"
+//            },
+//            {"[]",      "[]"},
+//            {"[1,2]",   "[1,2]"},
+//            {"[1",      RUBBISH_JSON},
+//            {
+//                "[{test: 'test'}]",
+//                "[{\"test\":\"test\"}]"
+//            }
+//        };
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            String expected = aTestData[1];
+//
+//            String result = xssAPI.getValidJSON(source, RUBBISH_JSON);
+//            if (!result.equals(expected)) {
+//                fail("Validating JSON '" + source + "', expecting '" + expected + "', but got '" + result + "'");
+//            }
+//        }
+//    }
+
+//    @Test
+//    public void testGetValidXML() {
+//        String[][] testData = {
+//            {null,      RUBBISH_XML},
+//            {"",        ""},
+//            {
+//                "<t/>",
+//                "<t/>"
+//            },
+//            {
+//                "<t>",
+//                RUBBISH_XML
+//            },
+//            {
+//                "<t>test</t>",
+//                "<t>test</t>"
+//            },
+//            {
+//                "<t>test",
+//                RUBBISH_XML
+//            },
+//            {
+//                "<t t=\"t\">test</t>",
+//                "<t t=\"t\">test</t>"
+//            },
+//            {
+//                "<t t=\"t>test</t>",
+//                RUBBISH_XML
+//            },
+//            {
+//                "<t><w>xyz</w></t>",
+//                "<t><w>xyz</w></t>"
+//            },
+//            {
+//                "<t><w>xyz</t></w>",
+//                RUBBISH_XML
+//            }
+//        };
+//        for (String[] aTestData : testData) {
+//            String source = aTestData[0];
+//            String expected = aTestData[1];
+//
+//            String result = xssAPI.getValidXML(source, RUBBISH_XML);
+//            if (!result.equals(expected)) {
+//                fail("Validating XML '" + source + "', expecting '" + expected + "', but got '" + result + "'");
+//            }
+//        }
+//    }
+}


### PR DESCRIPTION
The artifact, `org.apache.sling:org.apache.sling.xss.compat:1.0.0`, appears to be a **full clone** of the TPoV `org.apache.sling:org.apache.sling.xss:1.0.8` as there are very few differences in their binary jars (after ignoring modification times):
```
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/test_apache.sling.xss.compat$ ls -ltr *nodates*
-rw-rw-r-- 1 wtwhite wtwhite 137202 Oct  7 15:40 org.apache.sling.xss-1.0.8.jar.listing_nodates.txt
-rw-rw-r-- 1 wtwhite wtwhite 137237 Oct  7 15:42 org.apache.sling.xss.compat-1.0.0.jar.listing_nodates.txt
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/test_apache.sling.xss.compat$ !diff:p
diff *_nodates.txt|wc -l
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/test_apache.sling.xss.compat$ diff *_nodates.txt|wc -l
36
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/test_apache.sling.xss.compat$ diff *_nodates.txt
1c1
< Archive:  /home/wtwhite/.m2/repository/org/apache/sling/org.apache.sling.xss/1.0.8/org.apache.sling.xss-1.0.8.jar
---
> Archive:  /home/wtwhite/.m2/repository/org/apache/sling/org.apache.sling.xss.compat/1.0.0/org.apache.sling.xss.compat-1.0.0.jar
4c4
<      3073     META-INF/MANIFEST.MF
---
>      3100     META-INF/MANIFEST.MF
19,21c19,21
<       284     META-INF/DEPENDENCIES
<     11358     META-INF/LICENSE
<       290     META-INF/NOTICE
---
>       291     META-INF/DEPENDENCIES
>     16755     META-INF/LICENSE
>       541     META-INF/NOTICE
24,26c24,26
<         0     META-INF/maven/org.apache.sling/org.apache.sling.xss/
<       145     META-INF/maven/org.apache.sling/org.apache.sling.xss/pom.properties
<     12536     META-INF/maven/org.apache.sling/org.apache.sling.xss/pom.xml
---
>         0     META-INF/maven/org.apache.sling/org.apache.sling.xss.compat/
>       153     META-INF/maven/org.apache.sling/org.apache.sling.xss.compat/pom.properties
>     12578     META-INF/maven/org.apache.sling/org.apache.sling.xss.compat/pom.xml
863c863
<      2973     org/apache/sling/xss/JSONUtil.class
---
>      3057     org/apache/sling/xss/JSONUtil.class
865c865
<      1613     org/apache/sling/xss/XSSAPI.class
---
>      1687     org/apache/sling/xss/XSSAPI.class
2055c2055
<   5574998                     2050 files
---
>   5580888                     2050 files
```

It is **not critical** ([not used by any projects in Maven Central Repo](https://central.sonatype.com/artifact/org.apache.sling/org.apache.sling.xss.compat/1.0.0/dependents)).