### PR TITLE
Add the 2 vulnerable artifacts found by shadedetector for CVE-2018-1324

### DIFF
--- a/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/README.md
+++ b/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/README.md
@@ -1,0 +1,17 @@
+# [CVE-2018-1324](https://nvd.nist.gov/vuln/detail/CVE-2018-1324) from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+Project reproduces CVE-2018-1324 using CVE-specific test from a
+[vul4j commit](https://github.com/tuhh-softsec/vul4j/commit/45ddad15edd0f56a38d1d10e1ac6e1c2de9de881).
+
+The test has been rewritten to succeed if the vul4j test times out. The original test seems to be sensitive to timing,
+i.e. the fixed versions may not complete within the timeout given a slow environment, thus timeout was increased to 12
+seconds.
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/pom.xml
+++ b/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>com.liferay__com.liferay.portal.tools.bundle.support__3.2.7</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2018-1324 POC</description>
+    <name>CVE-2018-1324</name>
+
+    <properties>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.liferay</groupId>
+            <artifactId>com.liferay.portal.tools.bundle.support</artifactId>
+            <version>3.2.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/pov-project.json
+++ b/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/pov-project.json
@@ -1,0 +1,17 @@
+{
+  "id": "CVE-2018-1324",
+  "artifact": "org.apache.commons:commons-compress",
+  "vulnerableVersions": [
+    "1.11",
+    "1.12",
+    "1.13",
+    "1.14",
+    "1.15"
+  ],
+  "fixVersion": "1.16.1",
+  "testSignalWhenVulnerable": "success",
+  "references": [
+    "https://nvd.nist.gov/vuln/detail/CVE-2018-1324",
+    "https://github.com/advisories/GHSA-h436-432x-8fvx"
+  ]
+}

--- a/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,10272 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2018-1324",
+    "groupID" : "foo",
+    "artifactID" : "com.liferay__com.liferay.portal.tools.bundle.support__3.2.7",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:22:23.326640Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "com.liferay.portal.tools.bundle.support-3.2.7.jar (shaded: com.beust:jcommander:1.48)",
+    "filePath" : "/home/wtwhite/.m2/repository/com/liferay/com.liferay.portal.tools.bundle.support/3.2.7/com.liferay.portal.tools.bundle.support-3.2.7.jar/META-INF/maven/com.beust/jcommander/pom.xml",
+    "md5" : "8ef99bc1217fa6f75f2513bf08883ea3",
+    "sha1" : "e3c44d63445a893c083e87f1baa12300a2766c81",
+    "sha256" : "107e1a027e8ab334b81fb2896060db6baf32e37d2e304e6094236d3e7eb29903",
+    "description" : "A Java framework to parse command line options with annotations.",
+    "license" : "The Apache Software License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2018-1324:compile" ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "jcommander"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Cedric Beust"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.beust"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "JCommander"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://beust.com/jcommander"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "jcommander"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Cedric Beust"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.beust"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "JCommander"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://beust.com/jcommander"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.48"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.beust/jcommander@1.48",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.beust/jcommander@1.48?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "com.liferay.portal.tools.bundle.support-3.2.7.jar (shaded: commons-codec:commons-codec:1.10)",
+    "filePath" : "/home/wtwhite/.m2/repository/com/liferay/com.liferay.portal.tools.bundle.support/3.2.7/com.liferay.portal.tools.bundle.support-3.2.7.jar/META-INF/maven/commons-codec/commons-codec/pom.xml",
+    "md5" : "a7949292fa7a8f3333808e30ad7bbb90",
+    "sha1" : "44b9477418d2942d45550f7e7c66c16262062d0e",
+    "sha256" : "bdb8db7012d112a6e3ea8fdb7c510b300d99eff0819d27dddba9c43397ea4cfb",
+    "description" : "\n     The Apache Commons Codec package contains simple encoder and decoders for\n     various formats such as Base64 and Hexadecimal.  In addition to these\n     widely used encoders and decoders, the codec package also maintains a\n     collection of phonetic encoding utilities.\n  ",
+    "projectReferences" : [ "CVE-2018-1324:compile" ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-codec"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "bayard@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "dgraham@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "dlr@finemaltcoding.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ggregory@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "jon@collab.net"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "julius@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rwaldhoff@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sanders@totalsync.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tn@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tobrien@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bayard"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "dgraham"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "dlr"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ggregory"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jon"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "julius"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rwaldhoff"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sanders"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tn"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tobrien"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Daniel Rall"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "David Graham"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Gary Gregory"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Henri Yandell"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Jon S. Stevens"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Julius Davies"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rodney Waldhoff"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Scott Sanders"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Thomas Neidhart"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Tim OBrien"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org URL",
+        "value" : "http://juliusdavies.ca/"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "commons-codec"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Codec"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/proper/commons-codec/"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-codec"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "bayard@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "dgraham@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "dlr@finemaltcoding.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ggregory@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "jon@collab.net"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "julius@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rwaldhoff@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sanders@totalsync.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tn@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tobrien@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bayard"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "dgraham"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "dlr"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ggregory"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jon"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "julius"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rwaldhoff"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sanders"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tn"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tobrien"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Daniel Rall"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "David Graham"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Gary Gregory"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Henri Yandell"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Jon S. Stevens"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Julius Davies"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rodney Waldhoff"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Scott Sanders"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Thomas Neidhart"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Tim OBrien"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org URL",
+        "value" : "http://juliusdavies.ca/"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "commons-codec"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Codec"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/proper/commons-codec/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "1.10"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.10"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/commons-codec/commons-codec@1.10",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/commons-codec/commons-codec@1.10?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "com.liferay.portal.tools.bundle.support-3.2.7.jar (shaded: commons-logging:commons-logging:1.2)",
+    "filePath" : "/home/wtwhite/.m2/repository/com/liferay/com.liferay.portal.tools.bundle.support/3.2.7/com.liferay.portal.tools.bundle.support-3.2.7.jar/META-INF/maven/commons-logging/commons-logging/pom.xml",
+    "md5" : "51509fc18ecc54daf0a030f8a830deb0",
+    "sha1" : "075c03ba4b01932842a996ef8d3fc1ab61ddeac2",
+    "sha256" : "c91ab5aa570d86f6fd07cc158ec6bc2c50080402972ee9179fe24100739fbb20",
+    "description" : "Apache Commons Logging is a thin adapter allowing configurable bridging to other,\n    well known logging systems.",
+    "projectReferences" : [ "CVE-2018-1324:compile" ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-logging"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "baliuka@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "costin@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "craigmcc@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "dennisl@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "donaldp@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "morgand@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rdonkin@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rsitze@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rwaldhoff@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sanders@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "skitching@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tn@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "baliuka"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bstansberry"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "costin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "craigmcc"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "dennisl"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "donaldp"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "morgand"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rdonkin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rsitze"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rwaldhoff"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sanders"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "skitching"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tn"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Brian Stansberry"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Costin Manolache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Craig McClanahan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Dennis Lundberg"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Juozas Baliuka"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Morgan Delagrange"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Peter Donald"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Richard Sitze"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Robert Burrell Donkin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rodney Waldhoff"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Scott Sanders"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Simon Kitching"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Thomas Neidhart"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "The Apache Software Foundation"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "commons-logging"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Logging"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/proper/commons-logging/"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-logging"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "baliuka@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "costin@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "craigmcc@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "dennisl@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "donaldp@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "morgand@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rdonkin@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rsitze@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rwaldhoff@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sanders@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "skitching@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tn@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "baliuka"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bstansberry"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "costin"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "craigmcc"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "dennisl"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "donaldp"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "morgand"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rdonkin"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rsitze"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rwaldhoff"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sanders"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "skitching"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tn"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Brian Stansberry"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Costin Manolache"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Craig McClanahan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Dennis Lundberg"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Juozas Baliuka"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Morgan Delagrange"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Peter Donald"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Richard Sitze"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Robert Burrell Donkin"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rodney Waldhoff"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Scott Sanders"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Simon Kitching"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Thomas Neidhart"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Apache"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "The Apache Software Foundation"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "commons-logging"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Logging"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/proper/commons-logging/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "1.2"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.2"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/commons-logging/commons-logging@1.2",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/commons-logging/commons-logging@1.2?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "com.liferay.portal.tools.bundle.support-3.2.7.jar (shaded: org.apache.commons:commons-compress:1.12)",
+    "filePath" : "/home/wtwhite/.m2/repository/com/liferay/com.liferay.portal.tools.bundle.support/3.2.7/com.liferay.portal.tools.bundle.support-3.2.7.jar/META-INF/maven/org.apache.commons/commons-compress/pom.xml",
+    "md5" : "7e1b4425f98dbe81144887b8dd3683d4",
+    "sha1" : "d4ba952b054eef846e7255cc3ac6d4ca76ead72c",
+    "sha256" : "b787d574c851505e76212968b9ae1641ea79804aef7f5a2cee2a01cd4055213a",
+    "description" : "\nApache Commons Compress software defines an API for working with\ncompression and archive formats.  These include: bzip2, gzip, pack200,\nlzma, xz, Snappy, traditional Unix Compress, DEFLATE and ar, cpio,\njar, tar, zip, dump, 7z, arj.\n  ",
+    "projectReferences" : [ "CVE-2018-1324:compile" ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "bodewig at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "damjan at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ebourg at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ggregory at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "grobmeier at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "julius at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sebb at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tcurdt at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bodewig"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "damjan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ebourg"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ggregory"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "grobmeier"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "julius"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sebb"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tcurdt"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Christian Grobmeier"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Damjan Jovanovic"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Emmanuel Bourg"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Gary Gregory"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Julius Davies"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Sebastian Bazley"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stefan Bodewig"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Torsten Curdt"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/proper/commons-compress/"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-compress"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "bodewig at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "damjan at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ebourg at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ggregory at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "grobmeier at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "julius at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sebb at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tcurdt at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bodewig"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "damjan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ebourg"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ggregory"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "grobmeier"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "julius"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sebb"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tcurdt"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Christian Grobmeier"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Damjan Jovanovic"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Emmanuel Bourg"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Gary Gregory"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Julius Davies"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Sebastian Bazley"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stefan Bodewig"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Torsten Curdt"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Compress"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/proper/commons-compress/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "1.12"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.12"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.apache.commons/commons-compress@1.12",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.apache.commons/commons-compress@1.12?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:apache:commons_compress:1.12:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aapache&cpe_product=cpe%3A%2F%3Aapache%3Acommons_compress&cpe_version=cpe%3A%2F%3Aapache%3Acommons_compress%3A1.12"
+    } ],
+    "vulnerabilities" : [ {
+      "source" : "NVD",
+      "name" : "CVE-2021-35515",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-835" ],
+      "description" : "When reading a specially crafted 7Z archive, the construction of the list of codecs that decompress an entry can result in an infinite loop. This could be used to mount a denial of service attack against services that use Compress' sevenz package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rbe91c512c5385181149ab087b6c909825d34299f5c491c6482a2ed57@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [druid] branch master updated: Address CVE-2021-35515 CVE-2021-36090 (#11496)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rab292091eadd1ecc63c516e9541a7f241091cf2e652b8185a6059945@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [GitHub] [druid] suneet-s merged pull request #11496: Address CVE-2021-35515 CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] hanahmily merged pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+        "name" : "[poi-dev] 20210923 Re: [VOTE] Apache POI 5.1.0 release (RC1)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rbaea15ddc5a7c0c6b66660f1d6403b28595e2561bb283eade7d7cd69@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-35515: Apache Commons Compress 1.6 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35515",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35515"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] wu-sheng opened a new pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/1",
+        "name" : "[oss-security] 20210713 CVE-2021-35515: Apache Commons Compress 1.6 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/r19ebfd71770ec0617a9ea180e321ef927b3fefb4c81ec5d1902d20ab%40%3Cuser.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/r19ebfd71770ec0617a9ea180e321ef927b3fefb4c81ec5d1902d20ab%40%3Cuser.commons.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [skywalking] 01/01: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] commented on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210716 [GitHub] [pulsar] lhotari opened a new pull request #11345: [Security] Upgrade commons-compress to 1.21"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20211022-0001/",
+        "name" : "https://security.netapp.com/advisory/ntap-20211022-0001/"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2021-35515?component-type=maven&component-name=org.apache.commons%2Fcommons-compress&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2021-35515] CWE-835: Loop with Unreachable Exit Condition ('Infinite Loop')"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://lists.apache.org/thread.html/rbaea15ddc5a7c0c6b66660f1d6403b28595e2561bb283eade7d7cd69@%3Cannounce.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/rbaea15ddc5a7c0c6b66660f1d6403b28595e2561bb283eade7d7cd69@%3Cannounce.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [skywalking] branch master updated: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090 (#7400)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf2f4d7940371a7c7c5b679f50e28fc7fcc82cd00670ced87e013ac88@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [GitHub] [druid] suneet-s opened a new pull request #11496: Address CVE-2021-35515 CVE-2021-36090"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.6",
+          "versionEndIncluding" : "1.20"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:oncommand_insight:-:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_payments:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_trade_finance:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_treasury_management:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:12.0.0.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_automated_test_suite:1.8.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_service_communication_proxy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_route_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.5"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.7.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "14.0.0",
+          "versionEndIncluding" : "14.3.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:12.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:14.5.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_data_repository:8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.59:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.1.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.3.1:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-35516",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-770" ],
+      "description" : "When reading a specially crafted 7Z archive, Compress can be made to allocate large amounts of memory that finally leads to an out of memory error even for very small inputs. This could be used to mount a denial of service attack against services that use Compress' sevenz package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] commented on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210716 [GitHub] [pulsar] lhotari opened a new pull request #11345: [Security] Upgrade commons-compress to 1.21"
+      }, {
+        "source" : "MISC",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] hanahmily merged pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/rf68442d67eb166f4b6cf0bbbe6c7f99098c12954f37332073c9822ca%40%3Cuser.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/rf68442d67eb166f4b6cf0bbbe6c7f99098c12954f37332073c9822ca%40%3Cuser.commons.apache.org%3E"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20211022-0001/",
+        "name" : "https://security.netapp.com/advisory/ntap-20211022-0001/"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+        "name" : "[poi-dev] 20210923 Re: [VOTE] Apache POI 5.1.0 release (RC1)"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35516",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35516"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://issues.apache.org/jira/browse/COMPRESS-542",
+        "name" : "https://issues.apache.org/jira/browse/COMPRESS-542"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2021-35516?component-type=maven&component-name=org.apache.commons%2Fcommons-compress&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2021-35516] CWE-770: Allocation of Resources Without Limits or Throttling"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf5b1016fb15b7118b9a5e16bb0b78cb4f1dfcf7821eb137ab5757c91@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-35516: Apache Commons Compress 1.6 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] wu-sheng opened a new pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/2",
+        "name" : "[oss-security] 20210713 CVE-2021-35516: Apache Commons Compress 1.6 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [skywalking] branch master updated: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090 (#7400)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [skywalking] 01/01: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.6",
+          "versionEndIncluding" : "1.20"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:oncommand_insight:-:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:12.0.0.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_automated_test_suite:1.8.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_service_communication_proxy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_route_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.5"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.7.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "14.0.0",
+          "versionEndIncluding" : "14.3.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:12.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_data_repository:8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.59:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.1.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-35517",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-770" ],
+      "description" : "When reading a specially crafted TAR archive, Compress can be made to allocate large amounts of memory that finally leads to an out of memory error even for very small inputs. This could be used to mount a denial of service attack against services that use Compress' tar package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/OpenLiberty/open-liberty/issues/18808",
+        "name" : "https://github.com/OpenLiberty/open-liberty/issues/18808"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2021-35517?component-type=maven&component-name=org.apache.commons%2Fcommons-compress&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2021-35517] CWE-770: Allocation of Resources Without Limits or Throttling"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] hanahmily merged pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r54afdab05e01de970649c2d91a993f68a6b00cd73e6e34e16c832d46@%3Cuser.ant.apache.org%3E",
+        "name" : "[ant-user] 20210713 CVE-2021-36373: Apache Ant TAR archive denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+        "name" : "[poi-dev] 20210923 Re: [VOTE] Apache POI 5.1.0 release (RC1)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] wu-sheng opened a new pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://lists.apache.org/thread.html/ra393ffdc7c90a4a37ea023946f390285693795013a642d80fba20203@%3Cannounce.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/ra393ffdc7c90a4a37ea023946f390285693795013a642d80fba20203@%3Cannounce.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [skywalking] 01/01: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] commented on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210716 [GitHub] [pulsar] lhotari opened a new pull request #11345: [Security] Upgrade commons-compress to 1.21"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ra393ffdc7c90a4a37ea023946f390285693795013a642d80fba20203@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-35517: Apache Commons Compress 1.1 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/3",
+        "name" : "[oss-security] 20210713 CVE-2021-35517: Apache Commons Compress 1.1 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/r605d906b710b95f1bbe0036a53ac6968f667f2c249b6fbabada9a940%40%3Cuser.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/r605d906b710b95f1bbe0036a53ac6968f667f2c249b6fbabada9a940%40%3Cuser.commons.apache.org%3E"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/OpenLiberty/open-liberty/pull/17872",
+        "name" : "https://github.com/OpenLiberty/open-liberty/pull/17872"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35517",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-35517"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20211022-0001/",
+        "name" : "https://security.netapp.com/advisory/ntap-20211022-0001/"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/5",
+        "name" : "[oss-security] 20210713 CVE-2021-36373: Apache Ant TAR archive denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r31f75743ac173b0a606f8ea6ea53f351f386c44e7bcf78ae04007c29@%3Cissues.flink.apache.org%3E",
+        "name" : "[flink-issues] 20210908 [GitHub] [flink] MartijnVisser opened a new pull request #17194: [FLINK-24034] Upgrade commons-compress to 1.21 and other apache.commons updates"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [skywalking] branch master updated: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090 (#7400)"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://openliberty.io/docs/latest/security-vulnerabilities.html",
+        "name" : "https://openliberty.io/docs/latest/security-vulnerabilities.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r457b2ed564860996b20d938566fe8bd4bfb7c37be8e205448ccb5975@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-36373: Apache Ant TAR archive denial of service vulnerability"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.1",
+          "versionEndIncluding" : "1.20"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:oncommand_insight:-:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_payments:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_trade_finance:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_treasury_management:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:12.0.0.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_service_communication_proxy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_route_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.5"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.7.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "14.0.0",
+          "versionEndIncluding" : "14.3.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:12.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_data_repository:8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.59:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.1.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-36090",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "NVD-CWE-Other" ],
+      "description" : "When reading a specially crafted ZIP archive, Compress can be made to allocate large amounts of memory that finally leads to an out of memory error even for very small inputs. This could be used to mount a denial of service attack against services that use Compress' zip package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r54049b66afbca766b6763c7531e9fe7a20293a112bcb65462a134949@%3Ccommits.drill.apache.org%3E",
+        "name" : "[drill-commits] 20210804 [drill] branch master updated: Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/OpenLiberty/open-liberty/issues/18808",
+        "name" : "https://github.com/OpenLiberty/open-liberty/issues/18808"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rbe91c512c5385181149ab087b6c909825d34299f5c491c6482a2ed57@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [druid] branch master updated: Address CVE-2021-35515 CVE-2021-36090 (#11496)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rab292091eadd1ecc63c516e9541a7f241091cf2e652b8185a6059945@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [GitHub] [druid] suneet-s merged pull request #11496: Address CVE-2021-35515 CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] hanahmily merged pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/6",
+        "name" : "[oss-security] 20210713 CVE-2021-36374: Apache Ant ZIP, and ZIP based, archive denial of service vulerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+        "name" : "[poi-dev] 20210923 Re: [VOTE] Apache POI 5.1.0 release (RC1)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb5fa2ee61828fa2e42361b58468717e84902dd71c4aea8dc0b865df7@%3Cnotifications.james.apache.org%3E",
+        "name" : "[james-notifications] 20210714 [GitHub] [james-project] chibenwa opened a new pull request #537: [UPGRADE] Security upgrade: common-compress to 1.21"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/rc4134026d7d7b053d4f9f2205531122732405012c8804fd850a9b26f%40%3Cuser.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/rc4134026d7d7b053d4f9f2205531122732405012c8804fd850a9b26f%40%3Cuser.commons.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r0e87177f8e78b4ee453cd4d3d8f4ddec6f10d2c27707dd71e12cafc9@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-36374: Apache Ant ZIP, and ZIP based, archive denial of service vulerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] wu-sheng opened a new pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [skywalking] 01/01: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] commented on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://lists.apache.org/thread.html/r0e87177f8e78b4ee453cd4d3d8f4ddec6f10d2c27707dd71e12cafc9@%3Cannounce.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/r0e87177f8e78b4ee453cd4d3d8f4ddec6f10d2c27707dd71e12cafc9@%3Cannounce.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210716 [GitHub] [pulsar] lhotari opened a new pull request #11345: [Security] Upgrade commons-compress to 1.21"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf3f0a09fee197168a813966c5816157f6c600a47313a0d6813148ea6@%3Cissues.drill.apache.org%3E",
+        "name" : "[drill-issues] 20210803 [jira] [Created] (DRILL-7981) Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rbbf42642c3e4167788a7c13763d192ee049604d099681f765385d99d@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210804 [GitHub] [drill] luocooong opened a new pull request #2285: Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-36090",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r3227b1287e5bd8db6523b862c22676b046ad8f4fc96433225f46a2bd@%3Cissues.drill.apache.org%3E",
+        "name" : "[drill-issues] 20210805 [jira] [Commented] (DRILL-7981) Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/OpenLiberty/open-liberty/pull/17872",
+        "name" : "https://github.com/OpenLiberty/open-liberty/pull/17872"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rc7df4c2f0bbe2028a1498a46d322c91184f7a369e3e4c57d9518cacf@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210803 [jira] [Created] (DRILL-7981) Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r25f4c44616045085bc3cf901bb7e68e445eee53d1966fc08998fc456@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210805 [GitHub] [drill] luocooong merged pull request #2285: DRILL-7981: Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20211022-0001/",
+        "name" : "https://security.netapp.com/advisory/ntap-20211022-0001/"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2021-36090?component-type=maven&component-name=org.apache.commons%2Fcommons-compress&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2021-36090] CWE-Other"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rdd5412a5b9a25aed2a02c3317052d38a97128314d50bc1ed36e81d38@%3Cuser.ant.apache.org%3E",
+        "name" : "[ant-user] 20210713 CVE-2021-36374: Apache Ant ZIP, and ZIP based, archive denial of service vulerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r4f03c5de923e3f2a8c316248681258125140514ef3307bfe1538e1ab@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210804 [GitHub] [drill] luocooong merged pull request #2285: DRILL-7981: Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r75ffc7a461e7e7ae77690fa75bd47bb71365c732e0fbcc44da4f8ff5@%3Cdev.tomcat.apache.org%3E",
+        "name" : "[tomcat-dev] 20210811 [GitHub] [tomcat-jakartaee-migration] ebourg commented on issue #23: Vulnerability with Apache Commons Compress v1.20"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9a23d4dbf4e34d498664080bff59f2893b855eb16dae33e4aa92fa53@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-36090: Apache Commons Compress 1.0 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf93b6bb267580e01deb7f3696f7eaca00a290c66189a658cf7230a1a@%3Cissues.drill.apache.org%3E",
+        "name" : "[drill-issues] 20210804 [jira] [Commented] (DRILL-7981) Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/4",
+        "name" : "[oss-security] 20210713 CVE-2021-36090: Apache Commons Compress 1.0 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [skywalking] branch master updated: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090 (#7400)"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://openliberty.io/docs/latest/security-vulnerabilities.html",
+        "name" : "https://openliberty.io/docs/latest/security-vulnerabilities.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf2f4d7940371a7c7c5b679f50e28fc7fcc82cd00670ced87e013ac88@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [GitHub] [druid] suneet-s opened a new pull request #11496: Address CVE-2021-35515 CVE-2021-36090"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.0",
+          "versionEndExcluding" : "1.21"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:oncommand_insight:-:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_payments:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.6.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.7.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.9.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.12.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_trade_finance:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_treasury_management:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:12.0.0.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_automated_test_suite:1.8.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_service_communication_proxy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:8.2.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_element_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.2.0",
+          "versionEndIncluding" : "8.2.4.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_report_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.2.0",
+          "versionEndIncluding" : "8.2.5.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_route_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.5.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.4.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.4.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.5.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_analytical_applications_infrastructure:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.6",
+          "versionEndIncluding" : "8.1.1"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:*:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.7.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "14.0.0",
+          "versionEndIncluding" : "14.3.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:12.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_data_repository:8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.59:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.12.0",
+          "versionEndIncluding" : "17.12.11"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.8.0",
+          "versionEndIncluding" : "18.8.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "19.12.0",
+          "versionEndIncluding" : "19.12.11"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "20.12.0",
+          "versionEndIncluding" : "20.12.7"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.1.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2018-11771",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 5.5,
+        "attackVector" : "LOCAL",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "1.8",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-835" ],
+      "description" : "When reading a specially crafted ZIP archive, the read method of Apache Commons Compress 1.7 to 1.17's ZipArchiveInputStream can fail to return the correct EOF indication after the end of the stream has been reached. When combined with a java.io.InputStreamReader this can lead to an infinite stream, which can be used to mount a denial of service attack against services that use Compress' zip package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/714c6ac1b1b50f8557e7342903ef45f1538a7bc60a0b47d6e48c273d@%3Ccommits.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] spmallette commented on issue #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "SECTRACK",
+        "url" : "http://www.securitytracker.com/id/1041503",
+        "name" : "1041503"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-11771",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-11771"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/f28052d04cb8dbaae39bfd3dc8438e58c2a8be306a3f381f4728d7c1@%3Ccommits.commons.apache.org%3E",
+        "name" : "[commons-commits] 20190827 [commons-compress] branch master updated: record CVE-2019-12402"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/6c79965066c30d4e330e04d911d3761db41b82c89ae38d9a6b37a6f1@%3Cdev.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-dev] 20190924 [GitHub] [tinkerpop] spmallette commented on issue #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2018-11771?component-type=maven&component-name=org.apache.commons%2Fcommons-compress&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2018-11771] CWE-835: Loop with Unreachable Exit Condition ('Infinite Loop')"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/0adb631517766e793e18a59723e2df08ced41eb9a57478f14781c9f7@%3Cdev.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-dev] 20190930 [GitHub] [tinkerpop] spmallette closed pull request #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "BID",
+        "url" : "http://www.securityfocus.com/bid/105139",
+        "name" : "105139"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/b907e70bc422905d7962fd18f863f746bf7b4e7ed9da25c148580c61@%3Cnotifications.commons.apache.org%3E",
+        "name" : "[commons-notifications] 20190827 svn commit: r1049290 - in /websites/production/commons/content/proper/commons-compress: changes-report.html security-reports.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/c7954dc1e8fafd7ca1449f078953b419ebf8936e087f235f3bd024be@%3Ccommits.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch commented on issue #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/b8da751fc0ca949534cdf2744111da6bb0349d2798fac94b0a50f330@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20180816 [CVE-2018-11771] Apache Commons Compress 1.7 to 1.17 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/35f60d6d0407c13c39411038ba1aca71d92595ed7041beff4d07f2ee@%3Ccommits.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-commits] 20190923 [GitHub] [tinkerpop] robertdale commented on issue #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/3565494c263dfeb4dcb2a71cb24d09a1ca285cd6ac74edc025a3af8a@%3Ccommits.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-commits] 20190930 [GitHub] [tinkerpop] spmallette merged pull request #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/b8ef29df0f1d55aa741170748352ae8e425c7b1d286b2f257711a2dd@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20190530 [Discuss] RAT-244 - update to language level 1.7 due to CVE issues in RAT"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/eeecc1669242b28a3777ae13c68b376b0148d589d3d8170340d61120@%3Cdev.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-dev] 20190924 [GitHub] [tinkerpop] justinchuch commented on issue #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://issues.apache.org/jira/browse/COMPRESS-463",
+        "name" : "https://issues.apache.org/jira/browse/COMPRESS-463"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/f9cdd32af7d73e943452167d15801db39e8130409ebb9efb243b3f41@%3Ccommits.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-commits] 20190923 [GitHub] [tinkerpop] justinchuch opened a new pull request #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html#Apache_Commons_Compress_Security_Vulnerabilities",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html#Apache_Commons_Compress_Security_Vulnerabilities"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/e3eae9e6fc021c4c22dda59a335d21c12eecab480b48115a2f098ef6@%3Ccommits.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-commits] 20190923 [GitHub] [tinkerpop] spmallette commented on issue #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.7.0",
+          "versionEndIncluding" : "1.17.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:14.1.1.0.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2018-1324",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 5.5,
+        "attackVector" : "LOCAL",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "1.8",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-835" ],
+      "description" : "A specially crafted ZIP archive can be used to cause an infinite loop inside of Apache Commons Compress' extra field parser used by the ZipFile and ZipArchiveInputStream classes in versions 1.11 to 1.15. This can be used to mount a denial of service attack against services that use Compress' zip package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "OSSIndex",
+        "url" : "https://lists.apache.org/thread.html/1c7b6df6d1c5c8583518a0afa017782924918e4d6acfaf23ed5b2089@%3Cdev.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/1c7b6df6d1c5c8583518a0afa017782924918e4d6acfaf23ed5b2089@%3Cdev.commons.apache.org%3E"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2018-1324?component-type=maven&component-name=org.apache.commons%2Fcommons-compress&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2018-1324] CWE-835: Loop with Unreachable Exit Condition ('Infinite Loop')"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://issues.apache.org/jira/browse/COMPRESS-432",
+        "name" : "https://issues.apache.org/jira/browse/COMPRESS-432"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r5532dc8d5456b5151e8c286801e2e5769f5c04118b29c3b5d13ea387@%3Cissues.beam.apache.org%3E",
+        "name" : "[beam-issues] 20200421 [jira] [Closed] (BEAM-3873) Current version of commons-compress is DOS vulnerable CVE-2018-1324"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/b8ef29df0f1d55aa741170748352ae8e425c7b1d286b2f257711a2dd@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20190530 [Discuss] RAT-244 - update to language level 1.7 due to CVE issues in RAT"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-1324",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-1324"
+      }, {
+        "source" : "SECTRACK",
+        "url" : "http://www.securitytracker.com/id/1040549",
+        "name" : "1040549"
+      }, {
+        "source" : "BID",
+        "url" : "http://www.securityfocus.com/bid/103490",
+        "name" : "103490"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/1c7b6df6d1c5c8583518a0afa017782924918e4d6acfaf23ed5b2089@%3Cdev.commons.apache.org%3E",
+        "name" : "[dev] 20180316 [CVE-2018-1324] Apache Commons Compress denial of service vulnerability"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.11",
+          "versionEndIncluding" : "1.15"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:mysql_cluster:*:*:*:*:*:*:*:*",
+          "versionEndIncluding" : "7.4.34"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:mysql_cluster:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "7.5.0",
+          "versionEndIncluding" : "7.5.24"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:mysql_cluster:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "7.6.0",
+          "versionEndIncluding" : "7.6.20"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:mysql_cluster:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.0.27"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:14.1.1.0.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "com.liferay.portal.tools.bundle.support-3.2.7.jar (shaded: org.apache.httpcomponents:httpclient:4.5.2)",
+    "filePath" : "/home/wtwhite/.m2/repository/com/liferay/com.liferay.portal.tools.bundle.support/3.2.7/com.liferay.portal.tools.bundle.support-3.2.7.jar/META-INF/maven/org.apache.httpcomponents/httpclient/pom.xml",
+    "md5" : "71fd2a5a505554f3646f973a80c10b63",
+    "sha1" : "56f6338b324e438307e1f2c2b33bd02268310fc2",
+    "sha256" : "488001ba21829a4b28b0efbed18dccb13689f58f0985453863257049f7ec19f0",
+    "description" : "\n   Apache HttpComponents Client\n  ",
+    "projectReferences" : [ "CVE-2018-1324:compile" ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "httpclient"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.httpcomponents"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache HttpClient"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "httpcomponents-client"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://hc.apache.org/httpcomponents-client"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "httpclient"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.httpcomponents"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache HttpClient"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "httpcomponents-client"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://hc.apache.org/httpcomponents-client"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "4.5.2"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.apache.httpcomponents/httpclient@4.5.2",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.apache.httpcomponents/httpclient@4.5.2?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:apache:httpclient:4.5.2:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aapache&cpe_product=cpe%3A%2F%3Aapache%3Ahttpclient&cpe_version=cpe%3A%2F%3Aapache%3Ahttpclient%3A4.5.2"
+    } ],
+    "vulnerabilities" : [ {
+      "source" : "NVD",
+      "name" : "CVE-2020-13956",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 5.3,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "1.4",
+        "version" : "3.1"
+      },
+      "cwes" : [ "NVD-CWE-noinfo" ],
+      "description" : "Apache HttpClient versions prior to version 4.5.13 and 5.0.3 can misinterpret malformed authority component in request URIs passed to the library as java.net.URI object and pick the wrong target host for request execution.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2020-13956?component-type=maven&component-name=org.apache.httpcomponents%2Fhttpclient&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2020-13956] CWE-20: Improper Input Validation"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r06cf3ca5c8ceb94b39cd24a73d4e96153b485a7dac88444dd876accb@%3Cissues.drill.apache.org%3E",
+        "name" : "[drill-issues] 20210604 [jira] [Commented] (DRILL-7946) Bump HttpClient from 4.5.12 to 4.5.13 for CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r87ddc09295c27f25471269ad0a79433a91224045988b88f0413a97ec@%3Cissues.bookkeeper.apache.org%3E",
+        "name" : "[bookkeeper-issues] 20210914 [GitHub] [bookkeeper] nicoloboschi opened a new pull request #2793: Upgrade httpclient from 4.5.5 to 4.5.13 to address CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r2dc7930b43eadc78220d269b79e13ecd387e4bee52db67b2f47d4303@%3Cgitbox.hive.apache.org%3E",
+        "name" : "[hive-gitbox] 20210301 [GitHub] [hive] hsnusonic opened a new pull request #2032: HIVE-24837 Upgrade httpclient to 4.5.13+ due to CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r34efec51cb817397ccf9f86e25a75676d435ba5f83ee7b2eabdad707@%3Ccommits.creadur.apache.org%3E",
+        "name" : "[creadur-commits] 20210608 [jira] [Created] (TENTACLES-13) Upgrade httpclient to circumvent CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rcd9ad5dda60c82ab0d0c9bd3e9cb1dc740804451fc20c7f451ef5cc4@%3Cgitbox.hive.apache.org%3E",
+        "name" : "[hive-gitbox] 20210302 [GitHub] [hive] hsnusonic closed pull request #2032: HIVE-24837 Upgrade httpclient to 4.5.13+ due to CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r03bbc318c81be21f5c8a9b85e34f2ecc741aa804a8e43b0ef2c37749@%3Cissues.maven.apache.org%3E",
+        "name" : "[maven-issues] 20210530 [jira] [Updated] (DOXIA-615) Can you provide an updated version in order to fix CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r3cecd59fba74404cbf4eb430135e1080897fb376f111406a78bed13a@%3Cissues.lucene.apache.org%3E",
+        "name" : "[lucene-issues] 20211009 [GitHub] [lucene-solr] ventry1990 opened a new pull request #2579: SOLR-15269: Upgrade Apache HttpComponents Client to 4.5.13 to fix CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r63296c45d5d84447babaf39bd1487329d8a80d8d563e67a4b6f3d8a7@%3Cdev.ranger.apache.org%3E",
+        "name" : "[ranger-dev] 20201215 [jira] [Updated] (RANGER-3100) Upgrade httpclient version from 4.5.6 to 4.5.13+ due to CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r5de3d3808e7b5028df966e45115e006456c4e8931dc1e29036f17927@%3Cissues.solr.apache.org%3E",
+        "name" : "[solr-issues] 20210316 [jira] [Created] (SOLR-15269) upgrade httpclient to address CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20201215 [GitHub] [pulsar] yanshuchong opened a new issue #8967: CVSS issue list"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rea3dbf633dde5008d38bf6600a3738b9216e733e03f9ff7becf79625@%3Cissues.drill.apache.org%3E",
+        "name" : "[drill-issues] 20210604 [jira] [Created] (DRILL-7946) Bump HttpClient from 4.5.12 to 4.5.13 for CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r34178ab6ef106bc940665fd3f4ba5026fac3603b3fa2aefafa0b619d@%3Cdev.ranger.apache.org%3E",
+        "name" : "[ranger-dev] 20201216 [jira] [Commented] (RANGER-3100) Upgrade httpclient version from 4.5.6 to 4.5.13+ due to CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r3f740e4c38bba1face49078aa5cbeeb558c27be601cc9712ad2dcd1e@%3Ccommits.creadur.apache.org%3E",
+        "name" : "[creadur-commits] 20210608 [jira] [Work started] (TENTACLES-13) Upgrade httpclient to circumvent CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfc00884c7b7ca878297bffe45fcb742c362b00b26ba37070706d44c3@%3Cissues.hive.apache.org%3E",
+        "name" : "[hive-issues] 20210301 [jira] [Updated] (HIVE-24837) Upgrade httpclient to 4.5.13+ due to CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/re504acd4d63b8df2a7353658f45c9a3137e5f80e41cf7de50058b2c1@%3Cissues.solr.apache.org%3E",
+        "name" : "[solr-issues] 20210316 [jira] [Resolved] (SOLR-15270) upgrade httpclient to address CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r5fec9c1d67f928179adf484b01e7becd7c0a6fdfe3a08f92ea743b90@%3Cissues.hive.apache.org%3E",
+        "name" : "[hive-issues] 20210301 [jira] [Assigned] (HIVE-24837) Upgrade httpclient to 4.5.13+ due to CVE-2020-13956"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-13956",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfb35f6db9ba1f1e061b63769a4eff5abadcc254ebfefc280e5a0dcf1@%3Ccommits.creadur.apache.org%3E",
+        "name" : "[creadur-commits] 20210608 [jira] [Resolved] (TENTACLES-13) Upgrade httpclient to circumvent CVE-2020-13956"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20220210-0002/",
+        "name" : "https://security.netapp.com/advisory/ntap-20220210-0002/"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r549ac8c159bf0c568c19670bedeb8d7c0074beded951d34b1c1d0d05@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210604 [jira] [Resolved] (DRILL-7946) Bump HttpClient from 4.5.12 to 4.5.13 for CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rc505fee574fe8d18f9b0c655a4d120b0ae21bb6a73b96003e1d9be35@%3Cissues.solr.apache.org%3E",
+        "name" : "[solr-issues] 20210623 [jira] [Updated] (SOLR-15269) upgrade httpclient to address CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r6d672b46622842e565e00f6ef6bef83eb55d8792aac2bee75bff9a2a@%3Cissues.lucene.apache.org%3E",
+        "name" : "[lucene-issues] 20211007 [GitHub] [lucene-solr] madrob commented on pull request #2579: SOLR-15269: Upgrade Apache HttpComponents Client to 4.5.13 to fix CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf43d17ed0d1fb4fb79036b582810ef60b18b1ef3add0d5dea825af1e@%3Cissues.lucene.apache.org%3E",
+        "name" : "[lucene-issues] 20210921 [GitHub] [lucene-solr] madrob commented on pull request #2579: SOLR-15269: Upgrade Apache HttpComponents Client to 4.5.13 to fix CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ra8bc6b61c5df301a6fe5a716315528ecd17ccb8a7f907e24a47a1a5e@%3Cissues.lucene.apache.org%3E",
+        "name" : "[lucene-issues] 20211011 [GitHub] [lucene-solr] madrob merged pull request #2579: SOLR-15269: Upgrade Apache HttpComponents Client to 4.5.13 to fix CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r2a03dc210231d7e852ef73015f71792ac0fcaca6cccc024c522ef17d@%3Ccommits.creadur.apache.org%3E",
+        "name" : "[creadur-commits] 20210608 [jira] [Commented] (TENTACLES-13) Upgrade httpclient to circumvent CVE-2020-13956"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuApr2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuApr2021.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r2835543ef0f91adcc47da72389b816e36936f584c7be584d2314fac3@%3Cissues.lucene.apache.org%3E",
+        "name" : "[lucene-issues] 20210921 [GitHub] [lucene-solr] ventry1990 opened a new pull request #2579: SOLR-15269: Upgrade Apache HttpComponents Client to 4.5.13 to fix CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf7ca60f78f05b772cc07d27e31bcd112f9910a05caf9095e38ee150f@%3Cdev.ranger.apache.org%3E",
+        "name" : "[ranger-dev] 20201204 [jira] [Assigned] (RANGER-3100) Upgrade httpclient version from 4.5.6 to 4.5.13+ due to CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ree942561f4620313c75982a4e5f3b74fe6f7062b073210779648eec2@%3Cissues.lucene.apache.org%3E",
+        "name" : "[lucene-issues] 20211009 [GitHub] [lucene-solr] ventry1990 commented on pull request #2579: SOLR-15269: Upgrade Apache HttpComponents Client to 4.5.13 to fix CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb725052404fabffbe093c83b2c46f3f87e12c3193a82379afbc529f8@%3Csolr-user.lucene.apache.org%3E",
+        "name" : "[lucene-solr-user] 20201229 Upgrade httpclient version due to CVE-2020-13956?"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rcced7ed3237c29cd19c1e9bf465d0038b8b2e967b99fc283db7ca553@%3Cdev.ranger.apache.org%3E",
+        "name" : "[ranger-dev] 20201204 [jira] [Updated] (RANGER-3100) Upgrade httpclient version from 4.5.6 to 4.5.13+ due to CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb4ba262d6f08ab9cf8b1ebbcd9b00b0368ffe90dad7ad7918b4b56fc@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210604 [GitHub] [drill] luocooong opened a new pull request #2250: DRILL-7946: Bump HttpClient from 4.5.12 to 4.5.13 for CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r6a3cda38d050ebe13c1bc9a28d0a8ec38945095d07eca49046bcb89f@%3Cissues.solr.apache.org%3E",
+        "name" : "[solr-issues] 20210623 [jira] [Updated] (SOLR-15270) upgrade httpclient to address CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9e52a6c72c8365000ecd035e48cc9fee5a677a150350d4420c46443d@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210604 [GitHub] [drill] laurentgo merged pull request #2250: DRILL-7946: Bump HttpClient from 4.5.12 to 4.5.13 for CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd5ab56beb2ac6879f6ab427bc4e5f7691aed8362d17b713f61779858@%3Cissues.hive.apache.org%3E",
+        "name" : "[hive-issues] 20210301 [jira] [Work logged] (HIVE-24837) Upgrade httpclient to 4.5.13+ due to CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r132e4c6a560cfc519caa1aaee63bdd4036327610eadbd89f76dd5457@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20210621 [jira] [Updated] (RAT-275) Update httpclient to fix CVE-2020-13956 once a new doxia-core release is available"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r12cb62751b35bdcda0ae2a08b67877d665a1f4d41eee0fa7367169e0@%3Cdev.ranger.apache.org%3E",
+        "name" : "[ranger-dev] 20201215 [jira] [Commented] (RANGER-3100) Upgrade httpclient version from 4.5.6 to 4.5.13+ due to CVE-2020-13956"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1886587",
+        "name" : "https://bugzilla.redhat.com/show_bug.cgi?id=1886587"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r70c429923100c5a4fae8e5bc71c8a2d39af3de4888f50a0ac3755e6f@%3Ccommits.creadur.apache.org%3E",
+        "name" : "[creadur-commits] 20210608 [jira] [Assigned] (TENTACLES-13) Upgrade httpclient to circumvent CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ra539f20ef0fb0c27ee39945b5f56bf162e5c13d1c60f7344dab8de3b@%3Cissues.maven.apache.org%3E",
+        "name" : "[maven-issues] 20210530 [jira] [Resolved] (DOXIA-615) Can you provide an updated version in order to fix CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r043a75acdeb52b15dd5e9524cdadef4202e6a5228644206acf9363f9@%3Cdev.hive.apache.org%3E",
+        "name" : "[hive-dev] 20210301 [jira] [Created] (HIVE-24837) Upgrade httpclient to 4.5.13+ due to CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r8aa1e5c343b89aec5b69961471950e862f15246cb6392910161c389b@%3Cissues.maven.apache.org%3E",
+        "name" : "[maven-issues] 20210530 [jira] [Closed] (DOXIA-615) Can you provide an updated version in order to fix CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r4850b3fbaea02fde2886e461005e4af8d37c80a48b3ce2a6edca0e30@%3Cissues.solr.apache.org%3E",
+        "name" : "[solr-issues] 20211011 [jira] [Resolved] (SOLR-15269) upgrade httpclient to address CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rc5c6ccb86d2afe46bbd4b71573f0448dc1f87bbcd5a0d8c7f8f904b2@%3Cissues.lucene.apache.org%3E",
+        "name" : "[lucene-issues] 20210921 [GitHub] [lucene-solr] ventry1990 commented on pull request #2579: SOLR-15269: Upgrade Apache HttpComponents Client to 4.5.13 to fix CVE-2020-13956"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com//security-alerts/cpujul2021.html",
+        "name" : "N/A"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rc0863892ccfd9fd0d0ae10091f24ee769fb39b8957fe4ebabfc11f17@%3Cdev.jackrabbit.apache.org%3E",
+        "name" : "[jackrabbit-dev] 20210706 [GitHub] [jackrabbit-oak] reschke removed a comment on pull request #310: OAK-9482: upgrade httpclient to 4.5.13"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r6eb2dae157dbc9af1f30d1f64e9c60d4ebef618f3dce4a0e32d6ea4d@%3Ccommits.drill.apache.org%3E",
+        "name" : "[drill-commits] 20210604 [drill] branch master updated: DRILL-7946: Bump HttpClient from 4.5.12 to 4.5.13 for CVE-2020-13956 (#2250)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf4db88c22e1be9eb60c7dc623d0528642c045fb196a24774ac2fa3a3@%3Cissues.lucene.apache.org%3E",
+        "name" : "[lucene-issues] 20211009 [GitHub] [lucene-solr] ventry1990 closed pull request #2579: SOLR-15269: Upgrade Apache HttpComponents Client to 4.5.13 to fix CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r0bebe6f9808ac7bdf572873b4fa96a29c6398c90dab29f131f3ebffe@%3Cissues.solr.apache.org%3E",
+        "name" : "[solr-issues] 20211011 [jira] [Commented] (SOLR-15269) upgrade httpclient to address CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb33212dab7beccaf1ffef9b88610047c644f644c7a0ebdc44d77e381@%3Ccommits.turbine.apache.org%3E",
+        "name" : "[turbine-commits] 20210203 svn commit: r1886168 - in /turbine/core/trunk: ./ conf/ conf/test/ src/java/org/apache/turbine/services/urlmapper/ src/test/org/apache/turbine/services/urlmapper/ src/test/org/apache/turbine/services/urlmapper/model/ xdocs/howto/"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rae14ae25ff4a60251e3ba2629c082c5ba3851dfd4d21218b99b56652@%3Cissues.solr.apache.org%3E",
+        "name" : "[solr-issues] 20210316 [jira] [Created] (SOLR-15270) upgrade httpclient to address CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r5b55f65c123a7481104d663a915ec45a0d103e6aaa03f42ed1c07a89@%3Cdev.jackrabbit.apache.org%3E",
+        "name" : "[jackrabbit-dev] 20210706 [GitHub] [jackrabbit-oak] reschke commented on pull request #310: OAK-9482: upgrade httpclient to 4.5.13"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf03228972e56cb4a03e6d9558188c2938078cf3ceb23a3fead87c9ca@%3Cissues.bookkeeper.apache.org%3E",
+        "name" : "[bookkeeper-issues] 20210917 [GitHub] [bookkeeper] nicoloboschi commented on pull request #2793: Upgrade httpclient from 4.5.5 to 4.5.13 to address CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rc3739e0ad4bcf1888c6925233bfc37dd71156bbc8416604833095c42@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210604 [GitHub] [drill] cgivre commented on pull request #2250: DRILL-7946: Bump HttpClient from 4.5.12 to 4.5.13 for CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfbedcb586a1e7dfce87ee03c720e583fc2ceeafa05f35c542cecc624@%3Cissues.solr.apache.org%3E",
+        "name" : "[solr-issues] 20210912 [jira] [Updated] (SOLR-15269) upgrade httpclient to address CVE-2020-13956"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://www.openwall.com/lists/oss-security/2020/10/08/4",
+        "name" : "https://www.openwall.com/lists/oss-security/2020/10/08/4"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rad6222134183046f3928f733bf680919e0c390739bfbfe6c90049673@%3Cissues.drill.apache.org%3E",
+        "name" : "[drill-issues] 20210604 [jira] [Resolved] (DRILL-7946) Bump HttpClient from 4.5.12 to 4.5.13 for CVE-2020-13956"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/r6dab7da30f8bf075f79ee189e33b45a197502e2676481bb8787fc0d7%40%3Cdev.hc.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/r6dab7da30f8bf075f79ee189e33b45a197502e2676481bb8787fc0d7%40%3Cdev.hc.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r0a75b8f0f72f3e18442dc56d33f3827b905f2fe5b7ba48997436f5d1@%3Cissues.solr.apache.org%3E",
+        "name" : "[solr-issues] 20211019 [jira] [Closed] (SOLR-15269) upgrade httpclient to address CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r55b2a1d1e9b1ec9db792b93da8f0f99a4fd5a5310b02673359d9b4d1@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210604 [jira] [Created] (DRILL-7946) Bump HttpClient from 4.5.12 to 4.5.13 for CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rc990e2462ec32b09523deafb2c73606208599e196fa2d7f50bdbc587@%3Cissues.maven.apache.org%3E",
+        "name" : "[maven-issues] 20210621 [jira] [Assigned] (DOXIA-615) Can you provide an updated version in order to fix CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/reef569c2419705754a3acf42b5f19b2a158153cef0e448158bc54917@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210604 [GitHub] [drill] luocooong commented on pull request #2250: DRILL-7946: Bump HttpClient from 4.5.12 to 4.5.13 for CVE-2020-13956"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r69a94e2f302d1b778bdfefe90fcb4b8c50b226438c3c8c1d0de85a19@%3Cdev.ranger.apache.org%3E",
+        "name" : "[ranger-dev] 20211028 [jira] [Commented] (RANGER-3100) Upgrade httpclient version from 4.5.6 to 4.5.13+ due to CVE-2020-13956"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:httpclient:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "4.5.13"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:httpclient:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "5.0.0",
+          "versionEndExcluding" : "5.0.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:snapcenter:-:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_service_communication_proxy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:data_integrator:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:data_integrator:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:jd_edwards_enterpriseone_orchestrator:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "9.2.6.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:jd_edwards_enterpriseone_tools:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "9.2.6.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:nosql_database:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "20.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_pt_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_pt_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_pt_peopletools:8.59:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:16.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:16.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_customer_management_and_segmentation_foundation:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "16.0",
+          "versionEndIncluding" : "19.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:spatial_studio:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "20.1.1"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:sql_developer:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "20.4.1.407.0006"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:sql_developer:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "21.99"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:14.1.1.0.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:quarkus:quarkus:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "1.7.6"
+        }
+      } ]
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "com.liferay.portal.tools.bundle.support-3.2.7.jar (shaded: org.apache.httpcomponents:httpcore:4.4.4)",
+    "filePath" : "/home/wtwhite/.m2/repository/com/liferay/com.liferay.portal.tools.bundle.support/3.2.7/com.liferay.portal.tools.bundle.support-3.2.7.jar/META-INF/maven/org.apache.httpcomponents/httpcore/pom.xml",
+    "md5" : "1156470635cfbe8d66112ceb0dfc1842",
+    "sha1" : "2feaed055f70af1aafd223137e4bd456decc5995",
+    "sha256" : "3ef432497e39958060d418111630f9a553599d82c3143eb18fae564a4cb28a2b",
+    "description" : "\n   Apache HttpComponents Core (blocking I/O)\n  ",
+    "projectReferences" : [ "CVE-2018-1324:compile" ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "httpcore"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.httpcomponents"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache HttpCore"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "httpcomponents-core"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://hc.apache.org/httpcomponents-core-ga"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "httpcore"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.apache.httpcomponents"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache HttpCore"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "httpcomponents-core"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://hc.apache.org/httpcomponents-core-ga"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "4.4.4"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.apache.httpcomponents/httpcore@4.4.4",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.apache.httpcomponents/httpcore@4.4.4?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "com.liferay.portal.tools.bundle.support-3.2.7.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/com/liferay/com.liferay.portal.tools.bundle.support/3.2.7/com.liferay.portal.tools.bundle.support-3.2.7.jar",
+    "md5" : "4dc4d11b402df552adf59ed5f007e47b",
+    "sha1" : "c266a91e83ea1dbc23db795275d15e0f8d1da399",
+    "sha256" : "404cd4361d246266ed33be2bc68eaf75ed100cb4bf61fe98764b082fb09e5b45",
+    "description" : "Liferay Portal Tools Bundle Support",
+    "license" : "LGPL 2.1: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt",
+    "projectReferences" : [ "CVE-2018-1324:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "com.liferay.portal.tools.bundle.support"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "bundle"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "liferay"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "portal"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "tools"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "com.liferay.portal.tools.bundle.support"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "git-descriptor",
+        "value" : "517d8fc"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "git-sha",
+        "value" : "517d8fc3419ff0ae5ab874ea7f7794fcad0bf2a4"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "javac-debug",
+        "value" : "on"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "javac-deprecation",
+        "value" : "off"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "javac-encoding",
+        "value" : "UTF-8"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "jpm-command",
+        "value" : "liferay-bundle-support"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "com.liferay.portal.tools.bundle.support"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "liferay.portal.tools.bundle.support"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Brian Wing Shun Chan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Liferay, Inc."
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org URL",
+        "value" : "http://www.liferay.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.liferay"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "com.liferay.portal.tools.bundle.support"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "bundle"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "liferay"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "portal"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "tools"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "Liferay Portal Tools Bundle Support"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "com.liferay.portal.tools.bundle.support"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "git-descriptor",
+        "value" : "517d8fc"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "git-sha",
+        "value" : "517d8fc3419ff0ae5ab874ea7f7794fcad0bf2a4"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "javac-debug",
+        "value" : "on"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "javac-deprecation",
+        "value" : "off"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "javac-encoding",
+        "value" : "UTF-8"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "jpm-command",
+        "value" : "liferay-bundle-support"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "com.liferay.portal.tools.bundle.support"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "liferay.portal.tools.bundle.support"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Brian Wing Shun Chan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Liferay, Inc."
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org URL",
+        "value" : "http://www.liferay.com"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.liferay"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "3.2.7"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Bundle-Version",
+        "value" : "3.2.7"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "3.2.7"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.liferay/com.liferay.portal.tools.bundle.support@3.2.7",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.liferay/com.liferay.portal.tools.bundle.support@3.2.7?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:liferay:liferay:3.2.7:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aliferay&cpe_product=cpe%3A%2F%3Aliferay%3Aliferay&cpe_version=cpe%3A%2F%3Aliferay%3Aliferay%3A3.2.7"
+    }, {
+      "id" : "cpe:2.3:a:liferay:liferay_portal:3.2.7:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aliferay&cpe_product=cpe%3A%2F%3Aliferay%3Aliferay_portal&cpe_version=cpe%3A%2F%3Aliferay%3Aliferay_portal%3A3.2.7"
+    }, {
+      "id" : "cpe:2.3:a:liferay:portal:3.2.7:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aliferay&cpe_product=cpe%3A%2F%3Aliferay%3Aportal&cpe_version=cpe%3A%2F%3Aliferay%3Aportal%3A3.2.7"
+    } ],
+    "vulnerabilities" : [ {
+      "source" : "NVD",
+      "name" : "CVE-2019-16891",
+      "severity" : "CRITICAL",
+      "cvssv2" : {
+        "score" : 7.5,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "PARTIAL",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "HIGH",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "6.4"
+      },
+      "cvssv3" : {
+        "baseScore" : 9.8,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "HIGH",
+        "integrityImpact" : "HIGH",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "CRITICAL",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "5.9",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-502" ],
+      "description" : "Liferay Portal CE 6.2.5 allows remote command execution because of deserialization of a JSON payload.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://dappsec.substack.com/p/an-advisory-for-cve-2019-16891-from",
+        "name" : "https://dappsec.substack.com/p/an-advisory-for-cve-2019-16891-from"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.liferay.com/downloads-community",
+        "name" : "https://www.liferay.com/downloads-community"
+      }, {
+        "source" : "MISC",
+        "url" : "https://sec.vnpt.vn/2019/09/liferay-deserialization-json-deserialization-part-4/",
+        "name" : "https://sec.vnpt.vn/2019/09/liferay-deserialization-json-deserialization-part-4/"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.youtube.com/watch?v=DjMEfQW3bf0",
+        "name" : "https://www.youtube.com/watch?v=DjMEfQW3bf0"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:community:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "6.0.6"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.0:b1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.0:b2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.0:b3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.0:b4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.0:ga1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.0:rc1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.1:ga2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.2:ga3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:b1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:b2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:ga1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:m1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:m2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:m3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:m4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:m5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:m6:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:rc1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:rc2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:rc3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:rc4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:rc5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:rc6:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.1:ga2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.2:ga3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.3:ga4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.4:ga5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.5:ga6:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:a1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:a2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:a3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:a4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:a5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b6:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b7:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:ga1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m6:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m7:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.1:ga2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.2:ga3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.3:ga4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.4:ga5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.5:ga6:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.6:ga7:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:a1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:a2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:b1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:b2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:b3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:ga1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:m1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:m2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:rc1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.1:ga2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.2:ga3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.3:ga4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:alpha1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:beta1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:beta2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:beta3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:m2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:rc1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:rc2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:rc3:*:*:community:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2020-7961",
+      "knownExploitedVulnerability" : {
+        "VendorProject" : "Liferay",
+        "Product" : "Liferay Portal",
+        "Name" : "Liferay Portal Deserialization of Untrusted Data Vulnerability",
+        "DateAdded" : "2021-11-03",
+        "Description" : "Liferay Portal contains a deserialization of untrusted data vulnerability that allows remote attackers to execute code via JSON web services.",
+        "RequiredAction" : "Apply updates per vendor instructions.",
+        "DueDate" : "2022-05-03",
+        "Notes" : ""
+      },
+      "severity" : "CRITICAL",
+      "cvssv2" : {
+        "score" : 7.5,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "PARTIAL",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "HIGH",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "6.4"
+      },
+      "cvssv3" : {
+        "baseScore" : 9.8,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "HIGH",
+        "integrityImpact" : "HIGH",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "CRITICAL",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "5.9",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-502" ],
+      "description" : "Deserialization of Untrusted Data in Liferay Portal prior to 7.2.1 CE GA2 allows remote attackers to execute arbitrary code via JSON web services (JSONWS).",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://research.checkpoint.com/2021/freakout-leveraging-newest-vulnerabilities-for-creating-a-botnet/",
+        "name" : "https://research.checkpoint.com/2021/freakout-leveraging-newest-vulnerabilities-for-creating-a-botnet/"
+      }, {
+        "source" : "MISC",
+        "url" : "http://packetstormsecurity.com/files/158392/Liferay-Portal-Remote-Code-Execution.html",
+        "name" : "http://packetstormsecurity.com/files/158392/Liferay-Portal-Remote-Code-Execution.html"
+      }, {
+        "source" : "MISC",
+        "url" : "http://packetstormsecurity.com/files/157254/Liferay-Portal-Java-Unmarshalling-Remote-Code-Execution.html",
+        "name" : "http://packetstormsecurity.com/files/157254/Liferay-Portal-Java-Unmarshalling-Remote-Code-Execution.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/117954271",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/117954271"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:community:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "7.2.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2010-5327",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 6.5,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "SINGLE",
+        "confidentialImpact" : "PARTIAL",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.0",
+        "impactScore" : "6.4"
+      },
+      "cvssv3" : {
+        "baseScore" : 8.8,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "LOW",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "HIGH",
+        "integrityImpact" : "HIGH",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "5.9",
+        "version" : "3.0"
+      },
+      "cwes" : [ "CWE-264" ],
+      "description" : "Liferay Portal through 6.2.10 allows remote authenticated users to execute arbitrary shell commands via a crafted Velocity template.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://issues.liferay.com/browse/LPS-64547",
+        "name" : "https://issues.liferay.com/browse/LPS-64547"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://github.com/liferay/liferay-portal/commit/90c4e85a8f8135f069f3f05e4d54a77704769f91",
+        "name" : "https://github.com/liferay/liferay-portal/commit/90c4e85a8f8135f069f3f05e4d54a77704769f91"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://issues.liferay.com/browse/LPS-7087",
+        "name" : "https://issues.liferay.com/browse/LPS-7087"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities",
+        "name" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/-/asset_publisher/4AHAYapUm8Xc/content/lps-64547-remote-code-execution-and-privilege-escalation-in-templates",
+        "name" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/-/asset_publisher/4AHAYapUm8Xc/content/lps-64547-remote-code-execution-and-privilege-escalation-in-templates"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://issues.liferay.com/browse/LPE-14964",
+        "name" : "https://issues.liferay.com/browse/LPE-14964"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "6.2.10"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2018-10795",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 6.5,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "SINGLE",
+        "confidentialImpact" : "PARTIAL",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.0",
+        "impactScore" : "6.4"
+      },
+      "cvssv3" : {
+        "baseScore" : 8.8,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "LOW",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "HIGH",
+        "integrityImpact" : "HIGH",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "5.9",
+        "version" : "3.0"
+      },
+      "cwes" : [ "CWE-434" ],
+      "description" : "** DISPUTED ** Liferay 6.2.x and before has an FCKeditor configuration that allows an attacker to upload or transfer files of dangerous types that can be automatically processed within the product's environment via a browser/liferay/browser.html?Type= or html/js/editor/fckeditor/editor/filemanager/browser/liferay/browser.html URI. NOTE: the vendor disputes this issue because file upload is an expected feature, subject to Role Based Access Control checks where only authenticated users with proper permissions can upload files.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://cxsecurity.com/issue/WLB-2018050029",
+        "name" : "https://cxsecurity.com/issue/WLB-2018050029"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "6.2.5"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2020-15841",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "PARTIAL",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 8.8,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "HIGH",
+        "integrityImpact" : "HIGH",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "5.9",
+        "version" : "3.1"
+      },
+      "cwes" : [ "NVD-CWE-noinfo" ],
+      "description" : "Liferay Portal before 7.3.0, and Liferay DXP 7.0 before fix pack 89, 7.1 before fix pack 17, and 7.2 before fix pack 4, does not safely test a connection to a LDAP server, which allows remote attackers to obtain the LDAP server's password via the Test LDAP Connection feature.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/119317439",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/119317439"
+      }, {
+        "source" : "MISC",
+        "url" : "https://issues.liferay.com/browse/LPE-16928",
+        "name" : "https://issues.liferay.com/browse/LPE-16928"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_24:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_25:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_26:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_27:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_28:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_3\\+:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_30:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_33:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_35:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_36:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_39:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_40:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_41:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_42:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_43:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_44:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_45:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_46:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_47:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_48:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_49:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_50:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_51:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_52:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_53:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_54:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_56:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_57:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_58:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_59:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_60:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_61:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_64:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_65:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_66:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_67:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_68:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_69:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_70:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_71:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_72:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_73:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_75:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_76:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_78:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_79:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_80:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_81:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_10:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_11:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_12:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_15:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_16:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "7.3.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2020-15842",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 6.8,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "PARTIAL",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "6.4"
+      },
+      "cvssv3" : {
+        "baseScore" : 8.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "HIGH",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "HIGH",
+        "integrityImpact" : "HIGH",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "2.2",
+        "impactScore" : "5.9",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-502" ],
+      "description" : "Liferay Portal before 7.3.0, and Liferay DXP 7.0 before fix pack 90, 7.1 before fix pack 17, and 7.2 before fix pack 5, allows man-in-the-middle attackers to execute arbitrary code via crafted serialized payloads, because of insecure deserialization.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/119317427",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/119317427"
+      }, {
+        "source" : "MISC",
+        "url" : "https://issues.liferay.com/browse/LPE-16963",
+        "name" : "https://issues.liferay.com/browse/LPE-16963"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_24:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_25:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_26:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_27:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_28:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_3\\+:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_30:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_33:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_35:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_36:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_39:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_40:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_41:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_42:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_43:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_44:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_45:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_46:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_47:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_48:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_49:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_50:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_51:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_52:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_53:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_54:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_56:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_57:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_58:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_59:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_60:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_61:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_64:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_65:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_66:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_67:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_68:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_69:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_70:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_71:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_72:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_73:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_75:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_76:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_78:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_79:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_80:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_81:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_10:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_11:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_12:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_15:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_16:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "7.3.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2020-24554",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-601" ],
+      "description" : "The redirect module in Liferay Portal before 7.3.3 does not limit the number of URLs resulting in a 404 error that is recorded, which allows remote attackers to perform a denial of service attack by making repeated requests for pages that do not exist.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/119784956",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/119784956"
+      }, {
+        "source" : "MISC",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "7.3.3"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-33322",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "HIGH",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-613" ],
+      "description" : "In Liferay Portal 7.3.0 and earlier, and Liferay DXP 7.0 before fix pack 96, 7.1 before fix pack 18, and 7.2 before fix pack 5, password reset tokens are not invalidated after a user changes their password, which allows remote attackers to change the user’s password via the old password reset token.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://issues.liferay.com/browse/LPE-16981",
+        "name" : "https://issues.liferay.com/browse/LPE-16981"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/120748020",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/120748020"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_24:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_25:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_26:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_27:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_28:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_3\\+:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_30:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_33:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_35:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_36:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_39:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_40:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_41:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_42:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_43:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_44:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_45:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_46:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_47:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_48:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_49:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_50:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_51:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_52:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_53:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_54:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_56:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_57:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_58:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_59:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_60:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_61:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_64:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_65:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_66:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_67:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_68:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_69:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_70:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_71:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_72:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_73:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_75:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_76:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_78:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_79:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_80:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_81:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_82:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_83:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_84:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_85:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_86:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_87:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_88:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_89:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_90:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_91:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_92:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_93:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_94:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_95:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_10:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_11:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_12:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_15:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_16:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_17:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_18:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "7.3.1"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-38266",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "NVD-CWE-noinfo" ],
+      "description" : "The Portal Security module in Liferay Portal 7.2.1 and earlier, and Liferay DXP 7.0 before fix pack 90, 7.1 before fix pack 17 and 7.2 before fix pack 5 does not correctly import users from LDAP, which allows remote attackers to prevent a legitimate user from authenticating by attempting to sign in as a user that exist in LDAP.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/cve-2021-38266",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/cve-2021-38266"
+      }, {
+        "source" : "MISC",
+        "url" : "https://issues.liferay.com/browse/LPE-17191",
+        "name" : "https://issues.liferay.com/browse/LPE-17191"
+      }, {
+        "source" : "MISC",
+        "url" : "http://liferay.com",
+        "name" : "http://liferay.com"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_10:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_11:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_12:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_15:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_16:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_17:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_18:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_19:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_20:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_21:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_22:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_23:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_24:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_25:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_26:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_27:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_28:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_29:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_30:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_31:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_32:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_33:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_34:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_35:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_36:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_37:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_38:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_39:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_40:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_41:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_42:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_43:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_44:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_45:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_46:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_47:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_48:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_49:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_50:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_51:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_52:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_53:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_54:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_55:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_56:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_57:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_58:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_59:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_60:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_61:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_62:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_63:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_64:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_65:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_66:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_67:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_68:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_69:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_70:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_71:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_72:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_73:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_74:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_75:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_76:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_77:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_78:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_79:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_80:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_81:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_82:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_83:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_84:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_85:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_86:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_87:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_88:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_89:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_10:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_11:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_12:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_15:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_16:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:community:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "7.2.1"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2020-15839",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "SINGLE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "LOW",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-434" ],
+      "description" : "Liferay Portal before 7.3.3, and Liferay DXP 7.1 before fix pack 18 and 7.2 before fix pack 6, does not restrict the size of a multipart/form-data POST action, which allows remote authenticated users to conduct denial-of-service attacks by uploading large files.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://issues.liferay.com/browse/LPE-17029",
+        "name" : "https://issues.liferay.com/browse/LPE-17029"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/119784928",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/119784928"
+      }, {
+        "source" : "MISC",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities"
+      }, {
+        "source" : "MISC",
+        "url" : "https://issues.liferay.com/browse/LPE-17055",
+        "name" : "https://issues.liferay.com/browse/LPE-17055"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_10:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_11:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_12:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_15:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_16:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_17:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:sp1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "7.3.3"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-33333",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 6.5,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "SINGLE",
+        "confidentialImpact" : "PARTIAL",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.0",
+        "impactScore" : "6.4"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.3,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "LOW",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "LOW",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "3.4",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-276" ],
+      "description" : "The Portal Workflow module in Liferay Portal 7.3.2 and earlier, and Liferay DXP 7.0 before fix pack 93, 7.1 before fix pack 19 and 7.2 before fix pack 6, does not properly check user permission, which allows remote authenticated users to view and delete workflow submissions via crafted URLs.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://issues.liferay.com/browse/LPE-17032",
+        "name" : "https://issues.liferay.com/browse/LPE-17032"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/120747742",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/120747742"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_24:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_25:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_26:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_27:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_28:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_3\\+:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_30:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_33:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_35:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_36:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_39:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_40:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_41:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_42:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_43:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_44:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_45:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_46:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_47:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_48:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_49:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_50:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_51:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_52:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_53:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_54:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_56:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_57:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_58:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_59:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_60:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_61:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_64:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_65:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_66:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_67:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_68:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_69:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_70:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_71:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_72:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_73:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_75:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_76:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_78:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_79:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_80:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_81:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_82:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_83:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_84:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_85:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_86:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_87:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_88:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_89:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_90:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_91:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_92:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_10:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_11:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_12:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_15:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_16:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_17:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_18:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "7.3.3"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2016-10404",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.0"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "XSS exists in Liferay Portal before 7.0 CE GA4 via a crafted redirect field to modules/apps/foundation/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/init.jsp.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-70/-/asset_publisher/cjE0ourZXJZE/content/cst-7017-multiple-xss-vulnerabilities",
+        "name" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-70/-/asset_publisher/cjE0ourZXJZE/content/cst-7017-multiple-xss-vulnerabilities"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://github.com/liferay/liferay-portal/commit/333f65bae9106182d12e02d249d4f95e16e93fa2",
+        "name" : "https://github.com/liferay/liferay-portal/commit/333f65bae9106182d12e02d249d4f95e16e93fa2"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:ga3:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "7.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2016-3670",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.0"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "Cross-site scripting (XSS) vulnerability in users.jsp in the Profile Search functionality in Liferay before 7.0.0 CE RC1 allows remote attackers to inject arbitrary web script or HTML via the FirstName field.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://issues.liferay.com/browse/LPS-62387",
+        "name" : "https://issues.liferay.com/browse/LPS-62387"
+      }, {
+        "source" : "EXPLOIT-DB",
+        "url" : "https://www.exploit-db.com/exploits/39880/",
+        "name" : "39880"
+      }, {
+        "source" : "MISC",
+        "url" : "http://packetstormsecurity.com/files/137279/Liferay-CE-Stored-Cross-Site-Scripting.html",
+        "name" : "http://packetstormsecurity.com/files/137279/Liferay-CE-Stored-Cross-Site-Scripting.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://labs.integrity.pt/advisories/cve-2016-3670/",
+        "name" : "https://labs.integrity.pt/advisories/cve-2016-3670/"
+      }, {
+        "source" : "FULLDISC",
+        "url" : "http://seclists.org/fulldisclosure/2016/Jun/5",
+        "name" : "20160601 CVE-2016-3670 Stored Cross Site Scripting in Liferay CE"
+      }, {
+        "source" : "SECTRACK",
+        "url" : "http://www.securitytracker.com/id/1036083",
+        "name" : "1036083"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:ga6:*:*:community_edition:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "6.2"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2017-1000425",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.0"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "Cross-site scripting (XSS) vulnerability in the /html/portal/flash.jsp page in Liferay Portal CE 7.0 GA4 and older allows remote attackers to inject arbitrary web script or HTML via a javascript: URI in the \"movie\" parameter.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://github.com/liferay/liferay-portal/commit/9435af4ef8a90b5333da925a5ec860a43d18c031",
+        "name" : "https://github.com/liferay/liferay-portal/commit/9435af4ef8a90b5333da925a5ec860a43d18c031"
+      }, {
+        "source" : "MISC",
+        "url" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/-/asset_publisher/4AHAYapUm8Xc/content/cst-7030-multiple-xss-vulnerabilities-in-7-0-ce-ga4",
+        "name" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/-/asset_publisher/4AHAYapUm8Xc/content/cst-7030-multiple-xss-vulnerabilities-in-7-0-ce-ga4"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:community:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "7.0.3_ga4"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2017-12645",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.0"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "XSS exists in Liferay Portal before 7.0 CE GA4 via an invalid portletId.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-70/-/asset_publisher/cjE0ourZXJZE/content/cst-7017-multiple-xss-vulnerabilities",
+        "name" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-70/-/asset_publisher/cjE0ourZXJZE/content/cst-7017-multiple-xss-vulnerabilities"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://issues.liferay.com/browse/LPS-72307",
+        "name" : "https://issues.liferay.com/browse/LPS-72307"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:ga3:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "7.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2017-12646",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.0"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "XSS exists in Liferay Portal before 7.0 CE GA4 via a login name, password, or e-mail address.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-70/-/asset_publisher/cjE0ourZXJZE/content/cst-7017-multiple-xss-vulnerabilities",
+        "name" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-70/-/asset_publisher/cjE0ourZXJZE/content/cst-7017-multiple-xss-vulnerabilities"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://github.com/brianchandotcom/liferay-portal/pull/49833",
+        "name" : "https://github.com/brianchandotcom/liferay-portal/pull/49833"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:ga3:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "7.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2017-12647",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.0"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "XSS exists in Liferay Portal before 7.0 CE GA4 via a Knowledge Base article title.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-70/-/asset_publisher/cjE0ourZXJZE/content/cst-7017-multiple-xss-vulnerabilities",
+        "name" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-70/-/asset_publisher/cjE0ourZXJZE/content/cst-7017-multiple-xss-vulnerabilities"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://github.com/brianchandotcom/liferay-portal/pull/48901",
+        "name" : "https://github.com/brianchandotcom/liferay-portal/pull/48901"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:ga3:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "7.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2017-12648",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.0"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "XSS exists in Liferay Portal before 7.0 CE GA4 via a bookmark URL.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-70/-/asset_publisher/cjE0ourZXJZE/content/cst-7017-multiple-xss-vulnerabilities",
+        "name" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-70/-/asset_publisher/cjE0ourZXJZE/content/cst-7017-multiple-xss-vulnerabilities"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://github.com/brianchandotcom/liferay-portal/pull/47888",
+        "name" : "https://github.com/brianchandotcom/liferay-portal/pull/47888"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:ga3:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "7.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2017-12649",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.0"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "XSS exists in Liferay Portal before 7.0 CE GA4 via a crafted title or summary that is mishandled in the Web Content Display.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-70/-/asset_publisher/cjE0ourZXJZE/content/cst-7017-multiple-xss-vulnerabilities",
+        "name" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-70/-/asset_publisher/cjE0ourZXJZE/content/cst-7017-multiple-xss-vulnerabilities"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://github.com/brianchandotcom/liferay-portal/pull/47579",
+        "name" : "https://github.com/brianchandotcom/liferay-portal/pull/47579"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:ga3:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "7.0"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2019-16147",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "Liferay Portal through 7.2.0 GA1 allows XSS via a journal article title to journal_article/page.jsp in journal/journal-taglib.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://github.com/liferay/liferay-portal/commit/7e063aed70f947a92bb43a4471e0c4e650fe8f7f",
+        "name" : "https://github.com/liferay/liferay-portal/commit/7e063aed70f947a92bb43a4471e0c4e650fe8f7f"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "7.2.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:alpha1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:beta1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:beta2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:beta3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:ga1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:milestone2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:rc2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.2.0:rc3:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-33326",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "Cross-site scripting (XSS) vulnerability in the Frontend JS module in Liferay Portal 7.3.4 and earlier, and Liferay DXP 7.0 before fix pack 96, 7.1 before fix pack 20 and 7.2 before fix pack 9, allows remote attackers to inject arbitrary web script or HTML via the title of a modal window.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://issues.liferay.com/browse/LPE-17093",
+        "name" : "https://issues.liferay.com/browse/LPE-17093"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/120747869",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/120747869"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_24:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_25:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_26:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_27:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_28:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_3\\+:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_30:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_33:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_35:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_36:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_39:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_40:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_41:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_42:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_43:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_44:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_45:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_46:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_47:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_48:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_49:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_50:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_51:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_52:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_53:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_54:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_56:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_57:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_58:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_59:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_60:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_61:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_64:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_65:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_66:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_67:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_68:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_69:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_70:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_71:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_72:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_73:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_75:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_76:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_78:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_79:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_80:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_81:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_82:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_83:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_84:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_85:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_86:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_87:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_88:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_89:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_90:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_91:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_92:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_93:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_94:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_95:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_10:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_11:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_12:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_15:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_16:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_17:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_18:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_19:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "7.3.5"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-38263",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "Cross-site scripting (XSS) vulnerability in the Server module's script console in Liferay Portal 7.3.2 and earlier, and Liferay DXP 7.0 before fix pack 101, 7.1 before fix pack 20 and 7.2 before fix pack 10 allows remote attackers to inject arbitrary web script or HTML via the output of a script.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://issues.liferay.com/browse/LPE-17061",
+        "name" : "https://issues.liferay.com/browse/LPE-17061"
+      }, {
+        "source" : "MISC",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/cve-2021-38263-reflected-xss-with-script-page",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/cve-2021-38263-reflected-xss-with-script-page"
+      }, {
+        "source" : "MISC",
+        "url" : "http://liferay.com",
+        "name" : "http://liferay.com"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_10:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_100:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_11:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_12:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_15:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_16:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_17:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_18:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_19:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_20:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_21:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_22:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_23:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_24:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_25:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_26:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_27:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_28:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_29:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_30:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_31:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_32:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_33:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_34:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_35:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_36:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_37:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_38:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_39:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_40:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_41:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_42:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_43:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_44:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_45:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_46:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_47:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_48:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_49:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_50:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_51:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_52:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_53:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_54:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_55:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_56:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_57:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_58:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_59:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_60:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_61:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_62:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_63:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_64:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_65:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_66:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_67:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_68:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_69:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_70:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_71:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_72:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_73:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_74:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_75:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_76:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_77:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_78:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_79:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_80:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_81:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_82:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_83:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_84:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_85:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_86:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_87:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_88:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_89:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_90:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_91:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_92:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_93:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_94:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_95:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_96:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_97:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_98:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.0:fix_pack_99:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_10:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_11:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_12:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_15:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_16:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_17:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_18:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_19:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.1:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:digital_experience_platform:7.2:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "7.3.2"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2022-28980",
+      "severity" : "MEDIUM",
+      "cvssv3" : {
+        "baseScore" : 6.1,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "2.7",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "Multiple cross-site scripting (XSS) vulnerabilities in Liferay Portal v7.4.3.4 and Liferay DXP v7.4 GA allows attackers to execute arbitrary web scripts or HTML via parameters with the filter_ prefix.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "http://liferay.com",
+        "name" : "http://liferay.com"
+      }, {
+        "source" : "MISC",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/cve-2022-28980-reflected-xss-with-filter_*-parameters-in-applied-fragment-filters",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/cve-2022-28980-reflected-xss-with-filter_*-parameters-in-applied-fragment-filters"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.4:ga:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "7.4.3.5"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2020-15840",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "PARTIAL",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 5.3,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "1.4",
+        "version" : "3.1"
+      },
+      "cwes" : [ "NVD-CWE-noinfo" ],
+      "description" : "In Liferay Portal before 7.3.1, Liferay Portal 6.2 EE, and Liferay DXP 7.2, DXP 7.1 and DXP 7.0, the property 'portlet.resource.id.banned.paths.regexp' can be bypassed with doubled encoded URLs.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/119772204",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/119772204"
+      }, {
+        "source" : "MISC",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://issues.liferay.com/browse/LPE-17046",
+        "name" : "https://issues.liferay.com/browse/LPE-17046"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "7.3.1"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2:-:*:*:enterprise:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-29040",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "PARTIAL",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 5.3,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "1.4",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-209" ],
+      "description" : "The JSON web services in Liferay Portal 7.3.4 and earlier, and Liferay DXP 7.0 before fix pack 97, 7.1 before fix pack 20 and 7.2 before fix pack 10 may provide overly verbose error messages, which allows remote attackers to use the contents of error messages to help launch another, more focused attacks via crafted inputs.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/120743429",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/120743429"
+      }, {
+        "source" : "MISC",
+        "url" : "http://liferay.com",
+        "name" : "http://liferay.com"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "7.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_24:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_25:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_26:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_27:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_28:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_3\\+:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_30:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_33:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_35:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_36:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_39:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_40:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_41:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_42:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_43:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_44:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_45:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_46:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_47:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_48:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_49:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_50:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_51:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_52:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_53:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_54:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_56:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_57:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_58:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_59:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_60:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_61:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_64:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_65:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_66:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_67:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_68:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_69:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_70:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_71:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_72:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_73:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_75:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_76:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_78:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_79:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_80:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_81:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_82:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_83:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_84:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_85:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_86:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_87:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_88:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_89:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_90:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_91:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_92:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_93:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_94:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_95:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_96:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_10:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_11:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_12:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_15:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_16:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_17:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_18:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_19:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "7.3.4"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-33325",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "SINGLE",
+        "confidentialImpact" : "PARTIAL",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 4.9,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "HIGH",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "HIGH",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "1.2",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-312" ],
+      "description" : "The Portal Workflow module in Liferay Portal 7.3.2 and earlier, and Liferay DXP 7.0 before fix pack 93, 7.1 before fix pack 19, and 7.2 before fix pack 7, user's clear text passwords are stored in the database if workflow is enabled for user creation, which allows attackers with access to the database to obtain a user's password.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/120748389",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/120748389"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://issues.liferay.com/browse/LPE-17042",
+        "name" : "https://issues.liferay.com/browse/LPE-17042"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_24:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_25:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_26:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_27:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_28:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_3\\+:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_30:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_33:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_35:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_36:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_39:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_40:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_41:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_42:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_43:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_44:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_45:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_46:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_47:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_48:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_49:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_50:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_51:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_52:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_53:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_54:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_56:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_57:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_58:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_59:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_60:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_61:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_64:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_65:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_66:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_67:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_68:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_69:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_70:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_71:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_72:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_73:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_75:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_76:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_78:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_79:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_80:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_81:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_82:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_83:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_84:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_85:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_86:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_87:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_88:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_89:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_90:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_91:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_92:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_10:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_11:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_12:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_15:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_16:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_17:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_18:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "7.3.3"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2019-6588",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 2.6,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "HIGH",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "LOW",
+        "version" : "2.0",
+        "exploitabilityScore" : "4.9",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 4.7,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "HIGH",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "CHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "1.6",
+        "impactScore" : "2.7",
+        "version" : "3.0"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "In Liferay Portal before 7.1 CE GA4, an XSS vulnerability exists in the SimpleCaptcha API when custom code passes unsanitized input into the \"url\" parameter of the JSP taglib call <liferay-ui:captcha url=\"<%= url %>\" /> or <liferay-captcha:captcha url=\"<%= url %>\" />. Liferay Portal out-of-the-box behavior with no customizations is not vulnerable.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-71/-/asset_publisher/7v4O7y85hZMo/content/cst-7130-multiple-xss-vulnerabilities-in-7-1-ce-ga3",
+        "name" : "https://dev.liferay.com/web/community-security-team/known-vulnerabilities/liferay-portal-71/-/asset_publisher/7v4O7y85hZMo/content/cst-7130-multiple-xss-vulnerabilities-in-7-1-ce-ga3"
+      }, {
+        "source" : "MISC",
+        "url" : "http://packetstormsecurity.com/files/153252/Liferay-Portal-7.1-CE-GA4-Cross-Site-Scripting.html",
+        "name" : "http://packetstormsecurity.com/files/153252/Liferay-Portal-7.1-CE-GA4-Cross-Site-Scripting.html"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:community:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "6.0.6"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.0:b1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.0:b2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.0:b3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.0:b4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.0:ga1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.0:rc1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.1:ga2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.1.2:ga3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:b1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:b2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:ga1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:m1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:m2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:m3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:m4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:m5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:m6:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:rc1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:rc2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:rc3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:rc4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:rc5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.0:rc6:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.1:ga2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.2:ga3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.3:ga4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.4:ga5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:6.2.5:ga6:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:a1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:a2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:a3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:a4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:a5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b6:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:b7:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:ga1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m6:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.0:m7:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.1:ga2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.2:ga3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.3:ga4:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.4:ga5:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.5:ga6:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.0.6:ga7:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:a1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:a2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:b1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:b2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:b3:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:ga1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:m1:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:m2:*:*:community:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:7.1.0:rc1:*:*:community:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2009-3742",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "Cross-site scripting (XSS) vulnerability in Liferay Portal before 5.3.0 allows remote attackers to inject arbitrary web script or HTML via the p_p_id parameter.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "http://issues.liferay.com/browse/LPS-6034",
+        "name" : "http://issues.liferay.com/browse/LPS-6034"
+      }, {
+        "source" : "CERT-VN",
+        "url" : "http://www.kb.cert.org/vuls/id/750796",
+        "name" : "VU#750796"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "5.2.3"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-33320",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "SINGLE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 4.3,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "LOW",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "LOW",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.8",
+        "impactScore" : "1.4",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-770" ],
+      "description" : "The Flags module in Liferay Portal 7.3.1 and earlier, and Liferay DXP 7.0 before fix pack 96, 7.1 before fix pack 20, and 7.2 before fix pack 5, does not limit the rate at which content can be flagged as inappropriate, which allows remote authenticated users to spam the site administrator with emails",
+      "notes" : "",
+      "references" : [ {
+        "source" : "CONFIRM",
+        "url" : "https://issues.liferay.com/browse/LPE-17007",
+        "name" : "https://issues.liferay.com/browse/LPE-17007"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/120747590",
+        "name" : "https://portal.liferay.dev/learn/security/known-vulnerabilities/-/asset_publisher/HbL5mxmVrnXW/content/id/120747590"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_24:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_25:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_26:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_27:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_28:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_3\\+:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_30:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_33:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_35:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_36:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_39:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_40:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_41:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_42:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_43:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_44:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_45:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_46:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_47:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_48:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_49:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_50:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_51:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_52:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_53:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_54:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_56:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_57:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_58:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_59:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_60:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_61:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_64:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_65:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_66:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_67:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_68:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_69:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_70:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_71:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_72:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_73:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_75:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_76:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_78:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_79:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_80:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_81:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_82:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_83:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_84:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_85:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_86:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_87:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_88:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_89:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_90:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_91:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_92:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_93:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_94:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.0:fix_pack_95:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_10:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_11:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_12:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_13:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_14:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_15:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_16:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_17:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_18:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_19:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_5:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_6:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_7:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_8:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.1:fix_pack_9:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_1:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_2:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_3:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:dxp:7.2:fix_pack_4:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndExcluding" : "7.3.1"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2014-8349",
+      "severity" : "LOW",
+      "cvssv2" : {
+        "score" : 3.5,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "SINGLE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "LOW",
+        "version" : "2.0",
+        "exploitabilityScore" : "6.8",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cwes" : [ "CWE-79" ],
+      "description" : "Cross-site scripting (XSS) vulnerability in Liferay Portal Enterprise Edition (EE) 6.2 SP8 and earlier allows remote authenticated users to inject arbitrary web script or HTML via the _20_body parameter in the comment field in an uploaded file.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "http://packetstormsecurity.com/files/129199/Liferay-Portal-6.2-EE-SP8-Cross-Site-Scripting.html",
+        "name" : "http://packetstormsecurity.com/files/129199/Liferay-Portal-6.2-EE-SP8-Cross-Site-Scripting.html"
+      }, {
+        "source" : "FULLDISC",
+        "url" : "http://seclists.org/fulldisclosure/2014/Nov/61",
+        "name" : "20141120 CVE-2014-8349 LIFERAY Portal Stored XSS"
+      }, {
+        "source" : "SECTRACK",
+        "url" : "http://www.securitytracker.com/id/1031255",
+        "name" : "1031255"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:liferay:liferay_portal:*:sp8:*:*:enterprise:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionEndIncluding" : "6.2"
+        }
+      } ]
+    } ]
+  } ]
+}

--- a/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/scan-results/grype/grype-report.json
+++ b/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/scan-results/grype/grype-report.json
@@ -1,0 +1,96 @@
+{
+ "matches": [],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:08.199182766+13:00"
+ }
+}

--- a/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/scan-results/snyk/snyk-report.json
+++ b/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/scan-results/snyk/snyk-report.json
@@ -1,0 +1,177 @@
+{
+  "vulnerabilities": [
+    {
+      "id": "snyk:lic:maven:com.liferay:com.liferay.portal.tools.bundle.support:LGPL-2.1",
+      "type": "license",
+      "title": "LGPL-2.1 license",
+      "semver": {
+        "vulnerable": [
+          "[1.0.0,)"
+        ]
+      },
+      "license": "LGPL-2.1",
+      "language": "java",
+      "description": "LGPL-2.1 license",
+      "packageName": "com.liferay:com.liferay.portal.tools.bundle.support",
+      "creationTime": "2023-06-13T16:07:54.269Z",
+      "packageManager": "maven",
+      "publicationTime": "2023-06-13T16:07:54.269Z",
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "from": [
+        "foo:com.liferay__com.liferay.portal.tools.bundle.support__3.2.7@0.0.1",
+        "com.liferay:com.liferay.portal.tools.bundle.support@3.2.7"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "com.liferay:com.liferay.portal.tools.bundle.support",
+      "version": "3.2.7"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 1,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "1 vulnerable dependency path",
+  "remediation": {
+    "unresolved": [
+      {
+        "id": "snyk:lic:maven:com.liferay:com.liferay.portal.tools.bundle.support:LGPL-2.1",
+        "type": "license",
+        "title": "LGPL-2.1 license",
+        "semver": {
+          "vulnerable": [
+            "[1.0.0,)"
+          ]
+        },
+        "license": "LGPL-2.1",
+        "language": "java",
+        "description": "LGPL-2.1 license",
+        "packageName": "com.liferay:com.liferay.portal.tools.bundle.support",
+        "creationTime": "2023-06-13T16:07:54.269Z",
+        "packageManager": "maven",
+        "publicationTime": "2023-06-13T16:07:54.269Z",
+        "severity": "medium",
+        "from": [
+          "foo:com.liferay__com.liferay.portal.tools.bundle.support__3.2.7@0.0.1",
+          "com.liferay:com.liferay.portal.tools.bundle.support@3.2.7"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "isRuntime": false,
+        "name": "com.liferay:com.liferay.portal.tools.bundle.support",
+        "version": "3.2.7",
+        "severityWithCritical": "medium"
+      }
+    ],
+    "upgrade": {},
+    "patch": {},
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 1,
+  "projectName": "foo:com.liferay__com.liferay.portal.tools.bundle.support__3.2.7",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7"
+}

--- a/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/scan-results/steady/steady-report.json
+++ b/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/scan-results/steady/steady-report.json
@@ -1,0 +1,58 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 21:49 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "com.liferay__com.liferay.portal.tools.bundle.support__3.2.7",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "TEST, PROVIDED" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+			{
+		
+			"bug":{
+				"id":"CVE-2013-4366",
+				"cvssScore": "9.8" ,
+				"cvssVersion": "3.1" 
+			},
+			"filename": "com.liferay.portal.tools.bundle.support-3.2.7.jar",
+			"sha1": "C266A91E83EA1DBC23DB795275D15E0F8D1DA399",
+			
+			"modules": [
+			
+				{
+			
+				"groupId": "foo",
+				"artifactId": "com.liferay__com.liferay.portal.tools.bundle.support__3.2.7",
+				"version": "0.0.1",
+				
+				"href": "http://localhost:8033/backend/../apps/#/$space.getSpaceToken()/foo/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/0.0.1",
+				
+				"scope": "COMPILE",
+				"isTransitive": false,
+				
+					"containsVulnerableCode": "unknown",
+				
+						"potentiallyExecutesVulnerableCode": "noLibraryCodeAtAll",
+				
+						"actuallyExecutesVulnerableCode": "noLibraryCodeAtAll"
+				}
+			]
+		}
+		]
+	}
+}

--- a/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/src/test/java/org/apache/commons/compress/Test_CVE_2018_1324.java
+++ b/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7/src/test/java/org/apache/commons/compress/Test_CVE_2018_1324.java
@@ -1,0 +1,43 @@
+package org.apache.commons.compress;
+
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.compress.archivers.zip.ZipLong;
+import org.apache.commons.compress.archivers.zip.ZipShort;
+import org.apache.commons.compress.archivers.zip.X0017_StrongEncryptionHeader;
+import org.opentest4j.AssertionFailedError;
+import org.xml.sax.helpers.DefaultHandler;
+
+
+import java.io.IOException;
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+
+public class Test_CVE_2018_1324 {
+
+  @Test
+  public void vulnerabilityProof() {
+    assertThrows(AssertionFailedError.class, this::testCVE_2018_1324);
+  }
+
+  // Running test should not be in an infinite loop
+  public void testCVE_2018_1324() throws IOException {
+    // the data is crafted based on the file difflist_fsbwserver.f-secure.com_80_583109529_2.zip
+    byte[] data = {23, 0, 0, 0, 1, 40, 0, 0, 0, 62, 55, 15, 87, 121, -27, -23, -5, 9, -118, -2, -45, -115, -63, -110, -24};
+    int offset = 4;
+    int length = 0;
+
+    ZipShort.putShort(1, data, offset + 14); // reduce the number of second loops from 65152 -> 1 to save testing time
+
+    assertEquals(3924130135L, ZipLong.getValue(data, offset + 8));
+    assertEquals(1, ZipShort.getValue(data, offset + 14));
+
+    X0017_StrongEncryptionHeader x0017 = new X0017_StrongEncryptionHeader();
+    assertTimeoutPreemptively(Duration.ofSeconds(12), () -> x0017.parseCentralDirectoryFormat(data, offset, length));
+  }
+}

--- a/CVE-2018-1324/io.takari__commons-compress__1.12/README.md
+++ b/CVE-2018-1324/io.takari__commons-compress__1.12/README.md
@@ -1,0 +1,17 @@
+# [CVE-2018-1324](https://nvd.nist.gov/vuln/detail/CVE-2018-1324) from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+Project reproduces CVE-2018-1324 using CVE-specific test from a
+[vul4j commit](https://github.com/tuhh-softsec/vul4j/commit/45ddad15edd0f56a38d1d10e1ac6e1c2de9de881).
+
+The test has been rewritten to succeed if the vul4j test times out. The original test seems to be sensitive to timing,
+i.e. the fixed versions may not complete within the timeout given a slow environment, thus timeout was increased to 12
+seconds.
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2018-1324/io.takari__commons-compress__1.12/pom.xml
+++ b/CVE-2018-1324/io.takari__commons-compress__1.12/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>io.takari__commons-compress__1.12</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2018-1324 POC</description>
+    <name>CVE-2018-1324</name>
+
+    <properties>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.takari</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2018-1324/io.takari__commons-compress__1.12/pov-project.json
+++ b/CVE-2018-1324/io.takari__commons-compress__1.12/pov-project.json
@@ -1,0 +1,17 @@
+{
+  "id": "CVE-2018-1324",
+  "artifact": "org.apache.commons:commons-compress",
+  "vulnerableVersions": [
+    "1.11",
+    "1.12",
+    "1.13",
+    "1.14",
+    "1.15"
+  ],
+  "fixVersion": "1.16.1",
+  "testSignalWhenVulnerable": "success",
+  "references": [
+    "https://nvd.nist.gov/vuln/detail/CVE-2018-1324",
+    "https://github.com/advisories/GHSA-h436-432x-8fvx"
+  ]
+}

--- a/CVE-2018-1324/io.takari__commons-compress__1.12/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2018-1324/io.takari__commons-compress__1.12/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,2197 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2018-1324",
+    "groupID" : "foo",
+    "artifactID" : "io.takari__commons-compress__1.12",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:22:30.023290Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "commons-compress-1.12.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/io/takari/commons-compress/1.12/commons-compress-1.12.jar",
+    "md5" : "61c9f407e80c5f8f1a13437852732f7e",
+    "sha1" : "8f42294d1de4f464a3868eed9120ad8beeba5888",
+    "sha256" : "717dcb9324d372045da539d69e1e54b89235d75dc3cf092fe206d8666f9b29ac",
+    "description" : "\nApache Commons Compress software defines an API for working with\ncompression and archive formats.  These include: bzip2, gzip, pack200,\nlzma, xz, Snappy, traditional Unix Compress, DEFLATE and ar, cpio,\njar, tar, zip, dump, 7z, arj.\n  ",
+    "projectReferences" : [ "CVE-2018-1324:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/io.takari__commons-compress__1.12@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "commons-compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "extension-name",
+        "value" : "org.apache.commons.compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Implementation-Vendor-Id",
+        "value" : "io.takari"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "bodewig at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "damjan at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ebourg at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ggregory at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "grobmeier at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "julius at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sebb at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tcurdt at apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bodewig"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "damjan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ebourg"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ggregory"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "grobmeier"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "julius"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sebb"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tcurdt"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Christian Grobmeier"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Damjan Jovanovic"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Emmanuel Bourg"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Gary Gregory"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Julius Davies"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Sebastian Bazley"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stefan Bodewig"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Torsten Curdt"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "io.takari"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Compress"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "takari"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/proper/commons-compress/"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "commons-compress"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "compress"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "extension-name",
+        "value" : "org.apache.commons.compress"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Title",
+        "value" : "Apache Commons Compress"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "specification-title",
+        "value" : "Apache Commons Compress"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-compress"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "bodewig at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "damjan at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ebourg at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ggregory at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "grobmeier at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "julius at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sebb at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tcurdt at apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bodewig"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "damjan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ebourg"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ggregory"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "grobmeier"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "julius"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sebb"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tcurdt"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Christian Grobmeier"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Damjan Jovanovic"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Emmanuel Bourg"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Gary Gregory"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Julius Davies"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Sebastian Bazley"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stefan Bodewig"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Torsten Curdt"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "io.takari"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Compress"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "takari"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/proper/commons-compress/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.12"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Version",
+        "value" : "1.12"
+      }, {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "1.12"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.12"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/io.takari/commons-compress@1.12",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/io.takari/commons-compress@1.12?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:apache:commons_compress:1.12:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aapache&cpe_product=cpe%3A%2F%3Aapache%3Acommons_compress&cpe_version=cpe%3A%2F%3Aapache%3Acommons_compress%3A1.12"
+    } ],
+    "vulnerabilities" : [ {
+      "source" : "NVD",
+      "name" : "CVE-2021-35515",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-835" ],
+      "description" : "When reading a specially crafted 7Z archive, the construction of the list of codecs that decompress an entry can result in an infinite loop. This could be used to mount a denial of service attack against services that use Compress' sevenz package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] commented on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210716 [GitHub] [pulsar] lhotari opened a new pull request #11345: [Security] Upgrade commons-compress to 1.21"
+      }, {
+        "source" : "MISC",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rbe91c512c5385181149ab087b6c909825d34299f5c491c6482a2ed57@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [druid] branch master updated: Address CVE-2021-35515 CVE-2021-36090 (#11496)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rab292091eadd1ecc63c516e9541a7f241091cf2e652b8185a6059945@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [GitHub] [druid] suneet-s merged pull request #11496: Address CVE-2021-35515 CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] hanahmily merged pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20211022-0001/",
+        "name" : "https://security.netapp.com/advisory/ntap-20211022-0001/"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+        "name" : "[poi-dev] 20210923 Re: [VOTE] Apache POI 5.1.0 release (RC1)"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rbaea15ddc5a7c0c6b66660f1d6403b28595e2561bb283eade7d7cd69@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-35515: Apache Commons Compress 1.6 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] wu-sheng opened a new pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [skywalking] branch master updated: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090 (#7400)"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/1",
+        "name" : "[oss-security] 20210713 CVE-2021-35515: Apache Commons Compress 1.6 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf2f4d7940371a7c7c5b679f50e28fc7fcc82cd00670ced87e013ac88@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [GitHub] [druid] suneet-s opened a new pull request #11496: Address CVE-2021-35515 CVE-2021-36090"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/r19ebfd71770ec0617a9ea180e321ef927b3fefb4c81ec5d1902d20ab%40%3Cuser.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/r19ebfd71770ec0617a9ea180e321ef927b3fefb4c81ec5d1902d20ab%40%3Cuser.commons.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [skywalking] 01/01: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.6",
+          "versionEndIncluding" : "1.20"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:oncommand_insight:-:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_payments:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_trade_finance:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_treasury_management:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:12.0.0.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_automated_test_suite:1.8.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_service_communication_proxy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_route_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.5"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.7.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "14.0.0",
+          "versionEndIncluding" : "14.3.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:12.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:14.5.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_data_repository:8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.59:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.1.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.3.1:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-35516",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-770" ],
+      "description" : "When reading a specially crafted 7Z archive, Compress can be made to allocate large amounts of memory that finally leads to an out of memory error even for very small inputs. This could be used to mount a denial of service attack against services that use Compress' sevenz package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] commented on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210716 [GitHub] [pulsar] lhotari opened a new pull request #11345: [Security] Upgrade commons-compress to 1.21"
+      }, {
+        "source" : "MISC",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] hanahmily merged pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/rf68442d67eb166f4b6cf0bbbe6c7f99098c12954f37332073c9822ca%40%3Cuser.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/rf68442d67eb166f4b6cf0bbbe6c7f99098c12954f37332073c9822ca%40%3Cuser.commons.apache.org%3E"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20211022-0001/",
+        "name" : "https://security.netapp.com/advisory/ntap-20211022-0001/"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+        "name" : "[poi-dev] 20210923 Re: [VOTE] Apache POI 5.1.0 release (RC1)"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf5b1016fb15b7118b9a5e16bb0b78cb4f1dfcf7821eb137ab5757c91@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-35516: Apache Commons Compress 1.6 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] wu-sheng opened a new pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/2",
+        "name" : "[oss-security] 20210713 CVE-2021-35516: Apache Commons Compress 1.6 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [skywalking] branch master updated: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090 (#7400)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [skywalking] 01/01: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.6",
+          "versionEndIncluding" : "1.20"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:oncommand_insight:-:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:12.0.0.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_automated_test_suite:1.8.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_service_communication_proxy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_route_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.5"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.7.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "14.0.0",
+          "versionEndIncluding" : "14.3.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:12.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_data_repository:8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.59:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.1.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-35517",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-770" ],
+      "description" : "When reading a specially crafted TAR archive, Compress can be made to allocate large amounts of memory that finally leads to an out of memory error even for very small inputs. This could be used to mount a denial of service attack against services that use Compress' tar package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] commented on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210716 [GitHub] [pulsar] lhotari opened a new pull request #11345: [Security] Upgrade commons-compress to 1.21"
+      }, {
+        "source" : "MISC",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ra393ffdc7c90a4a37ea023946f390285693795013a642d80fba20203@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-35517: Apache Commons Compress 1.1 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/3",
+        "name" : "[oss-security] 20210713 CVE-2021-35517: Apache Commons Compress 1.1 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/r605d906b710b95f1bbe0036a53ac6968f667f2c249b6fbabada9a940%40%3Cuser.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/r605d906b710b95f1bbe0036a53ac6968f667f2c249b6fbabada9a940%40%3Cuser.commons.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] hanahmily merged pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20211022-0001/",
+        "name" : "https://security.netapp.com/advisory/ntap-20211022-0001/"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r54afdab05e01de970649c2d91a993f68a6b00cd73e6e34e16c832d46@%3Cuser.ant.apache.org%3E",
+        "name" : "[ant-user] 20210713 CVE-2021-36373: Apache Ant TAR archive denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+        "name" : "[poi-dev] 20210923 Re: [VOTE] Apache POI 5.1.0 release (RC1)"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/5",
+        "name" : "[oss-security] 20210713 CVE-2021-36373: Apache Ant TAR archive denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r31f75743ac173b0a606f8ea6ea53f351f386c44e7bcf78ae04007c29@%3Cissues.flink.apache.org%3E",
+        "name" : "[flink-issues] 20210908 [GitHub] [flink] MartijnVisser opened a new pull request #17194: [FLINK-24034] Upgrade commons-compress to 1.21 and other apache.commons updates"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] wu-sheng opened a new pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [skywalking] branch master updated: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090 (#7400)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r457b2ed564860996b20d938566fe8bd4bfb7c37be8e205448ccb5975@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-36373: Apache Ant TAR archive denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [skywalking] 01/01: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.1",
+          "versionEndIncluding" : "1.20"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:oncommand_insight:-:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_payments:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_trade_finance:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_treasury_management:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:12.0.0.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_service_communication_proxy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_route_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.5"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.7.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "14.0.0",
+          "versionEndIncluding" : "14.3.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:12.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_data_repository:8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.59:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.1.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2021-36090",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 5.0,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "2.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.5,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "NVD-CWE-Other" ],
+      "description" : "When reading a specially crafted ZIP archive, Compress can be made to allocate large amounts of memory that finally leads to an out of memory error even for very small inputs. This could be used to mount a denial of service attack against services that use Compress' zip package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://commons.apache.org/proper/commons-compress/security-reports.html",
+        "name" : "https://commons.apache.org/proper/commons-compress/security-reports.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r54049b66afbca766b6763c7531e9fe7a20293a112bcb65462a134949@%3Ccommits.drill.apache.org%3E",
+        "name" : "[drill-commits] 20210804 [drill] branch master updated: Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rbe91c512c5385181149ab087b6c909825d34299f5c491c6482a2ed57@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [druid] branch master updated: Address CVE-2021-35515 CVE-2021-36090 (#11496)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rab292091eadd1ecc63c516e9541a7f241091cf2e652b8185a6059945@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [GitHub] [druid] suneet-s merged pull request #11496: Address CVE-2021-35515 CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9f54c0caa462267e0cc68b49f141e91432b36b23348d18c65bd0d040@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rba65ed5ddb0586f5b12598f55ec7db3633e7b7fede60466367fbf86a@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [GitHub] [skywalking] hanahmily merged pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/6",
+        "name" : "[oss-security] 20210713 CVE-2021-36374: Apache Ant ZIP, and ZIP based, archive denial of service vulerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb6e1fa80d34e5ada45f72655d84bfd90db0ca44ef19236a49198c88c@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] edited a comment on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r67ef3c07fe3b8c1b02d48012149d280ad6da8e4cec253b527520fb2b@%3Cdev.poi.apache.org%3E",
+        "name" : "[poi-dev] 20210923 Re: [VOTE] Apache POI 5.1.0 release (RC1)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb5fa2ee61828fa2e42361b58468717e84902dd71c4aea8dc0b865df7@%3Cnotifications.james.apache.org%3E",
+        "name" : "[james-notifications] 20210714 [GitHub] [james-project] chibenwa opened a new pull request #537: [UPGRADE] Security upgrade: common-compress to 1.21"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/rc4134026d7d7b053d4f9f2205531122732405012c8804fd850a9b26f%40%3Cuser.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/rc4134026d7d7b053d4f9f2205531122732405012c8804fd850a9b26f%40%3Cuser.commons.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r0e87177f8e78b4ee453cd4d3d8f4ddec6f10d2c27707dd71e12cafc9@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-36374: Apache Ant ZIP, and ZIP based, archive denial of service vulerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd4332baaf6debd03d60deb7ec93bee49e5fdbe958cb6800dff7fb00e@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] wu-sheng opened a new pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb7adf3e55359819e77230b4586521e5c6874ce5ed93384bdc14d6aee@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [skywalking] 01/01: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/racd0c0381c8404f298b226cd9db2eaae965b14c9c568224aa3f437ae@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210802 [GitHub] [skywalking] codecov[bot] commented on pull request #7400: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb064d705fdfa44b5dae4c366b369ef6597951083196321773b983e71@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210716 [GitHub] [pulsar] lhotari opened a new pull request #11345: [Security] Upgrade commons-compress to 1.21"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf3f0a09fee197168a813966c5816157f6c600a47313a0d6813148ea6@%3Cissues.drill.apache.org%3E",
+        "name" : "[drill-issues] 20210803 [jira] [Created] (DRILL-7981) Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rbbf42642c3e4167788a7c13763d192ee049604d099681f765385d99d@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210804 [GitHub] [drill] luocooong opened a new pull request #2285: Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r3227b1287e5bd8db6523b862c22676b046ad8f4fc96433225f46a2bd@%3Cissues.drill.apache.org%3E",
+        "name" : "[drill-issues] 20210805 [jira] [Commented] (DRILL-7981) Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rc7df4c2f0bbe2028a1498a46d322c91184f7a369e3e4c57d9518cacf@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210803 [jira] [Created] (DRILL-7981) Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r25f4c44616045085bc3cf901bb7e68e445eee53d1966fc08998fc456@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210805 [GitHub] [drill] luocooong merged pull request #2285: DRILL-7981: Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20211022-0001/",
+        "name" : "https://security.netapp.com/advisory/ntap-20211022-0001/"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rdd5412a5b9a25aed2a02c3317052d38a97128314d50bc1ed36e81d38@%3Cuser.ant.apache.org%3E",
+        "name" : "[ant-user] 20210713 CVE-2021-36374: Apache Ant ZIP, and ZIP based, archive denial of service vulerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r4f03c5de923e3f2a8c316248681258125140514ef3307bfe1538e1ab@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20210804 [GitHub] [drill] luocooong merged pull request #2285: DRILL-7981: Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r75ffc7a461e7e7ae77690fa75bd47bb71365c732e0fbcc44da4f8ff5@%3Cdev.tomcat.apache.org%3E",
+        "name" : "[tomcat-dev] 20210811 [GitHub] [tomcat-jakartaee-migration] ebourg commented on issue #23: Vulnerability with Apache Commons Compress v1.20"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r9a23d4dbf4e34d498664080bff59f2893b855eb16dae33e4aa92fa53@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20210713 CVE-2021-36090: Apache Commons Compress 1.0 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf93b6bb267580e01deb7f3696f7eaca00a290c66189a658cf7230a1a@%3Cissues.drill.apache.org%3E",
+        "name" : "[drill-issues] 20210804 [jira] [Commented] (DRILL-7981) Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090"
+      }, {
+        "source" : "MLIST",
+        "url" : "http://www.openwall.com/lists/oss-security/2021/07/13/4",
+        "name" : "[oss-security] 20210713 CVE-2021-36090: Apache Commons Compress 1.0 to 1.20 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfba19167efc785ad3561e7ef29f340d65ac8f0d897aed00e0731e742@%3Cnotifications.skywalking.apache.org%3E",
+        "name" : "[skywalking-notifications] 20210803 [skywalking] branch master updated: Fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090 (#7400)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rf2f4d7940371a7c7c5b679f50e28fc7fcc82cd00670ced87e013ac88@%3Ccommits.druid.apache.org%3E",
+        "name" : "[druid-commits] 20210726 [GitHub] [druid] suneet-s opened a new pull request #11496: Address CVE-2021-35515 CVE-2021-36090"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.0",
+          "versionEndExcluding" : "1.21"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:oncommand_insight:-:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.1",
+          "versionEndIncluding" : "18.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_payments:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.6.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.7.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.9.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.12.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_trade_finance:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_treasury_management:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:business_process_management_suite:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:12.0.0.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_automated_test_suite:1.8.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_service_communication_proxy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:8.2.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_element_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.2.0",
+          "versionEndIncluding" : "8.2.4.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_report_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.2.0",
+          "versionEndIncluding" : "8.2.5.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_session_route_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.2.5.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.4.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.4.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.5.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_analytical_applications_infrastructure:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.6",
+          "versionEndIncluding" : "8.1.1"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_crime_and_compliance_management_studio:8.0.8.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:*:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.7.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_enterprise_case_management:8.0.8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "14.0.0",
+          "versionEndIncluding" : "14.3.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:12.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_universal_banking:14.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_data_repository:8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.59:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.12.0",
+          "versionEndIncluding" : "17.12.11"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "18.8.0",
+          "versionEndIncluding" : "18.8.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "19.12.0",
+          "versionEndIncluding" : "19.12.11"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "20.12.0",
+          "versionEndIncluding" : "20.12.7"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.1.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2018-11771",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 5.5,
+        "attackVector" : "LOCAL",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "1.8",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-835" ],
+      "description" : "When reading a specially crafted ZIP archive, the read method of Apache Commons Compress 1.7 to 1.17's ZipArchiveInputStream can fail to return the correct EOF indication after the end of the stream has been reached. When combined with a java.io.InputStreamReader this can lead to an infinite stream, which can be used to mount a denial of service attack against services that use Compress' zip package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/714c6ac1b1b50f8557e7342903ef45f1538a7bc60a0b47d6e48c273d@%3Ccommits.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] spmallette commented on issue #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "SECTRACK",
+        "url" : "http://www.securitytracker.com/id/1041503",
+        "name" : "1041503"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/f28052d04cb8dbaae39bfd3dc8438e58c2a8be306a3f381f4728d7c1@%3Ccommits.commons.apache.org%3E",
+        "name" : "[commons-commits] 20190827 [commons-compress] branch master updated: record CVE-2019-12402"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/6c79965066c30d4e330e04d911d3761db41b82c89ae38d9a6b37a6f1@%3Cdev.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-dev] 20190924 [GitHub] [tinkerpop] spmallette commented on issue #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/0adb631517766e793e18a59723e2df08ced41eb9a57478f14781c9f7@%3Cdev.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-dev] 20190930 [GitHub] [tinkerpop] spmallette closed pull request #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "BID",
+        "url" : "http://www.securityfocus.com/bid/105139",
+        "name" : "105139"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/b907e70bc422905d7962fd18f863f746bf7b4e7ed9da25c148580c61@%3Cnotifications.commons.apache.org%3E",
+        "name" : "[commons-notifications] 20190827 svn commit: r1049290 - in /websites/production/commons/content/proper/commons-compress: changes-report.html security-reports.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/c7954dc1e8fafd7ca1449f078953b419ebf8936e087f235f3bd024be@%3Ccommits.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch commented on issue #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/b8da751fc0ca949534cdf2744111da6bb0349d2798fac94b0a50f330@%3Cannounce.apache.org%3E",
+        "name" : "[announce] 20180816 [CVE-2018-11771] Apache Commons Compress 1.7 to 1.17 denial of service vulnerability"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/35f60d6d0407c13c39411038ba1aca71d92595ed7041beff4d07f2ee@%3Ccommits.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-commits] 20190923 [GitHub] [tinkerpop] robertdale commented on issue #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/3565494c263dfeb4dcb2a71cb24d09a1ca285cd6ac74edc025a3af8a@%3Ccommits.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-commits] 20190930 [GitHub] [tinkerpop] spmallette merged pull request #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/b8ef29df0f1d55aa741170748352ae8e425c7b1d286b2f257711a2dd@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20190530 [Discuss] RAT-244 - update to language level 1.7 due to CVE issues in RAT"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/eeecc1669242b28a3777ae13c68b376b0148d589d3d8170340d61120@%3Cdev.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-dev] 20190924 [GitHub] [tinkerpop] justinchuch commented on issue #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/f9cdd32af7d73e943452167d15801db39e8130409ebb9efb243b3f41@%3Ccommits.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-commits] 20190923 [GitHub] [tinkerpop] justinchuch opened a new pull request #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/e3eae9e6fc021c4c22dda59a335d21c12eecab480b48115a2f098ef6@%3Ccommits.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-commits] 20190923 [GitHub] [tinkerpop] spmallette commented on issue #1199: Upgrade commons-compress to version 1.19 due to CVE-2018-11771"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.7.0",
+          "versionEndIncluding" : "1.17.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:14.1.1.0.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2018-1324",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 4.3,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "2.9",
+        "userInteractionRequired" : "true"
+      },
+      "cvssv3" : {
+        "baseScore" : 5.5,
+        "attackVector" : "LOCAL",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "REQUIRED",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "NONE",
+        "integrityImpact" : "NONE",
+        "availabilityImpact" : "HIGH",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "1.8",
+        "impactScore" : "3.6",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-835" ],
+      "description" : "A specially crafted ZIP archive can be used to cause an infinite loop inside of Apache Commons Compress' extra field parser used by the ZipFile and ZipArchiveInputStream classes in versions 1.11 to 1.15. This can be used to mount a denial of service attack against services that use Compress' zip package.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r5532dc8d5456b5151e8c286801e2e5769f5c04118b29c3b5d13ea387@%3Cissues.beam.apache.org%3E",
+        "name" : "[beam-issues] 20200421 [jira] [Closed] (BEAM-3873) Current version of commons-compress is DOS vulnerable CVE-2018-1324"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/b8ef29df0f1d55aa741170748352ae8e425c7b1d286b2f257711a2dd@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20190530 [Discuss] RAT-244 - update to language level 1.7 due to CVE issues in RAT"
+      }, {
+        "source" : "SECTRACK",
+        "url" : "http://www.securitytracker.com/id/1040549",
+        "name" : "1040549"
+      }, {
+        "source" : "BID",
+        "url" : "http://www.securityfocus.com/bid/103490",
+        "name" : "103490"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/1c7b6df6d1c5c8583518a0afa017782924918e4d6acfaf23ed5b2089@%3Cdev.commons.apache.org%3E",
+        "name" : "[dev] 20180316 [CVE-2018-1324] Apache Commons Compress denial of service vulnerability"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_compress:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.11",
+          "versionEndIncluding" : "1.15"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:mysql_cluster:*:*:*:*:*:*:*:*",
+          "versionEndIncluding" : "7.4.34"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:mysql_cluster:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "7.5.0",
+          "versionEndIncluding" : "7.5.24"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:mysql_cluster:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "7.6.0",
+          "versionEndIncluding" : "7.6.20"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:mysql_cluster:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.0.27"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:14.1.1.0.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    } ]
+  } ]
+}

--- a/CVE-2018-1324/io.takari__commons-compress__1.12/scan-results/grype/grype-report.json
+++ b/CVE-2018-1324/io.takari__commons-compress__1.12/scan-results/grype/grype-report.json
@@ -1,0 +1,96 @@
+{
+ "matches": [],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:08.254766762+13:00"
+ }
+}

--- a/CVE-2018-1324/io.takari__commons-compress__1.12/scan-results/snyk/snyk-report.json
+++ b/CVE-2018-1324/io.takari__commons-compress__1.12/scan-results/snyk/snyk-report.json
@@ -1,0 +1,177 @@
+{
+  "vulnerabilities": [
+    {
+      "id": "snyk:lic:maven:io.takari:commons-compress:EPL-1.0",
+      "type": "license",
+      "title": "EPL-1.0 license",
+      "semver": {
+        "vulnerable": [
+          "[1.12,)"
+        ]
+      },
+      "license": "EPL-1.0",
+      "language": "java",
+      "description": "EPL-1.0 license",
+      "packageName": "io.takari:commons-compress",
+      "creationTime": "2023-06-13T14:54:11.573Z",
+      "packageManager": "maven",
+      "publicationTime": "2023-06-13T14:54:11.573Z",
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "from": [
+        "foo:io.takari__commons-compress__1.12@0.0.1",
+        "io.takari:commons-compress@1.12"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "io.takari:commons-compress",
+      "version": "1.12"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 1,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "1 vulnerable dependency path",
+  "remediation": {
+    "unresolved": [
+      {
+        "id": "snyk:lic:maven:io.takari:commons-compress:EPL-1.0",
+        "type": "license",
+        "title": "EPL-1.0 license",
+        "semver": {
+          "vulnerable": [
+            "[1.12,)"
+          ]
+        },
+        "license": "EPL-1.0",
+        "language": "java",
+        "description": "EPL-1.0 license",
+        "packageName": "io.takari:commons-compress",
+        "creationTime": "2023-06-13T14:54:11.573Z",
+        "packageManager": "maven",
+        "publicationTime": "2023-06-13T14:54:11.573Z",
+        "severity": "medium",
+        "from": [
+          "foo:io.takari__commons-compress__1.12@0.0.1",
+          "io.takari:commons-compress@1.12"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "isRuntime": false,
+        "name": "io.takari:commons-compress",
+        "version": "1.12",
+        "severityWithCritical": "medium"
+      }
+    ],
+    "upgrade": {},
+    "patch": {},
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 1,
+  "projectName": "foo:io.takari__commons-compress__1.12",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2018-1324/io.takari__commons-compress__1.12"
+}

--- a/CVE-2018-1324/io.takari__commons-compress__1.12/scan-results/steady/steady-report.json
+++ b/CVE-2018-1324/io.takari__commons-compress__1.12/scan-results/steady/steady-report.json
@@ -1,0 +1,27 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 21:50 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "io.takari__commons-compress__1.12",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "TEST, PROVIDED" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+		]
+	}
+}

--- a/CVE-2018-1324/io.takari__commons-compress__1.12/src/test/java/org/apache/commons/compress/Test_CVE_2018_1324.java
+++ b/CVE-2018-1324/io.takari__commons-compress__1.12/src/test/java/org/apache/commons/compress/Test_CVE_2018_1324.java
@@ -1,0 +1,43 @@
+package org.apache.commons.compress;
+
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.compress.archivers.zip.ZipLong;
+import org.apache.commons.compress.archivers.zip.ZipShort;
+import org.apache.commons.compress.archivers.zip.X0017_StrongEncryptionHeader;
+import org.opentest4j.AssertionFailedError;
+import org.xml.sax.helpers.DefaultHandler;
+
+
+import java.io.IOException;
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+
+public class Test_CVE_2018_1324 {
+
+  @Test
+  public void vulnerabilityProof() {
+    assertThrows(AssertionFailedError.class, this::testCVE_2018_1324);
+  }
+
+  // Running test should not be in an infinite loop
+  public void testCVE_2018_1324() throws IOException {
+    // the data is crafted based on the file difflist_fsbwserver.f-secure.com_80_583109529_2.zip
+    byte[] data = {23, 0, 0, 0, 1, 40, 0, 0, 0, 62, 55, 15, 87, 121, -27, -23, -5, 9, -118, -2, -45, -115, -63, -110, -24};
+    int offset = 4;
+    int length = 0;
+
+    ZipShort.putShort(1, data, offset + 14); // reduce the number of second loops from 65152 -> 1 to save testing time
+
+    assertEquals(3924130135L, ZipLong.getValue(data, offset + 8));
+    assertEquals(1, ZipShort.getValue(data, offset + 14));
+
+    X0017_StrongEncryptionHeader x0017 = new X0017_StrongEncryptionHeader();
+    assertTimeoutPreemptively(Duration.ofSeconds(12), () -> x0017.parseCentralDirectoryFormat(data, offset, length));
+  }
+}


### PR DESCRIPTION
## `com.liferay:com.liferay.portal.tools.bundle.support:3.2.7`:

- ❌ **Not a full clone** based on the difference in name from the TPoV (`org.apache.commons:commons-compress:1.15`).
- ✔️ But **not critical** since [the 3 artifacts dependent on the vulnerable version](https://central.sonatype.com/artifact/com.liferay/com.liferay.portal.tools.bundle.support/3.2.7/dependents) are all from the same groupId (`com.liferay`), as are [the latest version's 12 dependent packages](https://central.sonatype.com/artifact/com.liferay/com.liferay.portal.tools.bundle.support/3.7.4/dependents), and none of these dependent packages has reverse dependencies of its own -> **OK for public release**
- (✔️) Also, it **is remediated:** the vulnerability is absent from version `3.7.4`:
```
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/piccolo/68_big_run_accidentally_included_CVE-2019-44228_and_it_worked/vuln_final/CVE-2018-1324$ grep 'com.liferay__com.liferay.portal.tools.bundle.support__.* -> vuln is' !$
grep 'com.liferay__com.liferay.portal.tools.bundle.support__.* -> vuln is' ../../log117-CVE-2018-1324.log
2023-09-29 14:40:20,898 INFO [main] n.a.w.s.Main [Main.java:601] tests in /local/scratch/whitewa/shadedetector/.cache/build/env-d41d8cd98f00b204e9800998ecf8427e/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.7.4: 0 passed, 1 failed, 0 errors, 0 skipped -> vuln is absent
2023-09-29 14:45:47,696 INFO [main] n.a.w.s.Main [Main.java:601] tests in /local/scratch/whitewa/shadedetector/.cache/build/env-d41d8cd98f00b204e9800998ecf8427e/CVE-2018-1324/com.liferay__com.liferay.portal.tools.bundle.support__3.2.7: 1 passed, 0 failed, 0 errors, 0 skipped -> vuln is present
```
