### PR TITLE
Add the 1 vulnerable artifact found by shadedetector for CVE-2016-6798

### DIFF
--- a/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/README.md
+++ b/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/README.md
@@ -1,0 +1,9 @@
+# [CVE-2016-6798 -- sling](https://nvd.nist.gov/vuln/detail/CVE-2016-6798) from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+Project uses `org.apache.sling:org.apache.sling.xss:1.0.8`, test from https://github.com/apache/sling/commit/fb2719e8299fadddae62245482de112052a0e08c as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Based on the CVE-2016-5394 POV in this repo (which made its own minor changes -- see its [README](../CVE-2016-5394/README.md)), with the resource and some test setup removed and `testGetValidXML()` shrunk to just the repro-ing test introduced in the above-mentioned commit.
+
+Note that the test __fails__ indicating the vulnerability!
+
+Passes when the dependency on `org.apache.sling:org.apache.sling.xss:1.0.8` in `pom.xml` is changed to the next version available in the Maven repo, namely `1.0.12`.

--- a/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/pom.xml
+++ b/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>org.apache.sling__org.apache.sling.xss.compat__1.0.0</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2016-6798 POV</description>
+    <name>CVE-2016-6798</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.xss.compat</artifactId>
+            <version>1.0.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.api</artifactId>
+            <version>2.2.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.8.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.5.5</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.5.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.json</artifactId>
+            <version>2.0.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,1075 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2016-6798",
+    "groupID" : "foo",
+    "artifactID" : "org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:16:57.289545Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "javax.servlet-api-4.0.1.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/javax/servlet/javax.servlet-api/4.0.1/javax.servlet-api-4.0.1.jar",
+    "md5" : "b80414033bf3397de334b95e892a2f44",
+    "sha1" : "a27082684a2ff0bf397666c3943496c44541d1ca",
+    "sha256" : "83a03dd877d3674576f0da7b90755c8524af099ccf0607fc61aa971535ad7c60",
+    "description" : "Java(TM) Servlet 4.0 API Design Specification",
+    "license" : "CDDL + GPLv2 with classpath exception: https://oss.oracle.com/licenses/CDDL+GPL-1.1",
+    "projectReferences" : [ "CVE-2016-6798:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "javax"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "servlet"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "https://javaee.github.io"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "extension-name",
+        "value" : "javax.servlet"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Vendor",
+        "value" : "GlassFish Community"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Implementation-Vendor-Id",
+        "value" : "org.glassfish"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "specification-vendor",
+        "value" : "Oracle Corporation"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "edburns"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "shingwaichan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Ed Burns"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Shing Wai Chan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Oracle"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "javax.servlet"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Java Servlet API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "organization name",
+        "value" : "GlassFish Community"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "organization url",
+        "value" : "https://javaee.github.io"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "jvnet-parent"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "net.java"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://javaee.github.io/servlet-spec/"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom (hint)",
+        "name" : "developer org",
+        "value" : "sun"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "javax"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "servlet"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "https://javaee.github.io"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "Java Servlet API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "extension-name",
+        "value" : "javax.servlet"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "javax.servlet-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "edburns"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "shingwaichan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Ed Burns"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Shing Wai Chan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Oracle"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "javax.servlet"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Java Servlet API"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "organization name",
+        "value" : "GlassFish Community"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "organization url",
+        "value" : "https://javaee.github.io"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "jvnet-parent"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "net.java"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://javaee.github.io/servlet-spec/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "4.0.1"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Version",
+        "value" : "4.0.1"
+      }, {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "4.0.1"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "4.0.1"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/javax.servlet/javax.servlet-api@4.0.1",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/javax.servlet/javax.servlet-api@4.0.1?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:oracle:java_se:4.0.1:*:*:*:*:*:*:*",
+      "confidence" : "MEDIUM",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aoracle&cpe_product=cpe%3A%2F%3Aoracle%3Ajava_se&cpe_version=cpe%3A%2F%3Aoracle%3Ajava_se%3A4.0.1"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "org.apache.sling.api-2.2.0.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/org/apache/sling/org.apache.sling.api/2.2.0/org.apache.sling.api-2.2.0.jar",
+    "md5" : "e4f63cd7cf73e66f25564c12d7d06ae4",
+    "sha1" : "bcd3526bb75faa458b23467d2bd34ad17ec77199",
+    "sha256" : "f06e163c61f194e12f72fe8465e987807103992011a4c0ea164b5e0d0c99afe6",
+    "description" : "\n        The Apache Sling API defines an extension to the Servlet\n        API 2.4 to provide access to content and unified access\n        to request parameters hiding the differences between the\n        different methods of transferring parameters from client\n        to server. Note that the Apache Sling API bundle does not\n        include the Servlet API but instead requires the API to\n        be provided by the Servlet container in which the Apache\n        Sling framework is running or by another bundle.\n    ",
+    "license" : "http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2016-6798:provided" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.apache.sling.api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "request"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "sling"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "sling"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://sling.apache.org/site/sling-api.html"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "org.apache.sling.api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "apache.sling.api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.apache.sling.api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.sling"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Sling API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "sling"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.apache.sling.api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "request"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "sling"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "sling"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://sling.apache.org/site/sling-api.html"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "Apache Sling API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "org.apache.sling.api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "apache.sling.api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.apache.sling.api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.sling"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Sling API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "sling"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "2.2.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Bundle-Version",
+        "value" : "2.2.0"
+      }, {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "2.2.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "2.2.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aapache&cpe_product=cpe%3A%2F%3Aapache%3Asling&cpe_version=cpe%3A%2F%3Aapache%3Asling%3A2.2.0"
+    }, {
+      "id" : "cpe:2.3:a:apache:sling_api:2.2.0:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aapache&cpe_product=cpe%3A%2F%3Aapache%3Asling_api&cpe_version=cpe%3A%2F%3Aapache%3Asling_api%3A2.2.0"
+    } ],
+    "vulnerabilities" : [ {
+      "source" : "NVD",
+      "name" : "CVE-2022-45064",
+      "severity" : "CRITICAL",
+      "cvssv3" : {
+        "baseScore" : 9.0,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "LOW",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "HIGH",
+        "integrityImpact" : "HIGH",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "CRITICAL",
+        "exploitabilityScore" : "2.3",
+        "impactScore" : "6.0",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "The SlingRequestDispatcher doesn't correctly implement the RequestDispatcher API resulting in a generic type of include-based cross-site scripting issues on the Apache Sling level. The vulnerability is exploitable by an attacker that is able to include a resource with specific content-type and control the include path (i.e. writing content). The impact of a successful attack is privilege escalation to administrative power.\n\n\n\n\nPlease update to Apache Sling Engine >= 2.14.0 and enable the \"Check Content-Type overrides\" configuration option.\n\n\n\n\n",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread/hhp611hltby3whk03vx2mv7cmy3vs0ok",
+        "name" : "https://lists.apache.org/thread/hhp611hltby3whk03vx2mv7cmy3vs0ok"
+      }, {
+        "source" : "MISC",
+        "url" : "http://www.openwall.com/lists/oss-security/2023/04/18/6",
+        "name" : "http://www.openwall.com/lists/oss-security/2023/04/18/6"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "2.14.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2022-32549",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 5.3,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "1.4",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-116" ],
+      "description" : "Apache Sling Commons Log <= 5.4.0 and Apache Sling API <= 2.25.0 are vulnerable to log injection. The ability to forge logs may allow an attacker to cover tracks by injecting fake logs and potentially corrupt log files.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://lists.apache.org/thread/7z6h3806mwcov5kx6l96pq839sn0po1v",
+        "name" : "N/A"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling_api:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "2.25.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling_commons_log:*:*:*:*:*:*:*:*",
+          "versionEndIncluding" : "5.4.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2015-2944",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "Multiple cross-site scripting (XSS) vulnerabilities in Apache Sling API before 2.2.2 and Apache Sling Servlets Post before 2.1.2 allow remote attackers to inject arbitrary web script or HTML via the URI, related to (1) org/apache/sling/api/servlets/HtmlResponse and (2) org/apache/sling/servlets/post/HtmlResponse.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r04237d561f3e5bced0a26287454450a34275162aa6b1dbae1b707b31@%3Cdev.sling.apache.org%3E",
+        "name" : "[sling-dev] 20210409 [jira] [Resolved] (SLING-10284) Dependency check fails on CVE-2015-2944 for Sling Resource Merger 1.4.0"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd2a352858630721e7b1655bbdf85e692d6156fcfe68109e12b017b16@%3Cdev.sling.apache.org%3E",
+        "name" : "[sling-dev] 20210409 [jira] [Created] (SLING-10284) Dependency check fails on CVE-2015-2944 for Sling Resource Merger 1.4.0"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://issues.apache.org/jira/browse/SLING-2082",
+        "name" : "https://issues.apache.org/jira/browse/SLING-2082"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://issues.apache.org/jira/browse/SLING-2082",
+        "name" : "https://issues.apache.org/jira/browse/SLING-2082"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r93d68359eb0ea8c0f26d71ca3998143f99209a24db7b4dacfc688cea@%3Cdev.sling.apache.org%3E",
+        "name" : "[sling-dev] 20210409 [jira] [Commented] (SLING-10284) Dependency check fails on CVE-2015-2944 for Sling Resource Merger 1.4.0"
+      }, {
+        "source" : "JVNDB",
+        "url" : "http://jvndb.jvn.jp/jvndb/JVNDB-2015-000069",
+        "name" : "JVNDB-2015-000069"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-2944",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-2944"
+      }, {
+        "source" : "JVN",
+        "url" : "http://jvn.jp/en/jp/JVN61328139/index.html",
+        "name" : "JVN#61328139"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r4f41dd891a52133abdbf7f74ad1dde80c46f157c1f1cf8c23ba60a70@%3Cdev.sling.apache.org%3E",
+        "name" : "[sling-dev] 20210409 [jira] [Comment Edited] (SLING-10284) Dependency check fails on CVE-2015-2944 for Sling Resource Merger 1.4.0"
+      }, {
+        "source" : "BID",
+        "url" : "http://www.securityfocus.com/bid/74839",
+        "name" : "74839"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2015-2944?component-type=maven&component-name=org.apache.sling%2Forg.apache.sling.api&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2015-2944] CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling_api:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "2.2.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:sling_servlets_post:*:*:*:*:*:*:*:*",
+          "versionEndIncluding" : "2.1.0"
+        }
+      } ]
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "org.osgi.compendium-4.1.0.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/org/osgi/org.osgi.compendium/4.1.0/org.osgi.compendium-4.1.0.jar",
+    "md5" : "d5d6b2f7a724409184524de3633095b6",
+    "sha1" : "ca4b2d8f88b6d06cd49d99cd1f67e58293703aaa",
+    "sha256" : "6af2f4e80093b4d8de6221412c46b1d9917cfe1e458f43e97a86df1e04f22edc",
+    "description" : "OSGi Service Platform Release 4 Compendium Interfaces and Classes.",
+    "projectReferences" : [ "CVE-2016-6798:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.osgi.compendium"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "osgi"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "osgi"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-copyright",
+        "value" : "Copyright (c) OSGi Alliance (2000, 2007). All Rights Reserved."
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://www.osgi.org/"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "osgi.compendium"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "cvs-header",
+        "value" : "$Header: /cvshome/build/osgi/osgi.cmpn.mf,v 1.5 2007/01/27 03:03:33 hargrave Exp $"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.osgi.compendium"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "osgi.compendium"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.osgi"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.osgi.compendium"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "http"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "osgi"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "service"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "osgi"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-copyright",
+        "value" : "Copyright (c) OSGi Alliance (2000, 2007). All Rights Reserved."
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://www.osgi.org/"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "osgi.compendium"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "osgi.compendium"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "cvs-header",
+        "value" : "$Header: /cvshome/build/osgi/osgi.cmpn.mf,v 1.5 2007/01/27 03:03:33 hargrave Exp $"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.osgi.compendium"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "osgi.compendium"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.osgi"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "4.1.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "4.1.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.osgi/org.osgi.compendium@4.1.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.osgi/org.osgi.compendium@4.1.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "org.osgi.core-4.1.0.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/org/osgi/org.osgi.core/4.1.0/org.osgi.core-4.1.0.jar",
+    "md5" : "2f53de1a2939934088d4899e25967697",
+    "sha1" : "b88cd082b5b6774e9db939e28c0e3dc526c92d89",
+    "sha256" : "1073de173c659fc1aba698a41faee196cdab9a5b2455e83429d1f7393093934a",
+    "description" : "OSGi Service Platform Release 4 Core Interface and Classes.",
+    "projectReferences" : [ "CVE-2016-6798:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.osgi.core"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "osgi"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "osgi"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-copyright",
+        "value" : "Copyright (c) OSGi Alliance (2000, 2007). All Rights Reserved."
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://www.osgi.org/"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "osgi.core"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "cvs-header",
+        "value" : "$Header: /cvshome/build/osgi/osgi.core.mf,v 1.6 2007/01/27 03:03:33 hargrave Exp $"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.osgi.core"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "osgi.core"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.osgi"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "org.osgi.core"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "osgi"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "service"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-category",
+        "value" : "osgi"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-copyright",
+        "value" : "Copyright (c) OSGi Alliance (2000, 2007). All Rights Reserved."
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://www.osgi.org/"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "osgi.core"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "osgi.core"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "cvs-header",
+        "value" : "$Header: /cvshome/build/osgi/osgi.core.mf,v 1.6 2007/01/27 03:03:33 hargrave Exp $"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "org.osgi.core"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "osgi.core"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.osgi"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "4.1.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "4.1.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.osgi/org.osgi.core@4.1.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.osgi/org.osgi.core@4.1.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  } ]
+}

--- a/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/grype/grype-report.json
+++ b/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/grype/grype-report.json
@@ -1,0 +1,1387 @@
+{
+ "matches": [
+  {
+   "vulnerability": {
+    "id": "CVE-2022-45064",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-45064",
+    "namespace": "nvd:cpe",
+    "severity": "Critical",
+    "urls": [
+     "http://www.openwall.com/lists/oss-security/2023/04/18/6",
+     "https://lists.apache.org/thread/hhp611hltby3whk03vx2mv7cmy3vs0ok"
+    ],
+    "description": "The SlingRequestDispatcher doesn't correctly implement the RequestDispatcher API resulting in a generic type of include-based cross-site scripting issues on the Apache Sling level. The vulnerability is exploitable by an attacker that is able to include a resource with specific content-type and control the include path (i.e. writing content). The impact of a successful attack is privilege escalation to administrative power.\n\n\n\n\nPlease update to Apache Sling Engine >= 2.14.0 and enable the \"Check Content-Type overrides\" configuration option.\n\n\n\n\n",
+    "cvss": [
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 9,
+       "exploitabilityScore": 2.3,
+       "impactScore": 6
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 8,
+       "exploitabilityScore": 1.3,
+       "impactScore": 6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.api",
+       "version": "2.2.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2022-45064",
+      "versionConstraint": "<= 2.14.0 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "0ed136dfd42c2fe5",
+    "name": "org.apache.sling.api",
+    "version": "2.2.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.api:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:api:2.2.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.api",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2016-0956",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2016-0956",
+    "namespace": "nvd:cpe",
+    "severity": "High",
+    "urls": [
+     "http://packetstormsecurity.com/files/135720/Apache-Sling-Framework-2.3.6-Information-Disclosure.html",
+     "http://seclists.org/fulldisclosure/2016/Feb/48",
+     "http://www.securityfocus.com/archive/1/537498/100/0/threaded",
+     "https://helpx.adobe.com/security/products/experience-manager/apsb16-05.html",
+     "https://www.exploit-db.com/exploits/39435/"
+    ],
+    "description": "The Servlets Post component 2.3.6 in Apache Sling, as used in Adobe Experience Manager 5.6.1, 6.0.0, and 6.1.0, allows remote attackers to obtain sensitive information via unspecified vectors.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:L/Au:N/C:C/I:N/A:N",
+      "metrics": {
+       "baseScore": 7.8,
+       "exploitabilityScore": 10,
+       "impactScore": 6.9
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.0",
+      "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "metrics": {
+       "baseScore": 7.5,
+       "exploitabilityScore": 3.9,
+       "impactScore": 3.6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.api",
+       "version": "2.2.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2016-0956",
+      "versionConstraint": "none (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "0ed136dfd42c2fe5",
+    "name": "org.apache.sling.api",
+    "version": "2.2.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.api:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:api:2.2.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.api",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "GHSA-rxvx-44w5-44r7",
+    "dataSource": "https://github.com/advisories/GHSA-rxvx-44w5-44r7",
+    "namespace": "github:language:java",
+    "severity": "Medium",
+    "urls": [
+     "https://github.com/advisories/GHSA-rxvx-44w5-44r7"
+    ],
+    "description": "Improper Neutralization of Input During Web Page Generation in Apache Sling",
+    "cvss": [],
+    "fix": {
+     "versions": [
+      "2.2.2"
+     ],
+     "state": "fixed"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [
+    {
+     "id": "CVE-2015-2944",
+     "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2015-2944",
+     "namespace": "nvd:cpe",
+     "severity": "Medium",
+     "urls": [
+      "http://jvn.jp/en/jp/JVN61328139/index.html",
+      "http://jvndb.jvn.jp/jvndb/JVNDB-2015-000069",
+      "http://www.securityfocus.com/bid/74839",
+      "https://issues.apache.org/jira/browse/SLING-2082",
+      "https://lists.apache.org/thread.html/r04237d561f3e5bced0a26287454450a34275162aa6b1dbae1b707b31@%3Cdev.sling.apache.org%3E",
+      "https://lists.apache.org/thread.html/r4f41dd891a52133abdbf7f74ad1dde80c46f157c1f1cf8c23ba60a70@%3Cdev.sling.apache.org%3E",
+      "https://lists.apache.org/thread.html/r93d68359eb0ea8c0f26d71ca3998143f99209a24db7b4dacfc688cea@%3Cdev.sling.apache.org%3E",
+      "https://lists.apache.org/thread.html/rd2a352858630721e7b1655bbdf85e692d6156fcfe68109e12b017b16@%3Cdev.sling.apache.org%3E"
+     ],
+     "description": "Multiple cross-site scripting (XSS) vulnerabilities in Apache Sling API before 2.2.2 and Apache Sling Servlets Post before 2.1.2 allow remote attackers to inject arbitrary web script or HTML via the URI, related to (1) org/apache/sling/api/servlets/HtmlResponse and (2) org/apache/sling/servlets/post/HtmlResponse.",
+     "cvss": [
+      {
+       "version": "2.0",
+       "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+       "metrics": {
+        "baseScore": 4.3,
+        "exploitabilityScore": 8.6,
+        "impactScore": 2.9
+       },
+       "vendorMetadata": {}
+      }
+     ]
+    }
+   ],
+   "matchDetails": [
+    {
+     "type": "exact-direct-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "language": "java",
+      "namespace": "github:language:java",
+      "package": {
+       "name": "org.apache.sling.api",
+       "version": "2.2.0"
+      }
+     },
+     "found": {
+      "versionConstraint": "<=2.2.1 (unknown)",
+      "vulnerabilityID": "GHSA-rxvx-44w5-44r7"
+     }
+    }
+   ],
+   "artifact": {
+    "id": "0ed136dfd42c2fe5",
+    "name": "org.apache.sling.api",
+    "version": "2.2.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.api:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:api:2.2.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.api",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "GHSA-qmx3-m648-hr74",
+    "dataSource": "https://github.com/advisories/GHSA-qmx3-m648-hr74",
+    "namespace": "github:language:java",
+    "severity": "Medium",
+    "urls": [
+     "https://github.com/advisories/GHSA-qmx3-m648-hr74"
+    ],
+    "description": "Log Injection in Apache Sling Commons Log and Apache Sling API",
+    "cvss": [],
+    "fix": {
+     "versions": [],
+     "state": "not-fixed"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [
+    {
+     "id": "CVE-2022-32549",
+     "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-32549",
+     "namespace": "nvd:cpe",
+     "severity": "Medium",
+     "urls": [
+      "https://lists.apache.org/thread/7z6h3806mwcov5kx6l96pq839sn0po1v"
+     ],
+     "description": "Apache Sling Commons Log <= 5.4.0 and Apache Sling API <= 2.25.0 are vulnerable to log injection. The ability to forge logs may allow an attacker to cover tracks by injecting fake logs and potentially corrupt log files.",
+     "cvss": [
+      {
+       "version": "2.0",
+       "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+       "metrics": {
+        "baseScore": 5,
+        "exploitabilityScore": 10,
+        "impactScore": 2.9
+       },
+       "vendorMetadata": {}
+      },
+      {
+       "version": "3.1",
+       "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+       "metrics": {
+        "baseScore": 5.3,
+        "exploitabilityScore": 3.9,
+        "impactScore": 1.4
+       },
+       "vendorMetadata": {}
+      }
+     ]
+    }
+   ],
+   "matchDetails": [
+    {
+     "type": "exact-direct-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "language": "java",
+      "namespace": "github:language:java",
+      "package": {
+       "name": "org.apache.sling.api",
+       "version": "2.2.0"
+      }
+     },
+     "found": {
+      "versionConstraint": "<=2.25.0 (unknown)",
+      "vulnerabilityID": "GHSA-qmx3-m648-hr74"
+     }
+    }
+   ],
+   "artifact": {
+    "id": "0ed136dfd42c2fe5",
+    "name": "org.apache.sling.api",
+    "version": "2.2.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.api:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:api:2.2.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.api",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "GHSA-cxwh-vmhg-39r2",
+    "dataSource": "https://github.com/advisories/GHSA-cxwh-vmhg-39r2",
+    "namespace": "github:language:java",
+    "severity": "Medium",
+    "urls": [
+     "https://github.com/advisories/GHSA-cxwh-vmhg-39r2"
+    ],
+    "description": "Improper Restriction of Operations within the Bounds of a Memory Buffer in Apache Sling",
+    "cvss": [],
+    "fix": {
+     "versions": [
+      "2.4.0"
+     ],
+     "state": "fixed"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [
+    {
+     "id": "CVE-2013-2254",
+     "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2013-2254",
+     "namespace": "nvd:cpe",
+     "severity": "Medium",
+     "urls": [
+      "http://mail-archives.apache.org/mod_mbox/sling-dev/201310.mbox/%3CCAKkCf4pue6PnESsP1KTdEDJm1gpkANFaK%2BvUd9mzEVT7tXL%2B3A%40mail.gmail.com%3E",
+      "http://www.securityfocus.com/bid/62903",
+      "https://exchange.xforce.ibmcloud.com/vulnerabilities/87765",
+      "https://issues.apache.org/jira/browse/SLING-2913"
+     ],
+     "description": "The deepGetOrCreateNode function in impl/operations/AbstractCreateOperation.java in org.apache.sling.servlets.post.bundle 2.2.0 and 2.3.0 in Apache Sling does not properly handle a NULL value that returned when the session does not have permissions to the root node, which allows remote attackers to cause a denial of service (infinite loop) via unspecified vectors.",
+     "cvss": [
+      {
+       "version": "2.0",
+       "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+       "metrics": {
+        "baseScore": 5,
+        "exploitabilityScore": 10,
+        "impactScore": 2.9
+       },
+       "vendorMetadata": {}
+      }
+     ]
+    }
+   ],
+   "matchDetails": [
+    {
+     "type": "exact-direct-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "language": "java",
+      "namespace": "github:language:java",
+      "package": {
+       "name": "org.apache.sling.api",
+       "version": "2.2.0"
+      }
+     },
+     "found": {
+      "versionConstraint": "<=2.3.0 (unknown)",
+      "vulnerabilityID": "GHSA-cxwh-vmhg-39r2"
+     }
+    }
+   ],
+   "artifact": {
+    "id": "0ed136dfd42c2fe5",
+    "name": "org.apache.sling.api",
+    "version": "2.2.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.api:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:api:2.2.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.api",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2013-4390",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2013-4390",
+    "namespace": "nvd:cpe",
+    "severity": "Medium",
+    "urls": [
+     "http://mail-archives.apache.org/mod_mbox/sling-dev/201310.mbox/%3CCAKkCf4qdFxEW9NXBJoMsrBama8LFNyir%2B61A0Vfzp4njEpeU%3Dw%40mail.gmail.com%3E",
+     "http://www.securityfocus.com/bid/63241",
+     "https://issues.apache.org/jira/browse/SLING-3141"
+    ],
+    "description": "Open redirect vulnerability in the AbstractAuthenticationFormServlet in the Auth Core (org.apache.sling.auth.core) bundle before 1.1.4 in Apache Sling allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the resource parameter, related to \"a custom login form and XSS.\"",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+      "metrics": {
+       "baseScore": 5.8,
+       "exploitabilityScore": 8.6,
+       "impactScore": 4.9
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.api",
+       "version": "2.2.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2013-4390",
+      "versionConstraint": "none (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "0ed136dfd42c2fe5",
+    "name": "org.apache.sling.api",
+    "version": "2.2.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.api:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.2.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:api:2.2.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.api@2.2.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.api",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2022-45064",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-45064",
+    "namespace": "nvd:cpe",
+    "severity": "Critical",
+    "urls": [
+     "http://www.openwall.com/lists/oss-security/2023/04/18/6",
+     "https://lists.apache.org/thread/hhp611hltby3whk03vx2mv7cmy3vs0ok"
+    ],
+    "description": "The SlingRequestDispatcher doesn't correctly implement the RequestDispatcher API resulting in a generic type of include-based cross-site scripting issues on the Apache Sling level. The vulnerability is exploitable by an attacker that is able to include a resource with specific content-type and control the include path (i.e. writing content). The impact of a successful attack is privilege escalation to administrative power.\n\n\n\n\nPlease update to Apache Sling Engine >= 2.14.0 and enable the \"Check Content-Type overrides\" configuration option.\n\n\n\n\n",
+    "cvss": [
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 9,
+       "exploitabilityScore": 2.3,
+       "impactScore": 6
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 8,
+       "exploitabilityScore": 1.3,
+       "impactScore": 6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:2.0.6:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.commons.json",
+       "version": "2.0.6"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2022-45064",
+      "versionConstraint": "<= 2.14.0 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "3340f3da9089f983",
+    "name": "org.apache.sling.commons.json",
+    "version": "2.0.6",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.commons.json:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:json:2.0.6:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.commons.json@2.0.6",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.commons.json",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2016-0956",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2016-0956",
+    "namespace": "nvd:cpe",
+    "severity": "High",
+    "urls": [
+     "http://packetstormsecurity.com/files/135720/Apache-Sling-Framework-2.3.6-Information-Disclosure.html",
+     "http://seclists.org/fulldisclosure/2016/Feb/48",
+     "http://www.securityfocus.com/archive/1/537498/100/0/threaded",
+     "https://helpx.adobe.com/security/products/experience-manager/apsb16-05.html",
+     "https://www.exploit-db.com/exploits/39435/"
+    ],
+    "description": "The Servlets Post component 2.3.6 in Apache Sling, as used in Adobe Experience Manager 5.6.1, 6.0.0, and 6.1.0, allows remote attackers to obtain sensitive information via unspecified vectors.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:L/Au:N/C:C/I:N/A:N",
+      "metrics": {
+       "baseScore": 7.8,
+       "exploitabilityScore": 10,
+       "impactScore": 6.9
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.0",
+      "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "metrics": {
+       "baseScore": 7.5,
+       "exploitabilityScore": 3.9,
+       "impactScore": 3.6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:2.0.6:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.commons.json",
+       "version": "2.0.6"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2016-0956",
+      "versionConstraint": "none (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "3340f3da9089f983",
+    "name": "org.apache.sling.commons.json",
+    "version": "2.0.6",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.commons.json:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:json:2.0.6:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.commons.json@2.0.6",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.commons.json",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2013-4390",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2013-4390",
+    "namespace": "nvd:cpe",
+    "severity": "Medium",
+    "urls": [
+     "http://mail-archives.apache.org/mod_mbox/sling-dev/201310.mbox/%3CCAKkCf4qdFxEW9NXBJoMsrBama8LFNyir%2B61A0Vfzp4njEpeU%3Dw%40mail.gmail.com%3E",
+     "http://www.securityfocus.com/bid/63241",
+     "https://issues.apache.org/jira/browse/SLING-3141"
+    ],
+    "description": "Open redirect vulnerability in the AbstractAuthenticationFormServlet in the Auth Core (org.apache.sling.auth.core) bundle before 1.1.4 in Apache Sling allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the resource parameter, related to \"a custom login form and XSS.\"",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+      "metrics": {
+       "baseScore": 5.8,
+       "exploitabilityScore": 8.6,
+       "impactScore": 4.9
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:2.0.6:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.commons.json",
+       "version": "2.0.6"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2013-4390",
+      "versionConstraint": "none (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "3340f3da9089f983",
+    "name": "org.apache.sling.commons.json",
+    "version": "2.0.6",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.commons.json:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:commons:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:2.0.6:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:json:2.0.6:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.commons.json@2.0.6",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.commons.json",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2022-45064",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-45064",
+    "namespace": "nvd:cpe",
+    "severity": "Critical",
+    "urls": [
+     "http://www.openwall.com/lists/oss-security/2023/04/18/6",
+     "https://lists.apache.org/thread/hhp611hltby3whk03vx2mv7cmy3vs0ok"
+    ],
+    "description": "The SlingRequestDispatcher doesn't correctly implement the RequestDispatcher API resulting in a generic type of include-based cross-site scripting issues on the Apache Sling level. The vulnerability is exploitable by an attacker that is able to include a resource with specific content-type and control the include path (i.e. writing content). The impact of a successful attack is privilege escalation to administrative power.\n\n\n\n\nPlease update to Apache Sling Engine >= 2.14.0 and enable the \"Check Content-Type overrides\" configuration option.\n\n\n\n\n",
+    "cvss": [
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 9,
+       "exploitabilityScore": 2.3,
+       "impactScore": 6
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 8,
+       "exploitabilityScore": 1.3,
+       "impactScore": 6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.xss.compat",
+       "version": "1.0.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2022-45064",
+      "versionConstraint": "<= 2.14.0 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "48e668f1d58307a4",
+    "name": "org.apache.sling.xss.compat",
+    "version": "1.0.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.xss.compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:xss:1.0.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.xss.compat@1.0.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.xss.compat",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2016-6798",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2016-6798",
+    "namespace": "nvd:cpe",
+    "severity": "Critical",
+    "urls": [
+     "http://www.securityfocus.com/bid/99873",
+     "https://lists.apache.org/thread.html/b72c3a511592ec70729b3ec2d29302b6ce87bbeab62d4745617a6bd0@%3Cdev.sling.apache.org%3E"
+    ],
+    "description": "In the XSS Protection API module before 1.0.12 in Apache Sling, the method XSS.getValidXML() uses an insecure SAX parser to validate the input string, which allows for XXE attacks in all scripts which use this method to validate user input, potentially allowing an attacker to read sensitive data on the filesystem, perform same-site-request-forgery (SSRF), port-scanning behind the firewall or DoS the application.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+      "metrics": {
+       "baseScore": 7.5,
+       "exploitabilityScore": 10,
+       "impactScore": 6.4
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.0",
+      "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "metrics": {
+       "baseScore": 9.8,
+       "exploitabilityScore": 3.9,
+       "impactScore": 5.9
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.xss.compat",
+       "version": "1.0.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2016-6798",
+      "versionConstraint": "<= 1.0.10 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "48e668f1d58307a4",
+    "name": "org.apache.sling.xss.compat",
+    "version": "1.0.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.xss.compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:xss:1.0.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.xss.compat@1.0.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.xss.compat",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2016-0956",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2016-0956",
+    "namespace": "nvd:cpe",
+    "severity": "High",
+    "urls": [
+     "http://packetstormsecurity.com/files/135720/Apache-Sling-Framework-2.3.6-Information-Disclosure.html",
+     "http://seclists.org/fulldisclosure/2016/Feb/48",
+     "http://www.securityfocus.com/archive/1/537498/100/0/threaded",
+     "https://helpx.adobe.com/security/products/experience-manager/apsb16-05.html",
+     "https://www.exploit-db.com/exploits/39435/"
+    ],
+    "description": "The Servlets Post component 2.3.6 in Apache Sling, as used in Adobe Experience Manager 5.6.1, 6.0.0, and 6.1.0, allows remote attackers to obtain sensitive information via unspecified vectors.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:L/Au:N/C:C/I:N/A:N",
+      "metrics": {
+       "baseScore": 7.8,
+       "exploitabilityScore": 10,
+       "impactScore": 6.9
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.0",
+      "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "metrics": {
+       "baseScore": 7.5,
+       "exploitabilityScore": 3.9,
+       "impactScore": 3.6
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.xss.compat",
+       "version": "1.0.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2016-0956",
+      "versionConstraint": "none (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "48e668f1d58307a4",
+    "name": "org.apache.sling.xss.compat",
+    "version": "1.0.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.xss.compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:xss:1.0.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.xss.compat@1.0.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.xss.compat",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2016-5394",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2016-5394",
+    "namespace": "nvd:cpe",
+    "severity": "Medium",
+    "urls": [
+     "http://www.securityfocus.com/bid/99870",
+     "https://lists.apache.org/thread.html/332166037a54b97cf41e2b616aaed38439de94b19b204841478e4525@%3Cdev.sling.apache.org%3E"
+    ],
+    "description": "In the XSS Protection API module before 1.0.12 in Apache Sling, the encoding done by the XSSAPI.encodeForJSString() method is not restrictive enough and for some input patterns allows script tags to pass through unencoded, leading to potential XSS vulnerabilities.",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+      "metrics": {
+       "baseScore": 4.3,
+       "exploitabilityScore": 8.6,
+       "impactScore": 2.9
+      },
+      "vendorMetadata": {}
+     },
+     {
+      "version": "3.1",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+      "metrics": {
+       "baseScore": 6.1,
+       "exploitabilityScore": 2.8,
+       "impactScore": 2.7
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.xss.compat",
+       "version": "1.0.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2016-5394",
+      "versionConstraint": "< 1.0.12 (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "48e668f1d58307a4",
+    "name": "org.apache.sling.xss.compat",
+    "version": "1.0.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.xss.compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:xss:1.0.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.xss.compat@1.0.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.xss.compat",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  },
+  {
+   "vulnerability": {
+    "id": "CVE-2013-4390",
+    "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2013-4390",
+    "namespace": "nvd:cpe",
+    "severity": "Medium",
+    "urls": [
+     "http://mail-archives.apache.org/mod_mbox/sling-dev/201310.mbox/%3CCAKkCf4qdFxEW9NXBJoMsrBama8LFNyir%2B61A0Vfzp4njEpeU%3Dw%40mail.gmail.com%3E",
+     "http://www.securityfocus.com/bid/63241",
+     "https://issues.apache.org/jira/browse/SLING-3141"
+    ],
+    "description": "Open redirect vulnerability in the AbstractAuthenticationFormServlet in the Auth Core (org.apache.sling.auth.core) bundle before 1.1.4 in Apache Sling allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the resource parameter, related to \"a custom login form and XSS.\"",
+    "cvss": [
+     {
+      "version": "2.0",
+      "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+      "metrics": {
+       "baseScore": 5.8,
+       "exploitabilityScore": 8.6,
+       "impactScore": 4.9
+      },
+      "vendorMetadata": {}
+     }
+    ],
+    "fix": {
+     "versions": [],
+     "state": "unknown"
+    },
+    "advisories": []
+   },
+   "relatedVulnerabilities": [],
+   "matchDetails": [
+    {
+     "type": "cpe-match",
+     "matcher": "java-matcher",
+     "searchedBy": {
+      "namespace": "nvd:cpe",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*"
+      ],
+      "Package": {
+       "name": "org.apache.sling.xss.compat",
+       "version": "1.0.0"
+      }
+     },
+     "found": {
+      "vulnerabilityID": "CVE-2013-4390",
+      "versionConstraint": "none (unknown)",
+      "cpes": [
+       "cpe:2.3:a:apache:sling:*:*:*:*:*:*:*:*"
+      ]
+     }
+    }
+   ],
+   "artifact": {
+    "id": "48e668f1d58307a4",
+    "name": "org.apache.sling.xss.compat",
+    "version": "1.0.0",
+    "type": "java-archive",
+    "locations": [
+     {
+      "path": "/pom.xml"
+     }
+    ],
+    "language": "java",
+    "licenses": [],
+    "cpes": [
+     "cpe:2.3:a:apache:org.apache.sling.xss.compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:compat:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:sling:1.0.0:*:*:*:*:*:*:*",
+     "cpe:2.3:a:apache:xss:1.0.0:*:*:*:*:*:*:*"
+    ],
+    "purl": "pkg:maven/org.apache.sling/org.apache.sling.xss.compat@1.0.0",
+    "upstreams": [],
+    "metadataType": "JavaMetadata",
+    "metadata": {
+     "virtualPath": "",
+     "pomArtifactID": "org.apache.sling.xss.compat",
+     "pomGroupID": "org.apache.sling",
+     "manifestName": "",
+     "archiveDigests": null
+    }
+   }
+  }
+ ],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:05.503573171+13:00"
+ }
+}

--- a/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/snyk/snyk-report.json
+++ b/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/snyk/snyk-report.json
@@ -1,0 +1,306 @@
+{
+  "vulnerabilities": [
+    {
+      "id": "SNYK-JAVA-ORGAPACHESLING-2934398",
+      "title": "Log Manipulation",
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+      "credit": [
+        "Alex Collignon"
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,2.25.4)"
+        ]
+      },
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.25.4"
+      ],
+      "patches": [],
+      "insights": {
+        "triageAdvice": null
+      },
+      "language": "java",
+      "severity": "medium",
+      "cvssScore": 5.3,
+      "functions": [],
+      "malicious": false,
+      "isDisputed": false,
+      "moduleName": "org.apache.sling:org.apache.sling.api",
+      "references": [
+        {
+          "url": "https://lists.apache.org/thread/7z6h3806mwcov5kx6l96pq839sn0po1v",
+          "title": "Apache Advisory"
+        },
+        {
+          "url": "https://github.com/apache/sling-org-apache-sling-api/commit/8754cd20cb047498e1cf53fde1e5c0357232e6b9",
+          "title": "GitHub Commit"
+        },
+        {
+          "url": "https://github.com/apache/sling-org-apache-sling-commons-log/commit/6b1e8372cc0ecfc4bec8b8749dc317533aeb2b2f",
+          "title": "GitHub Commit"
+        }
+      ],
+      "cvssDetails": [
+        {
+          "assigner": "NVD",
+          "severity": "medium",
+          "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "cvssV3BaseScore": 5.3,
+          "modificationTime": "2022-06-30T01:11:40.368579Z"
+        }
+      ],
+      "description": "## Overview\n\nAffected versions of this package are vulnerable to Log Manipulation when an attacker injects falsified log lines.\n## Remediation\nUpgrade `org.apache.sling:org.apache.sling.api` to version 2.25.4 or higher.\n## References\n- [Apache Advisory](https://lists.apache.org/thread/7z6h3806mwcov5kx6l96pq839sn0po1v)\n- [GitHub Commit](https://github.com/apache/sling-org-apache-sling-api/commit/8754cd20cb047498e1cf53fde1e5c0357232e6b9)\n- [GitHub Commit](https://github.com/apache/sling-org-apache-sling-commons-log/commit/6b1e8372cc0ecfc4bec8b8749dc317533aeb2b2f)\n",
+      "epssDetails": {
+        "percentile": "0.36548",
+        "probability": "0.00088",
+        "modelVersion": "v2023.03.01"
+      },
+      "identifiers": {
+        "CVE": [
+          "CVE-2022-32549"
+        ],
+        "CWE": [
+          "CWE-117"
+        ]
+      },
+      "packageName": "org.apache.sling:org.apache.sling.api",
+      "proprietary": false,
+      "creationTime": "2022-06-23T07:45:26.323765Z",
+      "functions_new": [],
+      "alternativeIds": [],
+      "disclosureTime": "2022-06-23T05:15:24Z",
+      "packageManager": "maven",
+      "mavenModuleName": {
+        "groupId": "org.apache.sling",
+        "artifactId": "org.apache.sling.api"
+      },
+      "publicationTime": "2022-06-23T14:32:09.459273Z",
+      "modificationTime": "2022-06-30T01:11:40.368579Z",
+      "socialTrendAlert": false,
+      "severityWithCritical": "medium",
+      "from": [
+        "foo:org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1",
+        "org.apache.sling:org.apache.sling.api@2.2.0"
+      ],
+      "upgradePath": [
+        false,
+        "org.apache.sling:org.apache.sling.api@2.25.4"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.apache.sling:org.apache.sling.api",
+      "version": "2.2.0"
+    },
+    {
+      "id": "SNYK-JAVA-ORGAPACHESLING-30727",
+      "title": "Cross-site Scripting (XSS)",
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+      "credit": [
+        "Unknown"
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,2.2.2)"
+        ]
+      },
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.2.2"
+      ],
+      "patches": [],
+      "insights": {
+        "triageAdvice": null
+      },
+      "language": "java",
+      "severity": "medium",
+      "cvssScore": 4.3,
+      "functions": [],
+      "malicious": false,
+      "isDisputed": false,
+      "moduleName": "org.apache.sling:org.apache.sling.api",
+      "references": [
+        {
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-2944",
+          "title": "NVD"
+        }
+      ],
+      "cvssDetails": [
+        {
+          "assigner": "NVD",
+          "severity": "medium",
+          "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+          "cvssV3BaseScore": 4.3,
+          "modificationTime": "2023-02-09T11:24:02.410222Z"
+        }
+      ],
+      "description": "## Overview\n[`org.apache.sling:org.apache.sling.api`](https://sling.apache.org/) is a framework for RESTful web-applications based on an extensible content tree.\n\nMultiple cross-site scripting (XSS) vulnerabilities in Apache Sling API before 2.2.2 and Apache Sling Servlets Post before 2.1.2 allow remote attackers to inject arbitrary web script or HTML via the URI, related to (1) org/apache/sling/api/servlets/HtmlResponse and (2) org/apache/sling/servlets/post/HtmlResponse.\n\n## Details\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-2944)\n",
+      "epssDetails": {
+        "percentile": "0.66610",
+        "probability": "0.00325",
+        "modelVersion": "v2023.03.01"
+      },
+      "identifiers": {
+        "CVE": [
+          "CVE-2015-2944"
+        ],
+        "CWE": [
+          "CWE-79"
+        ]
+      },
+      "packageName": "org.apache.sling:org.apache.sling.api",
+      "proprietary": false,
+      "creationTime": "2017-02-22T07:28:22.765000Z",
+      "functions_new": [],
+      "alternativeIds": [],
+      "disclosureTime": "2015-06-02T14:59:00Z",
+      "packageManager": "maven",
+      "mavenModuleName": {
+        "groupId": "org.apache.sling",
+        "artifactId": "org.apache.sling.api"
+      },
+      "publicationTime": "2015-06-03T16:21:02Z",
+      "modificationTime": "2023-02-09T11:24:02.410222Z",
+      "socialTrendAlert": false,
+      "severityWithCritical": "medium",
+      "from": [
+        "foo:org.apache.sling__org.apache.sling.xss.compat__1.0.0@0.0.1",
+        "org.apache.sling:org.apache.sling.api@2.2.0"
+      ],
+      "upgradePath": [
+        false,
+        "org.apache.sling:org.apache.sling.api@2.2.2"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.apache.sling:org.apache.sling.api",
+      "version": "2.2.0"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 4,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "2 vulnerable dependency paths",
+  "remediation": {
+    "unresolved": [],
+    "upgrade": {
+      "org.apache.sling:org.apache.sling.api@2.2.0": {
+        "upgradeTo": "org.apache.sling:org.apache.sling.api@2.25.4",
+        "upgrades": [
+          "org.apache.sling:org.apache.sling.api@2.2.0",
+          "org.apache.sling:org.apache.sling.api@2.2.0"
+        ],
+        "vulns": [
+          "SNYK-JAVA-ORGAPACHESLING-2934398",
+          "SNYK-JAVA-ORGAPACHESLING-30727"
+        ]
+      }
+    },
+    "patch": {},
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 2,
+  "projectName": "foo:org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0"
+}

--- a/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/steady/steady-report.json
+++ b/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/scan-results/steady/steady-report.json
@@ -1,0 +1,122 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 21:26 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "TEST, PROVIDED" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+			{
+		
+			"bug":{
+				"id":"CVE-2012-0881",
+				"cvssScore": "7.5" ,
+				"cvssVersion": "3.0" 
+			},
+			"filename": "org.apache.sling.xss.compat-1.0.0.jar",
+			"sha1": "FAA555729B10D1D27AE85A0EF2B2BD0CD492D36F",
+			
+			"modules": [
+			
+				{
+			
+				"groupId": "foo",
+				"artifactId": "org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+				"version": "0.0.1",
+				
+				"href": "http://localhost:8033/backend/../apps/#/$space.getSpaceToken()/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0/0.0.1",
+				
+				"scope": "TEST",
+				"isTransitive": false,
+				
+					"containsVulnerableCode": "unknown",
+				
+						"potentiallyExecutesVulnerableCode": "noLibraryCodeAtAll",
+				
+						"actuallyExecutesVulnerableCode": "noLibraryCodeAtAll"
+				}
+			]
+		}
+			,
+			{
+		
+			"bug":{
+				"id":"CVE-2013-4002",
+				"cvssScore": "7.1" ,
+				"cvssVersion": "2.0" 
+			},
+			"filename": "org.apache.sling.xss.compat-1.0.0.jar",
+			"sha1": "FAA555729B10D1D27AE85A0EF2B2BD0CD492D36F",
+			
+			"modules": [
+			
+				{
+			
+				"groupId": "foo",
+				"artifactId": "org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+				"version": "0.0.1",
+				
+				"href": "http://localhost:8033/backend/../apps/#/$space.getSpaceToken()/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0/0.0.1",
+				
+				"scope": "TEST",
+				"isTransitive": false,
+				
+					"containsVulnerableCode": "unknown",
+				
+						"potentiallyExecutesVulnerableCode": "noLibraryCodeAtAll",
+				
+						"actuallyExecutesVulnerableCode": "noLibraryCodeAtAll"
+				}
+			]
+		}
+			,
+			{
+		
+			"bug":{
+				"id":"CVE-2014-0114",
+				"cvssScore": "7.5" ,
+				"cvssVersion": "2.0" 
+			},
+			"filename": "org.apache.sling.xss.compat-1.0.0.jar",
+			"sha1": "FAA555729B10D1D27AE85A0EF2B2BD0CD492D36F",
+			
+			"modules": [
+			
+				{
+			
+				"groupId": "foo",
+				"artifactId": "org.apache.sling__org.apache.sling.xss.compat__1.0.0",
+				"version": "0.0.1",
+				
+				"href": "http://localhost:8033/backend/../apps/#/$space.getSpaceToken()/foo/org.apache.sling__org.apache.sling.xss.compat__1.0.0/0.0.1",
+				
+				"scope": "TEST",
+				"isTransitive": false,
+				
+					"containsVulnerableCode": "unknown",
+				
+						"potentiallyExecutesVulnerableCode": "noLibraryCodeAtAll",
+				
+						"actuallyExecutesVulnerableCode": "noLibraryCodeAtAll"
+				}
+			]
+		}
+		]
+	}
+}

--- a/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/src/test/java/org/apache/sling/xss/impl/XSSAPIImplTest.java
+++ b/CVE-2016-6798/org.apache.sling__org.apache.sling.xss.compat__1.0.0/src/test/java/org/apache/sling/xss/impl/XSSAPIImplTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one or
+ * more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the
+ * Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+ * applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ ******************************************************************************/
+package org.apache.sling.xss.impl;
+
+import java.lang.reflect.Field;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.xss.XSSAPI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.reflect.Whitebox;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class XSSAPIImplTest {
+
+    public static final String RUBBISH_XML = "<rubbish/>";
+
+    private XSSAPI xssAPI;
+
+    @BeforeEach
+    public void setup() {
+        try {
+            XSSFilterImpl xssFilter = new XSSFilterImpl();
+
+            xssAPI = new XSSAPIImpl();
+
+            System.out.println("xssAPI set");
+
+            Whitebox.invokeMethod(xssAPI, "activate");
+            Field filterField = XSSAPIImpl.class.getDeclaredField("xssFilter");
+            filterField.setAccessible(true);
+            filterField.set(xssAPI, xssFilter);
+
+            ResourceResolver mockResolver = mock(ResourceResolver.class);
+            when(mockResolver.map(anyString())).thenAnswer(new Answer() {
+                public Object answer(InvocationOnMock invocation) {
+                    Object[] args = invocation.getArguments();
+                    String url = (String) args[0];
+                    return url.replaceAll("jcr:", "_jcr_");
+                }
+            });
+
+            SlingHttpServletRequest mockRequest = mock(SlingHttpServletRequest.class);
+            when(mockRequest.getResourceResolver()).thenReturn(mockResolver);
+
+            xssAPI = xssAPI.getRequestSpecificAPI(mockRequest);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testGetValidXML() {
+        String[][] testData = {
+            {
+                "<?xml version=\"1.0\"?><!DOCTYPE test SYSTEM \"http://nonExistentHost:1234/\"><test/>",
+                "<?xml version=\"1.0\"?><!DOCTYPE test SYSTEM \"http://nonExistentHost:1234/\"><test/>"
+            }
+        };
+        for (String[] aTestData : testData) {
+            String source = aTestData[0];
+            String expected = aTestData[1];
+
+            String result = xssAPI.getValidXML(source, RUBBISH_XML);
+            assertEquals(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
The artifact, `org.apache.sling:org.apache.sling.xss.compat:1.0.0`, appears to be a **full clone** of the TPoV `org.apache.sling:org.apache.sling.xss:1.0.8` -- see #2.

It is **not critical** ([not used by any projects in Maven Central Repo](https://central.sonatype.com/artifact/org.apache.sling/org.apache.sling.xss.compat/1.0.0/dependents)).