### PR TITLE
Add PoV projects demonstrating 2 more artifact versions vulnerable to CVE-2015-7501

### DIFF
--- a/CVE-2015-7501/VULN-CONFIRMED-MANUALLY/org.apache.servicemix.bundles__org.apache.servicemix.bundles.commons-collections__3.2.1_1/README.md
+++ b/CVE-2015-7501/VULN-CONFIRMED-MANUALLY/org.apache.servicemix.bundles__org.apache.servicemix.bundles.commons-collections__3.2.1_1/README.md
@@ -1,0 +1,5 @@
+This `pom.xml` is a PoV project that demonstrates that `org.apache.servicemix.bundles:org.apache.servicemix.bundles.commons-collections:3.2.1_1` is vulnerable to `CVE-2015-7501`: `mvn test` under JDK 8 makes the test pass.
+
+It was obtained by manually changing the artifact version to `3.2.1_1` in the `pom.xml` that `shadedetector` generated automatically for version `3.2.1_3`. `shadedetector` did not automatically determine that this artifact version was vulnerable because [the repo](https://repo1.maven.org/maven2/org/apache/servicemix/bundles/org.apache.servicemix.bundles.commons-collections/3.2.1_1/) contains no source jar for it.
+
+Thanks to @darakian for noticing that this version exists and is likely also vulnerable!

--- a/CVE-2015-7501/VULN-CONFIRMED-MANUALLY/org.apache.servicemix.bundles__org.apache.servicemix.bundles.commons-collections__3.2.1_1/pom.xml
+++ b/CVE-2015-7501/VULN-CONFIRMED-MANUALLY/org.apache.servicemix.bundles__org.apache.servicemix.bundles.commons-collections__3.2.1_1/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>org.apache.servicemix.bundles__org.apache.servicemix.bundles.commons-collections__3.2.1_1</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2015-7501 POC</description>
+    <name>CVE-2015-7501</name>
+
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.commons-collections</artifactId>
+            <version>3.2.1_1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2015-7501/VULN-CONFIRMED-MANUALLY/org.apache.servicemix.bundles__org.apache.servicemix.bundles.commons-collections__3.2.1_2/README.md
+++ b/CVE-2015-7501/VULN-CONFIRMED-MANUALLY/org.apache.servicemix.bundles__org.apache.servicemix.bundles.commons-collections__3.2.1_2/README.md
@@ -1,0 +1,5 @@
+This `pom.xml` is a PoV project that demonstrates that `org.apache.servicemix.bundles:org.apache.servicemix.bundles.commons-collections:3.2.1_2` is vulnerable to `CVE-2015-7501`: `mvn test` under JDK 8 makes the test pass.
+
+It was obtained by manually changing the artifact version to `3.2.1_2` in the `pom.xml` that `shadedetector` generated automatically for version `3.2.1_3`. `shadedetector` did not automatically determine that this artifact version was vulnerable because [the repo](https://repo1.maven.org/maven2/org/apache/servicemix/bundles/org.apache.servicemix.bundles.commons-collections/3.2.1_2/) contains no source jar for it.
+
+Thanks to @darakian for noticing that this version exists and is likely also vulnerable!

--- a/CVE-2015-7501/VULN-CONFIRMED-MANUALLY/org.apache.servicemix.bundles__org.apache.servicemix.bundles.commons-collections__3.2.1_2/pom.xml
+++ b/CVE-2015-7501/VULN-CONFIRMED-MANUALLY/org.apache.servicemix.bundles__org.apache.servicemix.bundles.commons-collections__3.2.1_2/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>org.apache.servicemix.bundles__org.apache.servicemix.bundles.commons-collections__3.2.1_2</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2015-7501 POC</description>
+    <name>CVE-2015-7501</name>
+
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.commons-collections</artifactId>
+            <version>3.2.1_2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
`shadedetector` automatically found that `org.apache.servicemix.bundles:org.apache.servicemix.bundles.commons-collections:3.2.1_3` is vulnerable to `CVE-2015-7501`. https://github.com/github/advisory-database/pull/2841#issuecomment-1760333172 asks whether 2 additional versions, namely `3.2.1_1` and `3.2.1_2`, are also vulnerable.

Indeed, both earlier versions **are vulnerable**:

## `3.2.1_1`

```
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/test_CVE-2015-7501_org.apache.servicemix.bundles.commons-collections__3.2.1_1$ diff ~/code/shadedetector/piccolo/68_big_run_accidentally_included_CVE-2019-44228_and_it_worked/vuln_final/CVE-2015-7501/org.apache.servicemix.bundles__org.apache.servicemix.bundles.commons-collections__3.2.1_3/pom.xml pom.xml
28c28
<             <version>3.2.1_3</version>
---
>             <version>3.2.1_1</version>
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/test_CVE-2015-7501_org.apache.servicemix.bundles.commons-collections__3.2.1_1$ JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 mvn clean test
--snip--
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running ConfirmVulnerabilitiesTests
generating payload object(s) for command: 'touch foo'
serializing payload
deserializing payload
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.069 s - in ConfirmVulnerabilitiesTests
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.503 s
[INFO] Finished at: 2023-10-13T13:31:42+13:00
[INFO] ------------------------------------------------------------------------
```

## `3.2.1_2`

```
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/test_CVE-2015-7501_org.apache.servicemix.bundles.commons-collections__3.2.1_2$ diff ~/code/shadedetector/piccolo/68_big_run_accidentally_included_CVE-2019-44228_and_it_worked/vuln_final/CVE-2015-7501/org.apache.servicemix.bundles__org.apache.servicemix.bundles.commons-collections__3.2.1_3/pom.xml pom.xml
28c28
<             <version>3.2.1_3</version>
---
>             <version>3.2.1_2</version>
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/test_CVE-2015-7501_org.apache.servicemix.bundles.commons-collections__3.2.1_2$ JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 mvn clean test
--snip--
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running ConfirmVulnerabilitiesTests
generating payload object(s) for command: 'touch foo'
serializing payload
deserializing payload
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.07 s - in ConfirmVulnerabilitiesTests
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.486 s
[INFO] Finished at: 2023-10-13T13:34:41+13:00
[INFO] ------------------------------------------------------------------------
``

They were not picked up automatically by `shadedetector` because the source jars were missing in the repo.