### PR TITLE
Add manually-tweaked pom.xml showing `org.apache.sling:apache.sling.xss.compat:1.1.0` is not vulnerable to CVE-2016-6798

### DIFF
--- a/CVE-2016-6798/NOT-VULNERABLE/org.apache.sling__org.apache.sling.xss.compat__1.1.0/README.md
+++ b/CVE-2016-6798/NOT-VULNERABLE/org.apache.sling__org.apache.sling.xss.compat__1.1.0/README.md
@@ -1,0 +1,3 @@
+This folder records the manually-tweaked PoV `pom.xml` used to demonstrate that `org.apache.sling:apache.sling.xss.compat:1.1.0` is *not* vulnerable to `CVE-2016-6798`.
+
+See https://github.com/jensdietrich/xshady-release/pull/3#issuecomment-1751584873 for details.

--- a/CVE-2016-6798/NOT-VULNERABLE/org.apache.sling__org.apache.sling.xss.compat__1.1.0/pom.xml
+++ b/CVE-2016-6798/NOT-VULNERABLE/org.apache.sling__org.apache.sling.xss.compat__1.1.0/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>org.apache.sling__org.apache.sling.xss.compat__1.1.0</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2016-5394 POV</description>
+    <name>CVE-2016-5394</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.xss.compat</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.api</artifactId>
+            <version>2.11.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.8.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.5.5</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.5.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.json</artifactId>
+            <version>2.0.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.sling</groupId>
+          <artifactId>org.apache.sling.serviceusermapper</artifactId>
+          <version>1.2.0</version>
+          <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Using the same manually-tweaked `pom.xml` as in #6 works here too, enabling the test to run *and pass* on version `1.1.0` of `org.apache.sling:apache.sling.xss.compat`, indicating that version is **not** vulnerable to `CVE-2016-6798`:

```
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.552 s
[INFO] Finished at: 2023-10-10T19:14:52+13:00
[INFO] ------------------------------------------------------------------------
```

This answers the question posed at https://github.com/github/advisory-database/pull/2827#issuecomment-1753925538 -- I'll add a commit there shortly with a `"fixed": "1.1.0"` entry.