### PR TITLE
Add the 1 vulnerable version of `com.diamondq.common:common-thirdparty.jcasbin` found by shadedetector for CVE-2021-29425

### DIFF
--- a/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/README.md
+++ b/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/README.md
@@ -1,0 +1,26 @@
+# [CVE-2021-29425 -- Commons-IO] (https://nvd.nist.gov/vuln/detail/CVE-2021-29425)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+
+
+Project uses `commons-io:commons-io:2.6` , tests from https://github.com/apache/commons-io/commit/2736b6fe0b3fa22ec8e2b4184897ecadb021fc78
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. irrelevant tests in class removed
+2. utility methods TestUtils
+3. JUnit version replaced by JUnit5 with JUnit4 vintage support
+4. uses Java 8 (note that compress does not have to be build)
+
+Note that the one test __fails__ indicating the vulnerability! After replacing `commons-io:commons-io:2.6` by `commons-io:commons-io:2.7`
+the respective test passes, indicating that the vulnerability has been fixed.
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/pom.xml
+++ b/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>com.diamondq.common__common-thirdparty.jcasbin__1.4.0</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2021-29425 POV</description>
+    <name>CVE-2021-29425</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.diamondq.common</groupId>
+            <artifactId>common-thirdparty.jcasbin</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,4851 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2021-29425",
+    "groupID" : "foo",
+    "artifactID" : "com.diamondq.common__common-thirdparty.jcasbin__1.4.0",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:29:13.806565Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "common-thirdparty.jcasbin-1.4.0.jar (shaded: com.googlecode.aviator:aviator:4.1.2)",
+    "filePath" : "/home/wtwhite/.m2/repository/com/diamondq/common/common-thirdparty.jcasbin/1.4.0/common-thirdparty.jcasbin-1.4.0.jar/META-INF/maven/com.googlecode.aviator/aviator/pom.xml",
+    "md5" : "265c683cdbe007bce428f10913fbc631",
+    "sha1" : "b5948d2458588756133ba0f5516e098488e3f741",
+    "sha256" : "7f84390e730d242c5a635d2a031199cd9e9ef49da4c9d2f86c6987edf187011a",
+    "description" : "A lightweight,high performance expression evaluator for java",
+    "license" : "GNU LESSER GENERAL PUBLIC LICENSE: http://www.gnu.org/licenses/lgpl.html",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "aviator"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dennis zhuang"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.googlecode.aviator"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "aviator"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://code.google.com/p/aviator/"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "aviator"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dennis zhuang"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.googlecode.aviator"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "aviator"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://code.google.com/p/aviator/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "4.1.2"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.googlecode.aviator/aviator@4.1.2",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.googlecode.aviator/aviator@4.1.2?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "common-thirdparty.jcasbin-1.4.0.jar (shaded: commons-io:commons-io:2.6)",
+    "filePath" : "/home/wtwhite/.m2/repository/com/diamondq/common/common-thirdparty.jcasbin/1.4.0/common-thirdparty.jcasbin-1.4.0.jar/META-INF/maven/commons-io/commons-io/pom.xml",
+    "md5" : "142e515fa628cd8379aaac94ab237a8c",
+    "sha1" : "5060835593e5b6ed18c82fc2e782f0a3c30a00b1",
+    "sha256" : "0c23863893a2291f5a7afdbd8d15923b3948afd87e563fa341cdcf6eae338a60",
+    "description" : "\nThe Apache Commons IO library contains utility classes, stream implementations, file filters,\nfile comparators, endian transformation classes, and much more.\n  ",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-io"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "bayard@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "dion@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ggregory@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "jeremias@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "jochen.wiedmann@gmail.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "krosenvold@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "martinc@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "matth@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "nicolaken@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "roxspring@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sanders@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bayard"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "dion"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ggregory"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jeremias"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jochen"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jukka"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "krosenvold"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "martinc"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "matth"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "niallp"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "nicolaken"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "roxspring"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sanders"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "scolebourne"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dIon Gillard"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Gary Gregory"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Henri Yandell"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Jeremias Maerki"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Jochen Wiedmann"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Jukka Zitting"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Kristian Rosenvold"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Martin Cooper"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Matthew Hawthorne"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Niall Pemberton"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Nicola Ken Barozzi"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rob Oxspring"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Scott Sanders"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stephen Colebourne"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "commons-io"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons IO"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/proper/commons-io/"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-io"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "bayard@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "dion@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ggregory@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "jeremias@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "jochen.wiedmann@gmail.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "krosenvold@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "martinc@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "matth@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "nicolaken@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "roxspring@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sanders@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bayard"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "dion"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ggregory"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jeremias"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jochen"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jukka"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "krosenvold"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "martinc"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "matth"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "niallp"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "nicolaken"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "roxspring"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sanders"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "scolebourne"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dIon Gillard"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Gary Gregory"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Henri Yandell"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Jeremias Maerki"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Jochen Wiedmann"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Jukka Zitting"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Kristian Rosenvold"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Martin Cooper"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Matthew Hawthorne"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Niall Pemberton"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Nicola Ken Barozzi"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rob Oxspring"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Scott Sanders"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stephen Colebourne"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "commons-io"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons IO"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/proper/commons-io/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "2.6"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "2.6"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/commons-io/commons-io@2.6",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/commons-io/commons-io@2.6?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:apache:commons_io:2.6:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aapache&cpe_product=cpe%3A%2F%3Aapache%3Acommons_io&cpe_version=cpe%3A%2F%3Aapache%3Acommons_io%3A2.6"
+    } ],
+    "vulnerabilities" : [ {
+      "source" : "NVD",
+      "name" : "CVE-2021-29425",
+      "severity" : "MEDIUM",
+      "cvssv2" : {
+        "score" : 5.8,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "MEDIUM",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "PARTIAL",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "NONE",
+        "severity" : "MEDIUM",
+        "version" : "2.0",
+        "exploitabilityScore" : "8.6",
+        "impactScore" : "4.9"
+      },
+      "cvssv3" : {
+        "baseScore" : 4.8,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "HIGH",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "NONE",
+        "baseSeverity" : "MEDIUM",
+        "exploitabilityScore" : "2.2",
+        "impactScore" : "2.5",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-22" ],
+      "description" : "In Apache Commons IO before 2.7, When invoking the method FileNameUtils.normalize with an improper input string, like \"//../foo\", or \"\\\\..\\foo\", the result would be the same value, thus possibly providing access to files in the parent directory, but not further above (thus \"limited\" path traversal), if the calling code would use the result to construct a path value.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r20416f39ca7f7344e7d76fe4d7063bb1d91ad106926626e7e83fb346@%3Cnotifications.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-notifications] 20210825 [GitHub] [zookeeper] ztzg commented on pull request #1735: ZOOKEEPER-4343: Bump commons-io to version 2.11 (avoids CVE-2021-29425)"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r462db908acc1e37c455e11b1a25992b81efd18e641e7e0ceb1b6e046@%3Cnotifications.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-notifications] 20210901 [GitHub] [zookeeper] ztzg closed pull request #1735: ZOOKEEPER-4343: Bump commons-io to version 2.11 (avoids CVE-2021-29425)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/raa053846cae9d497606027816ae87b4e002b2e0eb66cb0dee710e1f5@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20210427 [jira] [Created] (RAT-281) Update commons-io to fix CVE-2021-29425 Moderate severity"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rbebd3e19651baa7a4a5503a9901c95989df9d40602c8e35cb05d3eb5@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20210518 [jira] [Assigned] (WHISKER-19) Update commons-io to fix CVE-2021-29425"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r0bfa8f7921abdfae788b1f076a12f73a92c93cc0a6e1083bce0027c5@%3Cnotifications.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-notifications] 20210825 [GitHub] [zookeeper] ztzg edited a comment on pull request #1735: ZOOKEEPER-4343: Bump commons-io to version 2.11 (avoids CVE-2021-29425)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfd01af05babc95b8949e6d8ea78d9834699e1b06981040dde419a330@%3Cdev.commons.apache.org%3E",
+        "name" : "[commons-dev] 20210414 Re: [all] OSS Fuzz"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r8569a41d565ca880a4dee0e645dad1cd17ab4a92e68055ad9ebb7375@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20210427 [jira] [Commented] (RAT-281) Update commons-io to fix CVE-2021-29425 Moderate severity"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rc65f9bc679feffe4589ea0981ee98bc0af9139470f077a91580eeee0@%3Cpluto-dev.portals.apache.org%3E",
+        "name" : "[portals-pluto-dev] 20210714 [jira] [Closed] (PLUTO-789) Upgrade to commons-io-2.7 due to CVE-2021-29425"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/apache/commons-io/pull/52",
+        "name" : "https://github.com/apache/commons-io/pull/52"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r5149f78be265be69d34eacb4e4b0fc7c9c697bcdfa91a1c1658d717b@%3Cissues.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-issues] 20210901 [jira] [Resolved] (ZOOKEEPER-4343) OWASP Dependency-Check fails with CVE-2021-29425, commons-io-2.6"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfcd2c649c205f12b72dde044f905903460669a220a2eb7e12652d19d@%3Cdev.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-dev] 20210805 [jira] [Created] (ZOOKEEPER-4343) OWASP Dependency-Check fails with CVE-2021-29425, commons-io-2.6"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r86528f4b7d222aed7891e7ac03d69a0db2a2dfa17b86ac3470d7f374@%3Cnotifications.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-notifications] 20210825 [GitHub] [zookeeper] ztzg commented on a change in pull request #1735: ZOOKEEPER-4343: Bump commons-io to version 2.11 (avoids CVE-2021-29425)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r4050f9f6b42ebfa47a98cbdee4aabed4bb5fb8093db7dbb88faceba2@%3Ccommits.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-commits] 20210901 [zookeeper] branch master updated: ZOOKEEPER-4343: Bump commons-io to version 2.11 (avoids CVE-2021-29425)"
+      }, {
+        "source" : "CONFIRM",
+        "url" : "https://security.netapp.com/advisory/ntap-20220210-0004/",
+        "name" : "https://security.netapp.com/advisory/ntap-20220210-0004/"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.debian.org/debian-lts-announce/2021/08/msg00016.html",
+        "name" : "[debian-lts-announce] 20210812 [SECURITY] [DLA 2741-1] commons-io security update"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r2721aba31a8562639c4b937150897e24f78f747cdbda8641c0f659fe@%3Cusers.kafka.apache.org%3E",
+        "name" : "[kafka-users] 20210617 vulnerabilities"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r8bfc7235e6b39d90e6f446325a5a44c3e9e50da18860fdabcee23e29@%3Cissues.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-issues] 20210805 [jira] [Updated] (ZOOKEEPER-4343) OWASP Dependency-Check fails with CVE-2021-29425, commons-io-2.6"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r01b4a1fcdf3311c936ce33d75a9398b6c255f00c1a2f312ac21effe1@%3Cnotifications.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-notifications] 20210816 [GitHub] [zookeeper] nkalmar edited a comment on pull request #1735: ZOOKEEPER-4343: Bump commons-io to version 2.11 (avoids CVE-2021-29425)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/re41e9967bee064e7369411c28f0f5b2ad28b8334907c9c6208017279@%3Cnotifications.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-notifications] 20210813 [GitHub] [zookeeper] eolivelli commented on pull request #1735: ZOOKEEPER-4343: Bump commons-io to version 2.11 (avoids CVE-2021-29425)"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://issues.apache.org/jira/browse/IO-556",
+        "name" : "https://issues.apache.org/jira/browse/IO-556"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r92ea904f4bae190b03bd42a4355ce3c2fbe8f36ab673e03f6ca3f9fa@%3Cnotifications.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-notifications] 20210805 [GitHub] [zookeeper] ztzg opened a new pull request #1735: ZOOKEEPER-4343: Bump commons-io to version 2.7 (avoids CVE-2021-29425)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r477c285126ada5c3b47946bb702cb222ac4e7fd3100c8549bdd6d3b2@%3Cissues.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-issues] 20210805 [jira] [Created] (ZOOKEEPER-4343) OWASP Dependency-Check fails with CVE-2021-29425, commons-io-2.6"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r2345b49dbffa8a5c3c589c082fe39228a2c1d14f11b96c523da701db@%3Cnotifications.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-notifications] 20210805 [GitHub] [zookeeper] ztzg commented on pull request #1735: ZOOKEEPER-4343: Bump commons-io to version 2.7 (avoids CVE-2021-29425)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rca71a10ca533eb9bfac2d590533f02e6fb9064d3b6aa3ec90fdc4f51@%3Cnotifications.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-notifications] 20210813 [GitHub] [zookeeper] ztzg commented on pull request #1735: ZOOKEEPER-4343: Bump commons-io to version 2.11 (avoids CVE-2021-29425)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r345330b7858304938b7b8029d02537a116d75265a598c98fa333504a@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20210621 [jira] [Commented] (RAT-281) Update commons-io to fix CVE-2021-29425 Moderate severity"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/red3aea910403d8620c73e1c7b9c9b145798d0469eb3298a7be7891af@%3Cnotifications.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-notifications] 20210816 [GitHub] [zookeeper] nkalmar commented on pull request #1735: ZOOKEEPER-4343: Bump commons-io to version 2.11 (avoids CVE-2021-29425)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r2df50af2641d38f432ef025cd2ba5858215cc0cf3fc10396a674ad2e@%3Cpluto-scm.portals.apache.org%3E",
+        "name" : "[portals-pluto-scm] 20210714 [portals-pluto] branch master updated: PLUTO-789 Upgrade to commons-io-2.7 due to CVE-2021-29425"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rad4ae544747df32ccd58fff5a86cd556640396aeb161aa71dd3d192a@%3Cuser.commons.apache.org%3E",
+        "name" : "[commons-user] 20210709 commons-fileupload dependency and CVE"
+      }, {
+        "source" : "MISC",
+        "url" : "https://issues.apache.org/jira/browse/IO-556",
+        "name" : "https://issues.apache.org/jira/browse/IO-556"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2021-29425?component-type=maven&component-name=commons-io%2Fcommons-io&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2021-29425] CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+      }, {
+        "source" : "MISC",
+        "url" : "https://lists.apache.org/thread.html/rc359823b5500e9a9a2572678ddb8e01d3505a7ffcadfa8d13b8780ab%40%3Cuser.commons.apache.org%3E",
+        "name" : "https://lists.apache.org/thread.html/rc359823b5500e9a9a2572678ddb8e01d3505a7ffcadfa8d13b8780ab%40%3Cuser.commons.apache.org%3E"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rc5f3df5316c5237b78a3dff5ab95b311ad08e61d418cd992ca7e34ae@%3Cnotifications.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-notifications] 20210825 [GitHub] [zookeeper] eolivelli commented on pull request #1735: ZOOKEEPER-4343: Bump commons-io to version 2.11 (avoids CVE-2021-29425)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rc2dd3204260e9227a67253ef68b6f1599446005bfa0e1ddce4573a80@%3Cpluto-dev.portals.apache.org%3E",
+        "name" : "[portals-pluto-dev] 20210714 [jira] [Created] (PLUTO-789) Upgrade to commons-io-2.7 due to CVE-2021-29425"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r8efcbabde973ea72f5e0933adc48ef1425db5cde850bf641b3993f31@%3Cdev.commons.apache.org%3E",
+        "name" : "[commons-dev] 20210415 Re: [all] OSS Fuzz"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r2bc986a070457daca457a54fe71ee09d2584c24dc262336ca32b6a19@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20210518 [jira] [Updated] (WHISKER-19) Update commons-io to fix CVE-2021-29425"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r523a6ffad58f71c4f3761e3cee72df878e48cdc89ebdce933be1475c@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20210518 [jira] [Commented] (WHISKER-19) Update commons-io to fix CVE-2021-29425"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r808be7d93b17a7055c1981a8453ae5f0d0fce5855407793c5d0ffffa@%3Cuser.commons.apache.org%3E",
+        "name" : "[commons-user] 20210709 Re: commons-fileupload dependency and CVE"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://issues.apache.org/jira/browse/IO-559",
+        "name" : "https://issues.apache.org/jira/browse/IO-559"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r47ab6f68cbba8e730f42c4ea752f3a44eb95fb09064070f2476bb401@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20210427 [jira] [Closed] (RAT-281) Update commons-io to fix CVE-2021-29425 Moderate severity"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r27b1eedda37468256c4bb768fde1e8b79b37ec975cbbfd0d65a7ac34@%3Cdev.myfaces.apache.org%3E",
+        "name" : "[myfaces-dev] 20210504 [GitHub] [myfaces-tobago] lofwyr14 opened a new pull request #808: build: CVE fix"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rfa2f08b7c0caf80ca9f4a18bd875918fdd4e894e2ea47942a4589b9c@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20210427 [jira] [Updated] (RAT-281) Update commons-io to fix CVE-2021-29425 Moderate severity"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r0d73e2071d1f1afe1a15da14c5b6feb2cf17e3871168d5a3c8451436@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210420 [GitHub] [pulsar] merlimat merged pull request #10287: [Security] Upgrade commons-io to address CVE-2021-29425"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r873d5ddafc0a68fd999725e559776dc4971d1ab39c0f5cc81bd9bc04@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210420 [GitHub] [pulsar] lhotari opened a new pull request #10287: [Security] Upgrade commons-io to address CVE-2021-29425"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r1c2f4683c35696cf6f863e3c107e37ec41305b1930dd40c17260de71@%3Ccommits.pulsar.apache.org%3E",
+        "name" : "[pulsar-commits] 20210429 [pulsar] branch branch-2.7 updated: [Security] Upgrade commons-io to address CVE-2021-29425 (#10287)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ra8ef65aedc086d2d3d21492b4c08ae0eb8a3a42cc52e29ba1bc009d8@%3Cdev.creadur.apache.org%3E",
+        "name" : "[creadur-dev] 20210518 [jira] [Created] (WHISKER-19) Update commons-io to fix CVE-2021-29425"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd09d4ab3e32e4b3a480e2ff6ff118712981ca82e817f28f2a85652a6@%3Cnotifications.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-notifications] 20210813 [GitHub] [zookeeper] eolivelli commented on a change in pull request #1735: ZOOKEEPER-4343: Bump commons-io to version 2.11 (avoids CVE-2021-29425)"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rc10fa20ef4d13cbf6ebe0b06b5edb95466a1424a9b7673074ed03260@%3Cnotifications.zookeeper.apache.org%3E",
+        "name" : "[zookeeper-notifications] 20210806 [GitHub] [zookeeper] nkalmar commented on pull request #1735: ZOOKEEPER-4343: Bump commons-io to version 2.7 (avoids CVE-2021-29425)"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_io:2.2:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_io:2.3:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_io:2.4:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_io:2.5:-:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_io:2.6:-:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:linux:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:access_manager:11.1.2.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:access_manager:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:access_manager:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:agile_engineering_data_management:6.2.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:agile_plm:9.3.6:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:application_performance_management:13.4.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:application_performance_management:13.5.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:application_testing_suite:13.3.0.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:18.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:18.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:18.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_apis:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:17.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:18.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:18.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:19.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:20.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_digital_experience:21.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.6.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.7.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.10.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_management:2.12.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_enterprise_default_managment:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "2.3.0",
+          "versionEndIncluding" : "2.4.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_party_management:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "2.3.0",
+          "versionEndIncluding" : "2.4.1"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.6.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.7.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.7.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:blockchain_platform:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "21.1.2"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:commerce_guided_search:11.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_application_session_controller:3.9.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management_elastic_charging_engine:11.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management_elastic_charging_engine:12.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_network_repository_function:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_policy:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_contacts_server:8.0.0.6.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_converged_application_server_-_service_controller:6.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_convergence:3.0.2.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_design_studio:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "7.4.0",
+          "versionEndIncluding" : "7.4.2"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_design_studio:7.3.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.0",
+          "versionEndIncluding" : "8.1.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_diameter_intelligence_hub:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.2.0",
+          "versionEndIncluding" : "8.2.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_interactive_session_recorder:6.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_interactive_session_recorder:6.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_offline_mediation_controller:12.0.0.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_order_and_service_management:7.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_order_and_service_management:7.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_policy_management:12.5.0.0.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_pricing_design_center:12.0.0.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_pricing_design_center:12.0.0.5.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_service_broker:6.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:enterprise_communications_broker:3.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:enterprise_session_border_controller:8.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:enterprise_session_border_controller:9.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_analytical_applications_infrastructure:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.7",
+          "versionEndIncluding" : "8.1.1"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_model_management_and_governance:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "8.0.8",
+          "versionEndIncluding" : "8.1.1"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_core_banking:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "11.6.0",
+          "versionEndIncluding" : "11.8.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_core_banking:5.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_core_banking:11.10.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:fusion_middleware_mapviewer:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:health_sciences_data_management_workbench:2.5.2.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:health_sciences_data_management_workbench:3.0.0.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:health_sciences_information_manager:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "3.0.1",
+          "versionEndIncluding" : "3.0.4"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_data_repository:8.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:helidon:1.4.7:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:helidon:2.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_policy_administration:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_rules_palette:11.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_rules_palette:11.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_rules_palette:11.2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_rules_palette:11.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_rules_palette:11.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:oss_support_tools:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "2.12.42"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.7",
+          "versionEndIncluding" : "17.12"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:18.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:19.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:20.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_unifier:21.12:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:real_user_experience_insight:13.4.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:real_user_experience_insight:13.5.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:rest_data_services:*:*:*:*:-:*:*:*",
+          "versionEndExcluding" : "21.2"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:rest_data_services:21.3:*:*:*:-:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_assortment_planning:16.0.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_integration_bus:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "16.0.1",
+          "versionEndIncluding" : "16.0.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_integration_bus:13.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_integration_bus:14.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_integration_bus:14.1.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_integration_bus:15.0.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_integration_bus:19.0.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_integration_bus:19.0.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_merchandising_system:16.0.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_merchandising_system:19.0.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_order_broker:16.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_order_broker:18.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_order_broker:19.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_pricing:19.0.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_service_backbone:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "16.0.1",
+          "versionEndIncluding" : "16.0.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_service_backbone:14.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_service_backbone:14.1.3.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_service_backbone:15.0.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_service_backbone:19.0.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_service_backbone:19.0.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_size_profile_optimization:16.0.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_xstore_point_of_service:17.0.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_xstore_point_of_service:18.0.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_xstore_point_of_service:19.0.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_xstore_point_of_service:20.0.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:solaris_cluster:4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.1.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_testing_accelerator:6.0.0.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:webcenter_portal:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:12.1.3.0.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:14.1.1.0.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "common-thirdparty.jcasbin-1.4.0.jar (shaded: org.casbin:jcasbin:1.4.0)",
+    "filePath" : "/home/wtwhite/.m2/repository/com/diamondq/common/common-thirdparty.jcasbin/1.4.0/common-thirdparty.jcasbin-1.4.0.jar/META-INF/maven/org.casbin/jcasbin/pom.xml",
+    "md5" : "b2703a86c1071718619141ab6fd78e3b",
+    "sha1" : "978e7fe7d73a5d60f6b550642e15ff93f62a2bba",
+    "sha256" : "99055bae03b8c31416a1668398adebb48ca6ea84bf2a9fff8e93598a58d577d7",
+    "description" : "An authorization library that supports access control models like ACL, RBAC, ABAC in Java",
+    "license" : "The Apache Software License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "jcasbin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "hsluoyz@qq.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Yang Luo"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.casbin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "JCasbin Authorization Library"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://casbin.org/"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "jcasbin"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "hsluoyz@qq.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Yang Luo"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.casbin"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "JCasbin Authorization Library"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://casbin.org/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.4.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.casbin/jcasbin@1.4.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.casbin/jcasbin@1.4.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "common-thirdparty.jcasbin-1.4.0.jar (shaded: org.slf4j:slf4j-api:1.7.25)",
+    "filePath" : "/home/wtwhite/.m2/repository/com/diamondq/common/common-thirdparty.jcasbin/1.4.0/common-thirdparty.jcasbin-1.4.0.jar/META-INF/maven/org.slf4j/slf4j-api/pom.xml",
+    "md5" : "53f7013d37871f9bc0445619999c09bf",
+    "sha1" : "df51c4a85dd6acf8b6cdc9323596766b3d577c28",
+    "sha256" : "7cd9d7a0b5d93dfd461a148891b43509cf403a9c7f9fb49060d3554df1c81e1e",
+    "description" : "The slf4j API",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "slf4j-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.slf4j"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "SLF4J API Module"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "slf4j-parent"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://www.slf4j.org"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "slf4j-api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "org.slf4j"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "SLF4J API Module"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "slf4j-parent"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://www.slf4j.org"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.7.25"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/org.slf4j/slf4j-api@1.7.25",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/org.slf4j/slf4j-api@1.7.25?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "common-thirdparty.jcasbin-1.4.0.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/com/diamondq/common/common-thirdparty.jcasbin/1.4.0/common-thirdparty.jcasbin-1.4.0.jar",
+    "md5" : "2a12b426934f7631d2dd60de670a5e60",
+    "sha1" : "99bf64c75d7f6c36f7c0c019f5f8819a09bb46a8",
+    "sha256" : "813296c9f05500e7e7ba9170ce1825f26fd09d36d7198039f8e4571f49f7bbd0",
+    "description" : "OSGi Wrapper of jcasbin",
+    "license" : "The Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/com.diamondq.common__common-thirdparty.jcasbin__1.4.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "common-thirdparty.jcasbin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "jcasbin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "com.diamondq.common.thirdparty.jcasbin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "common-thirdparty.jcasbin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "common-thirdparty.jcasbin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "code@michaelmansell.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "mmansell"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Mike Mansell"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "DiamondQ"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org URL",
+        "value" : "http://www.diamondq.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.diamondq.common"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "DiamondQ Common: Third Party: jcasbin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://www.diamondq.com/common-thirdparty.jcasbin"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "common-thirdparty.jcasbin"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "jcasbin"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "DiamondQ Common: Third Party: jcasbin"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "com.diamondq.common.thirdparty.jcasbin"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "common-thirdparty.jcasbin"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "code@michaelmansell.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "mmansell"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Mike Mansell"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "DiamondQ"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org URL",
+        "value" : "http://www.diamondq.com"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.diamondq.common"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "DiamondQ Common: Third Party: jcasbin"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://www.diamondq.com/common-thirdparty.jcasbin"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.4.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Bundle-Version",
+        "value" : "1.4.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.4.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.diamondq.common/common-thirdparty.jcasbin@1.4.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.diamondq.common/common-thirdparty.jcasbin@1.4.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "commons-beanutils-1.9.3.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/commons-beanutils/commons-beanutils/1.9.3/commons-beanutils-1.9.3.jar",
+    "md5" : "4a105c9d029a7edc6f2b16567d37eab6",
+    "sha1" : "c845703de334ddc6b4b3cd26835458cb1cba1f3d",
+    "sha256" : "c058e39c7c64203d3a448f3adb588cb03d6378ed808485618f26e137f29dae73",
+    "description" : "Apache Commons BeanUtils provides an easy-to-use but flexible wrapper around reflection and introspection.",
+    "license" : "https://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/com.diamondq.common/common-thirdparty.jcasbin@1.4.0"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "commons-beanutils"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "beanutils"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "https://commons.apache.org/proper/commons-beanutils/"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "org.apache.commons.beanutils"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "implementation-build",
+        "value" : "tags/BEANUTILS_1_9_3_RC3@r1761785; 2016-09-21 16:19:55+0000"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "implementation-url",
+        "value" : "https://commons.apache.org/proper/commons-beanutils/"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Vendor",
+        "value" : "The Apache Software Foundation"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Implementation-Vendor-Id",
+        "value" : "org.apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "specification-vendor",
+        "value" : "The Apache Software Foundation"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-beanutils"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-beanutils"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "britter@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "craigmcc@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "dion@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "epugh@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "geirm@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ggregory@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "jcarman@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "jconlon@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "jstrachan@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "morgand@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "mvdb@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "niallp@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rdonkin@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rwaldhoff@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sanders@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "scolebourne@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "skitching@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "stain@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tobrien@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "yoavs@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "britter"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "craigmcc"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "dion"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "epugh"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "geirm"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ggregory"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jcarman"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jconlon"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jstrachan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "morgand"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "mvdb"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "niallp"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rdonkin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rwaldhoff"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sanders"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "scolebourne"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "skitching"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "stain"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tobrien"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "yoavs"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Benedikt Ritter"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Craig McClanahan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "David Eric Pugh"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Dion Gillard"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Gary Gregory"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Geir Magnusson Jr."
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "James Carman"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "James Strachan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "John E. Conlon"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Martin van den Bemt"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Morgan James Delagrange"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Niall Pemberton"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Robert Burrell Donkin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rodney Waldhoff"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Scott Sanders"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Simon Kitching"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stephen Colebourne"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stian Soiland-Reyes"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Tim O'Brien"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Yoav Shapira"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "The Apache Software Foundation"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "commons-beanutils"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons BeanUtils"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://commons.apache.org/proper/commons-beanutils/"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "commons-beanutils"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "beanutils"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "https://commons.apache.org/proper/commons-beanutils/"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "Apache Commons BeanUtils"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "org.apache.commons.beanutils"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "implementation-build",
+        "value" : "tags/BEANUTILS_1_9_3_RC3@r1761785; 2016-09-21 16:19:55+0000"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Title",
+        "value" : "Apache Commons BeanUtils"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "implementation-url",
+        "value" : "https://commons.apache.org/proper/commons-beanutils/"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "specification-title",
+        "value" : "Apache Commons BeanUtils"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-beanutils"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "britter@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "craigmcc@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "dion@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "epugh@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "geirm@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "ggregory@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "jcarman@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "jconlon@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "jstrachan@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "morgand@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "mvdb@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "niallp@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rdonkin@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rwaldhoff@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sanders@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "scolebourne@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "skitching@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "stain@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tobrien@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "yoavs@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "britter"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "craigmcc"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "dion"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "epugh"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "geirm"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "ggregory"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jcarman"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jconlon"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jstrachan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "morgand"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "mvdb"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "niallp"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rdonkin"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rwaldhoff"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sanders"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "scolebourne"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "skitching"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "stain"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tobrien"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "yoavs"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Benedikt Ritter"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Craig McClanahan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "David Eric Pugh"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Dion Gillard"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Gary Gregory"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Geir Magnusson Jr."
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "James Carman"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "James Strachan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "John E. Conlon"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Martin van den Bemt"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Morgan James Delagrange"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Niall Pemberton"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Robert Burrell Donkin"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rodney Waldhoff"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Scott Sanders"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Simon Kitching"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stephen Colebourne"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stian Soiland-Reyes"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Tim O'Brien"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Yoav Shapira"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "The Apache Software Foundation"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "commons-beanutils"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons BeanUtils"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://commons.apache.org/proper/commons-beanutils/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.9.3"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Bundle-Version",
+        "value" : "1.9.3"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Version",
+        "value" : "1.9.3"
+      }, {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "1.9.3"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.9.3"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/commons-beanutils/commons-beanutils@1.9.3",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/commons-beanutils/commons-beanutils@1.9.3?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:apache:commons_beanutils:1.9.3:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aapache&cpe_product=cpe%3A%2F%3Aapache%3Acommons_beanutils&cpe_version=cpe%3A%2F%3Aapache%3Acommons_beanutils%3A1.9.3"
+    } ],
+    "vulnerabilities" : [ {
+      "source" : "OSSINDEX",
+      "name" : "CVE-2014-0114",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 7.5,
+        "accessVector" : "N",
+        "accessComplexity" : "L",
+        "authenticationr" : "N",
+        "confidentialImpact" : "P",
+        "integrityImpact" : "P",
+        "availabilityImpact" : "P",
+        "severity" : "HIGH"
+      },
+      "cwes" : [ "CWE-20" ],
+      "description" : "Apache Commons BeanUtils, as distributed in lib/commons-beanutils-1.8.0.jar in Apache Struts 1.x through 1.3.10 and in other products requiring commons-beanutils through 1.9.2, does not suppress the class property, which allows remote attackers to \"manipulate\" the ClassLoader and execute arbitrary code via the class parameter, as demonstrated by the passing of this parameter to the getClass method of the ActionForm object in Struts 1.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0114",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0114"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://www.rapid7.com/db/modules/exploit/multi/http/struts_code_exec_classloader",
+        "name" : "http://www.rapid7.com/db/modules/exploit/multi/http/struts_code_exec_classloader"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2014-0114?component-type=maven&component-name=commons-beanutils%2Fcommons-beanutils&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2014-0114] CWE-20: Improper Input Validation"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://issues.apache.org/jira/browse/BEANUTILS-463",
+        "name" : "https://issues.apache.org/jira/browse/BEANUTILS-463"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:commons-beanutils:commons-beanutils:1.9.3:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true"
+        }
+      } ]
+    }, {
+      "source" : "NVD",
+      "name" : "CVE-2019-10086",
+      "severity" : "HIGH",
+      "cvssv2" : {
+        "score" : 7.5,
+        "accessVector" : "NETWORK",
+        "accessComplexity" : "LOW",
+        "authenticationr" : "NONE",
+        "confidentialImpact" : "PARTIAL",
+        "integrityImpact" : "PARTIAL",
+        "availabilityImpact" : "PARTIAL",
+        "severity" : "HIGH",
+        "version" : "2.0",
+        "exploitabilityScore" : "10.0",
+        "impactScore" : "6.4"
+      },
+      "cvssv3" : {
+        "baseScore" : 7.3,
+        "attackVector" : "NETWORK",
+        "attackComplexity" : "LOW",
+        "privilegesRequired" : "NONE",
+        "userInteraction" : "NONE",
+        "scope" : "UNCHANGED",
+        "confidentialityImpact" : "LOW",
+        "integrityImpact" : "LOW",
+        "availabilityImpact" : "LOW",
+        "baseSeverity" : "HIGH",
+        "exploitabilityScore" : "3.9",
+        "impactScore" : "3.4",
+        "version" : "3.1"
+      },
+      "cwes" : [ "CWE-502" ],
+      "description" : "In Apache Commons Beanutils 1.9.2, a special BeanIntrospector class was added which allows suppressing the ability for an attacker to access the classloader via the class property available on all Java objects. We, however were not using this by default characteristic of the PropertyUtilsBean.",
+      "notes" : "",
+      "references" : [ {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/re2028d4d76ba1db3e3c3a722d6c6034e801cc3b309f69cc166eaa32b@%3Ccommits.nifi.apache.org%3E",
+        "name" : "[nifi-commits] 20210907 [nifi] branch main updated: NIFI-9170 Upgrade commons-beanutils to 1.9.4 to mitigate CVE-2019-10086 NIFI-9170 Add two more 1.9.4 references to close out the few things identified by the Maven dependency plugin."
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2021.html"
+      }, {
+        "source" : "FEDORA",
+        "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/JIUYSL2RSIWZVNSUIXJTIFPIPIF6OAIO/",
+        "name" : "FEDORA-2019-79b5790566"
+      }, {
+        "source" : "REDHAT",
+        "url" : "https://access.redhat.com/errata/RHSA-2020:0805",
+        "name" : "RHSA-2020:0805"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r6194ced4828deb32023cd314e31f41c61d388b58935d102c7de91f58@%3Cdev.atlas.apache.org%3E",
+        "name" : "[atlas-dev] 20201023 [jira] [Commented] (ATLAS-4002) Upgrade commons-beanutils to 1.9.4 due to CVE-2019-10086"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpuapr2020.html",
+        "name" : "N/A"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r2d5f1d88c39bd615271abda63964a0bee9b2b57fef1f84cb4c43032e@%3Cissues.nifi.apache.org%3E",
+        "name" : "[nifi-issues] 20210907 [GitHub] [nifi] MikeThomsen commented on pull request #5351: NIFI-9170 Upgrade commons-beanutils to 1.9.4 to mitigate CVE-2019-10086"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rae81e0c8ebdf47ffaa85a01240836bfece8a990c48f55c7933162b5c@%3Cdev.atlas.apache.org%3E",
+        "name" : "[atlas-dev] 20201022 [jira] [Created] (ATLAS-4002) Upgrade commons-beanutils to 1.9.4 due to CVE-2019-10086"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ra41fd0ad4b7e1d675c03a5081a16a6603085a4e37d30b866067566fe@%3Cissues.nifi.apache.org%3E",
+        "name" : "[nifi-issues] 20210907 [GitHub] [nifi] asfgit closed pull request #5351: NIFI-9170 Upgrade commons-beanutils to 1.9.4 to mitigate CVE-2019-10086"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2022.html",
+        "name" : "N/A"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/a684107d3a78e431cf0fbb90629e8559a36ff8fe94c3a76e620b39fa@%3Cdev.shiro.apache.org%3E",
+        "name" : "[shiro-dev] 20191105 [jira] [Resolved] (SHIRO-723) Provide Minor Shiro Release that includes CVE-2019-10086 Fix"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/956995acee0d8bc046f1df0a55b7fbeb65dd2f82864e5de1078bacb0@%3Cissues.commons.apache.org%3E",
+        "name" : "[commons-issues] 20190906 [jira] [Updated] (CONFIGURATION-755) [CVE-2014-0114] Update Apache Commons BeanUtils from 1.9.3 to 1.9.4."
+      }, {
+        "source" : "MLIST",
+        "url" : "http://mail-archives.apache.org/mod_mbox/www-announce/201908.mbox/%3cC628798F-315D-4428-8CB1-4ED1ECC958E4@apache.org%3e",
+        "name" : "[www-announce] 20190815 [SECURITY] CVE-2019-10086. Apache Commons Beanutils does not suppresses the class property in PropertyUtilsBean by default."
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/d6ca9439c53374b597f33b7ec180001625597db48ea30356af01145f@%3Cdev.shiro.apache.org%3E",
+        "name" : "[shiro-dev] 20191001 [jira] [Updated] (SHIRO-723) Provide Minor Shiro Release that includes CVE-2019-10086 Fix"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/reee57101464cf7622d640ae013b2162eb864f603ec4093de8240bb8f@%3Cdev.atlas.apache.org%3E",
+        "name" : "[atlas-dev] 20201022 Re: Review Request 72983: ATLAS-4002 : Upgrade commons-beanutils to 1.9.4 due to CVE-2019-10086"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuApr2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuApr2021.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r306c0322aa5c0da731e03f3ce9f07f4745c052c6b73f4e78faf232ca@%3Cdev.atlas.apache.org%3E",
+        "name" : "[atlas-dev] 20201026 [jira] [Updated] (ATLAS-4002) Upgrade commons-beanutils to 1.9.4 due to CVE-2019-10086"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r46e536fc98942dce99fadd2e313aeefe90c1a769c5cd85d98df9d098@%3Cissues.nifi.apache.org%3E",
+        "name" : "[nifi-issues] 20210827 [GitHub] [nifi] naddym opened a new pull request #5351: NIFI-9170 Upgrade commons-beanutils to 1.9.4 to mitigate CVE-2019-10086"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rec74f3a94dd850259c730b4ba6f7b6211222b58900ec088754aa0534@%3Cissues.nifi.apache.org%3E",
+        "name" : "[nifi-issues] 20210827 [jira] [Created] (NIFI-9170) Upgrade commons-beanutils to 1.9.4 to mitigate CVE-2019-10086"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-10086",
+        "name" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-10086"
+      }, {
+        "source" : "OSSINDEX",
+        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2019-10086?component-type=maven&component-name=commons-beanutils%2Fcommons-beanutils&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1",
+        "name" : "[CVE-2019-10086] CWE-502: Deserialization of Untrusted Data"
+      }, {
+        "source" : "REDHAT",
+        "url" : "https://access.redhat.com/errata/RHSA-2020:0811",
+        "name" : "RHSA-2020:0811"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E",
+        "name" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2022.html"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujul2020.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujul2020.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/re3cd7cb641d7fc6684e4fc3c336a8bad4a01434bb5625a06e3600fd1@%3Cissues.nifi.apache.org%3E",
+        "name" : "[nifi-issues] 20210907 [jira] [Commented] (NIFI-9170) Upgrade commons-beanutils to 1.9.4 to mitigate CVE-2019-10086"
+      }, {
+        "source" : "OSSIndex",
+        "url" : "https://github.com/apache/commons-beanutils/pull/7",
+        "name" : "https://github.com/apache/commons-beanutils/pull/7"
+      }, {
+        "source" : "SUSE",
+        "url" : "http://lists.opensuse.org/opensuse-security-announce/2019-09/msg00007.html",
+        "name" : "openSUSE-SU-2019:2058"
+      }, {
+        "source" : "REDHAT",
+        "url" : "https://access.redhat.com/errata/RHSA-2020:0057",
+        "name" : "RHSA-2020:0057"
+      }, {
+        "source" : "REDHAT",
+        "url" : "https://access.redhat.com/errata/RHSA-2020:0804",
+        "name" : "RHSA-2020:0804"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r513a7a21c422170318115463b399dd58ab447fe0990b13e5884f0825@%3Ccommits.dolphinscheduler.apache.org%3E",
+        "name" : "[dolphinscheduler-commits] 20210121 [GitHub] [incubator-dolphinscheduler] lgcareer commented on pull request #4525: [Improvement-4506][LICENSE] upgrade the version of the commons-beanutils"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/02094ad226dbc17a2368beaf27e61d8b1432f5baf77d0ca995bb78bc@%3Cissues.commons.apache.org%3E",
+        "name" : "[commons-issues] 20190925 [GitHub] [commons-validator] jeff-schram opened a new pull request #18: Update pom.xml"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r43de02fd4a4f52c4bdeff8c02f09625d83cd047498009c1cdab857db@%3Cdev.rocketmq.apache.org%3E",
+        "name" : "[rocketmq-dev] 20201223 [GitHub] [rocketmq] crazywen opened a new pull request #2515: Update pom.xml"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/1f78f1e32cc5614ec0c5b822ba4bd7fc8e8b5c46c8e038b6bd609cb5@%3Cissues.commons.apache.org%3E",
+        "name" : "[commons-issues] 20190906 [jira] [Closed] (CONFIGURATION-755) [CVE-2014-0114] Update Apache Commons BeanUtils from 1.9.3 to 1.9.4."
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb8dac04cb7e9cc5dedee8dabaa1c92614f590642e5ebf02a145915ba@%3Ccommits.atlas.apache.org%3E",
+        "name" : "[atlas-commits] 20201023 [atlas] 01/05: ATLAS-4002 : Upgrade commons-beanutils to 1.9.4 due to CVE-2019-10086"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ra87ac17410a62e813cba901fdd4e9a674dd53daaf714870f28e905f1@%3Cdev.atlas.apache.org%3E",
+        "name" : "[atlas-dev] 20201023 [jira] [Updated] (ATLAS-4002) Upgrade commons-beanutils to 1.9.4 due to CVE-2019-10086"
+      }, {
+        "source" : "REDHAT",
+        "url" : "https://access.redhat.com/errata/RHSA-2020:0806",
+        "name" : "RHSA-2020:0806"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/c94bc9649d5109a663b2129371dc45753fbdeacd340105548bbe93c3@%3Cdev.shiro.apache.org%3E",
+        "name" : "[shiro-dev] 20191001 [jira] [Commented] (SHIRO-723) Provide Minor Shiro Release that includes CVE-2019-10086 Fix"
+      }, {
+        "source" : "N/A",
+        "url" : "https://www.oracle.com//security-alerts/cpujul2021.html",
+        "name" : "N/A"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+        "name" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r967953a14e05016bc4bcae9ef3dd92e770181158b4246976ed8295c9@%3Cdev.brooklyn.apache.org%3E",
+        "name" : "[brooklyn-dev] 20200420 [GitHub] [brooklyn-server] duncangrant opened a new pull request #1091: Update library versions due to CVEs"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/3d1ed1a1596c08c4d5fea97b36c651ce167b773f1afc75251ce7a125@%3Ccommits.tinkerpop.apache.org%3E",
+        "name" : "[tinkerpop-commits] 20190829 [tinkerpop] branch master updated: Bump commons-beanutils to 1.9.4 for CVE-2019-10086 - CTR"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/racd3e7b2149fa2f255f016bd6bffab0fea77b6fb81c50db9a17f78e6@%3Cdev.atlas.apache.org%3E",
+        "name" : "[atlas-dev] 20201023 [jira] [Commented] (ATLAS-4002) Upgrade commons-beanutils to 1.9.4 due to CVE-2019-10086"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rb1f76c2c0a4d6efb8a3523974f9d085d5838b73e7bffdf9a8f212997@%3Cissues.nifi.apache.org%3E",
+        "name" : "[nifi-issues] 20210915 [jira] [Updated] (NIFI-9170) Upgrade commons-beanutils to 1.9.4 to mitigate CVE-2019-10086"
+      }, {
+        "source" : "REDHAT",
+        "url" : "https://access.redhat.com/errata/RHSA-2020:0194",
+        "name" : "RHSA-2020:0194"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/5261066cd7adee081ee05c8bf0e96cf0b2eeaced391e19117ae4daa6@%3Cdev.shiro.apache.org%3E",
+        "name" : "[shiro-dev] 20191023 [jira] [Assigned] (SHIRO-723) Provide Minor Shiro Release that includes CVE-2019-10086 Fix"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/r18d8b4f9263e5cad3bbaef0cdba0e2ccdf9201316ac4b85e23eb7ee4@%3Cdev.atlas.apache.org%3E",
+        "name" : "[atlas-dev] 20201023 Re: Review Request 72983: ATLAS-4002 : Upgrade commons-beanutils to 1.9.4 due to CVE-2019-10086"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rcc029be4edaaf5b8bb85818aab494e16f312fced07a0f4a202771ba2@%3Cissues.nifi.apache.org%3E",
+        "name" : "[nifi-issues] 20210827 [jira] [Updated] (NIFI-9170) Upgrade commons-beanutils to 1.9.4 to mitigate CVE-2019-10086"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/rd2d2493f4f1af6980d265b8d84c857e2b7ab80a46e1423710c448957@%3Cissues.nifi.apache.org%3E",
+        "name" : "[nifi-issues] 20210908 [GitHub] [nifi] naddym commented on pull request #5351: NIFI-9170 Upgrade commons-beanutils to 1.9.4 to mitigate CVE-2019-10086"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/ra9a139fdc0999750dcd519e81384bc1fe3946f311b1796221205f51c@%3Ccommits.dolphinscheduler.apache.org%3E",
+        "name" : "[dolphinscheduler-commits] 20210121 [GitHub] [incubator-dolphinscheduler] c-f-cooper commented on pull request #4525: [Improvement-4506][LICENSE] upgrade the version of the commons-beanutils"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/2fd61dc89df9aeab738d2b49f48d42c76f7d53b980ba04e1d48bce48@%3Cdev.shiro.apache.org%3E",
+        "name" : "[shiro-dev] 20191001 [jira] [Created] (SHIRO-723) Provide Minor Shiro Release that includes CVE-2019-10086 Fiix"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E",
+        "name" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities"
+      }, {
+        "source" : "MISC",
+        "url" : "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "name" : "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      }, {
+        "source" : "REDHAT",
+        "url" : "https://access.redhat.com/errata/RHSA-2019:4317",
+        "name" : "RHSA-2019:4317"
+      }, {
+        "source" : "MLIST",
+        "url" : "https://lists.debian.org/debian-lts-announce/2019/08/msg00030.html",
+        "name" : "[debian-lts-announce] 20190824 [SECURITY] [DLA 1896-1] commons-beanutils security update"
+      }, {
+        "source" : "FEDORA",
+        "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/4APPGLBWMFAS4WHNLR4LIJ65DJGPV7TF/",
+        "name" : "FEDORA-2019-bcad44b5d6"
+      } ],
+      "vulnerableSoftware" : [ {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:commons_beanutils:*:*:*:*:*:*:*:*",
+          "vulnerabilityIdMatched" : "true",
+          "versionStartIncluding" : "1.0",
+          "versionEndIncluding" : "1.9.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:nifi:1.14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:apache:nifi:1.15.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:agile_plm:9.3.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:agile_plm:9.3.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:agile_plm:9.3.6:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:agile_product_lifecycle_management_integration_pack:3.5:*:*:*:*:e-business_suite:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:agile_product_lifecycle_management_integration_pack:3.5:*:*:*:*:sap:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:agile_product_lifecycle_management_integration_pack:3.6:*:*:*:*:e-business_suite:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:agile_product_lifecycle_management_integration_pack:3.6:*:*:*:*:sap:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:application_testing_suite:13.3.0.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.7.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:banking_platform:2.9.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:blockchain_platform:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "21.1.2"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:7.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management:12.0.0.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management_elastic_charging_engine:11.3.0.9:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_billing_and_revenue_management_elastic_charging_engine:12.0.0.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_console:1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_policy:1.9.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_cloud_native_core_unified_data_repository:1.6.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_convergence:3.0.2.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_design_studio:7.3.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_design_studio:7.3.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_design_studio:7.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_evolved_communications_application_server:7.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_metasolv_solution:6.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_metasolv_solution:6.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_network_integrity:7.3.6:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_performance_intelligence_center:10.4.0.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_pricing_design_center:12.0.0.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.3.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.3.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:communications_unified_inventory_management:7.4.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:customer_management_and_segmentation_foundation:18.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:enterprise_manager_for_virtualization:13.4.0.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_revenue_management_and_billing_analytics:2.7:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:financial_services_revenue_management_and_billing_analytics:2.8:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_private_banking:12.0.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:flexcube_private_banking:12.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:fusion_middleware:11.1.1.9:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:fusion_middleware:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:fusion_middleware:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_foundation:7.1.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_foundation:7.2.2:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_foundation:7.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_foundation:7.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:healthcare_foundation:8.0.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:hospitality_opera_5:5.5:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:hospitality_opera_5:5.6:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:hospitality_reporting_and_analytics:9.1.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:insurance_data_gateway:1.0.2.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:jd_edwards_enterpriseone_orchestrator:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "9.2.5.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:jd_edwards_enterpriseone_orchestrator:9.2.5.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:jd_edwards_enterpriseone_tools:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "9.2.5.3"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:jd_edwards_enterpriseone_tools:9.2.5.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.56:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_pt_peopletools:8.56:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_pt_peopletools:8.57:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:peoplesoft_enterprise_pt_peopletools:8.58:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "16.2.0",
+          "versionEndIncluding" : "16.2.11"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:primavera_gateway:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "17.12.0",
+          "versionEndIncluding" : "17.12.6"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:real-time_decisions_solutions:3.2.0.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_advanced_inventory_planning:14.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_back_office:14.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_central_office:14.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_invoice_matching:16.0.3:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_merchandising_system:5.0.3.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_point-of-service:14.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_predictive_application_server:16.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_price_management:14.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_price_management:14.0.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_price_management:15.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_price_management:16.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_returns_management:14.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_xstore_point_of_service:7.1:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_xstore_point_of_service:15.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_xstore_point_of_service:16.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_xstore_point_of_service:17.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:retail_xstore_point_of_service:18.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:service_bus:11.1.1.9.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:service_bus:12.2.1.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:service_bus:12.2.1.4.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:solaris_cluster:4.4:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:time_and_labor:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "12.2.6",
+          "versionEndIncluding" : "12.2.11"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_framework:*:*:*:*:*:*:*:*",
+          "versionStartIncluding" : "4.3.0.1.0",
+          "versionEndIncluding" : "4.3.0.6.0"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_framework:4.2.0.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_framework:4.2.0.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_framework:4.4.0.0.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_framework:4.4.0.2.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:utilities_framework:4.4.0.3.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:oracle:weblogic_server:10.3.6.0.0:*:*:*:*:*:*:*"
+        }
+      }, {
+        "software" : {
+          "id" : "cpe:2.3:a:redhat:jboss_enterprise_application_platform:7.2.0:*:*:*:*:*:*:*"
+        }
+      } ]
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "commons-collections-3.2.2.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar",
+    "md5" : "f54a8510f834a1a57166970bfc982e94",
+    "sha1" : "8ad72fe39fa8c91eaaf12aadb21e0c3661fe26d5",
+    "sha256" : "eeeae917917144a68a741d4c0dff66aa5c5c5fd85593ff217bced3fc8ca783b8",
+    "description" : "Types that extend and augment the Java Collections Framework.",
+    "license" : "http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/com.diamondq.common/common-thirdparty.jcasbin@1.4.0"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "commons-collections"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "collections"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://commons.apache.org/collections/"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "org.apache.commons.collections"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "implementation-build",
+        "value" : "tags/COLLECTIONS_3_2_2_RC3@r1714131; 2015-11-13 00:09:45+0100"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "implementation-url",
+        "value" : "http://commons.apache.org/collections/"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Vendor",
+        "value" : "The Apache Software Foundation"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Implementation-Vendor-Id",
+        "value" : "org.apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "specification-vendor",
+        "value" : "The Apache Software Foundation"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-collections"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-collections"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "amamment"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bayard"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "craigmcc"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "geirm"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jcarman"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "matth"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "morgand"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "psteitz"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rdonkin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rwaldhoff"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "scolebourne"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Arun M. Thomas"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Craig McClanahan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Geir Magnusson"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Henri Yandell"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "James Carman"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Matthew Hawthorne"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Morgan Delagrange"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Phil Steitz"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Robert Burrell Donkin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rodney Waldhoff"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stephen Colebourne"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "commons-collections"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Collections"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/collections/"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "commons-collections"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "collections"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://commons.apache.org/collections/"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "Apache Commons Collections"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "org.apache.commons.collections"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "implementation-build",
+        "value" : "tags/COLLECTIONS_3_2_2_RC3@r1714131; 2015-11-13 00:09:45+0100"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Title",
+        "value" : "Apache Commons Collections"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "implementation-url",
+        "value" : "http://commons.apache.org/collections/"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "specification-title",
+        "value" : "Apache Commons Collections"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-collections"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "amamment"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bayard"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "craigmcc"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "geirm"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "jcarman"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "matth"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "morgand"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "psteitz"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rdonkin"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rwaldhoff"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "scolebourne"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Arun M. Thomas"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Craig McClanahan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Geir Magnusson"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Henri Yandell"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "James Carman"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Matthew Hawthorne"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Morgan Delagrange"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Phil Steitz"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Robert Burrell Donkin"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rodney Waldhoff"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Stephen Colebourne"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "commons-collections"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Collections"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/collections/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "3.2.2"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Bundle-Version",
+        "value" : "3.2.2"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Version",
+        "value" : "3.2.2"
+      }, {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "3.2.2"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "3.2.2"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/commons-collections/commons-collections@3.2.2",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/commons-collections/commons-collections@3.2.2?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ],
+    "vulnerabilityIds" : [ {
+      "id" : "cpe:2.3:a:apache:commons_collections:3.2.2:*:*:*:*:*:*:*",
+      "confidence" : "HIGHEST",
+      "url" : "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aapache&cpe_product=cpe%3A%2F%3Aapache%3Acommons_collections&cpe_version=cpe%3A%2F%3Aapache%3Acommons_collections%3A3.2.2"
+    } ]
+  }, {
+    "isVirtual" : false,
+    "fileName" : "commons-logging-1.2.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
+    "md5" : "040b4b4d8eac886f6b4a2a3bd2f31b00",
+    "sha1" : "4bfc12adfe4842bf07b657f0369c4cb522955686",
+    "sha256" : "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636",
+    "description" : "Apache Commons Logging is a thin adapter allowing configurable bridging to other,\n    well known logging systems.",
+    "license" : "http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/com.diamondq.common/common-thirdparty.jcasbin@1.4.0"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "commons-logging"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "logging"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://commons.apache.org/proper/commons-logging/"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "org.apache.commons.logging"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "implementation-build",
+        "value" : "tags/LOGGING_1_2_RC2@r1608092; 2014-07-05 20:11:44+0200"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Vendor",
+        "value" : "The Apache Software Foundation"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Implementation-Vendor-Id",
+        "value" : "org.apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "specification-vendor",
+        "value" : "The Apache Software Foundation"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-logging"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-logging"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "baliuka@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "costin@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "craigmcc@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "dennisl@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "donaldp@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "morgand@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rdonkin@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rsitze@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rwaldhoff@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sanders@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "skitching@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tn@apache.org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "baliuka"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bstansberry"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "costin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "craigmcc"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "dennisl"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "donaldp"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "morgand"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rdonkin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rsitze"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rwaldhoff"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sanders"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "skitching"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tn"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Brian Stansberry"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Costin Manolache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Craig McClanahan"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Dennis Lundberg"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Juozas Baliuka"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Morgan Delagrange"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Peter Donald"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Richard Sitze"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Robert Burrell Donkin"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rodney Waldhoff"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Scott Sanders"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Simon Kitching"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Thomas Neidhart"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "The Apache Software Foundation"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "commons-logging"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Logging"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/proper/commons-logging/"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "commons-logging"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "logging"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "bundle-docurl",
+        "value" : "http://commons.apache.org/proper/commons-logging/"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "Bundle-Name",
+        "value" : "Apache Commons Logging"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "bundle-symbolicname",
+        "value" : "org.apache.commons.logging"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "Manifest",
+        "name" : "implementation-build",
+        "value" : "tags/LOGGING_1_2_RC2@r1608092; 2014-07-05 20:11:44+0200"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Title",
+        "value" : "Apache Commons Logging"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "Manifest",
+        "name" : "specification-title",
+        "value" : "Apache Commons Logging"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "commons-logging"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "baliuka@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "costin@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "craigmcc@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "dennisl@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "donaldp@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "morgand@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rdonkin@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rsitze@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "rwaldhoff@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "sanders@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "skitching@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "tn@apache.org"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "baliuka"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "bstansberry"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "costin"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "craigmcc"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "dennisl"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "donaldp"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "morgand"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rdonkin"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rsitze"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "rwaldhoff"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "sanders"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "skitching"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "tn"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Brian Stansberry"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Costin Manolache"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Craig McClanahan"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Dennis Lundberg"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Juozas Baliuka"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Morgan Delagrange"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Peter Donald"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Richard Sitze"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Robert Burrell Donkin"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Rodney Waldhoff"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Scott Sanders"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Simon Kitching"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "Thomas Neidhart"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "Apache"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer org",
+        "value" : "The Apache Software Foundation"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "commons-logging"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Apache Commons Logging"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-artifactid",
+        "value" : "commons-parent"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "parent-groupid",
+        "value" : "org.apache.commons"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "http://commons.apache.org/proper/commons-logging/"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.2"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "Manifest",
+        "name" : "Implementation-Version",
+        "value" : "1.2"
+      }, {
+        "type" : "version",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "parent-version",
+        "value" : "1.2"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.2"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/commons-logging/commons-logging@1.2",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/commons-logging/commons-logging@1.2?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  } ]
+}

--- a/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/scan-results/grype/grype-report.json
+++ b/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/scan-results/grype/grype-report.json
@@ -1,0 +1,96 @@
+{
+ "matches": [],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:11.798365352+13:00"
+ }
+}

--- a/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/scan-results/snyk/snyk-report.json
+++ b/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/scan-results/snyk/snyk-report.json
@@ -1,0 +1,370 @@
+{
+  "vulnerabilities": [
+    {
+      "id": "SNYK-JAVA-COMMONSBEANUTILS-460111",
+      "title": "Deserialization of Untrusted Data",
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+      "credit": [
+        "Rob Tompkins"
+      ],
+      "semver": {
+        "vulnerable": [
+          "[1.9.2,1.9.4)"
+        ]
+      },
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.9.4"
+      ],
+      "patches": [],
+      "insights": {
+        "triageAdvice": null
+      },
+      "language": "java",
+      "severity": "high",
+      "cvssScore": 7,
+      "functions": [
+        {
+          "version": [
+            "[1.9.2,1.9.4)"
+          ],
+          "functionId": {
+            "filePath": "org/apache/commons/beanutils/PropertyUtilsBean.java",
+            "className": "PropertyUtilsBean",
+            "functionName": "resetBeanIntrospectors"
+          }
+        }
+      ],
+      "malicious": false,
+      "isDisputed": false,
+      "moduleName": "commons-beanutils:commons-beanutils",
+      "references": [
+        {
+          "url": "https://github.com/apache/commons-beanutils/commit/62e82ad92cf4818709d6044aaf257b73d42659a4",
+          "title": "GitHub Commit"
+        },
+        {
+          "url": "http://mail-archives.apache.org/mod_mbox/www-announce/201908.mbox/%3cC628798F-315D-4428-8CB1-4ED1ECC958E4@apache.org%3e",
+          "title": "Mail Archives (Apache.org)"
+        }
+      ],
+      "cvssDetails": [
+        {
+          "assigner": "NVD",
+          "severity": "high",
+          "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "cvssV3BaseScore": 7.3,
+          "modificationTime": "2022-07-26T01:11:38.376078Z"
+        },
+        {
+          "assigner": "SUSE",
+          "severity": "high",
+          "cvssV3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "cvssV3BaseScore": 7.3,
+          "modificationTime": "2022-05-04T00:13:48.207325Z"
+        },
+        {
+          "assigner": "Red Hat",
+          "severity": "high",
+          "cvssV3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "cvssV3BaseScore": 7.3,
+          "modificationTime": "2022-10-25T19:30:22.028347Z"
+        }
+      ],
+      "description": "## Overview\n\n[commons-beanutils:commons-beanutils](https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils) is a provides an easy-to-use but flexible wrapper around reflection and introspection.\n\n\nAffected versions of this package are vulnerable to Deserialization of Untrusted Data.\nIn Apache Commons Beanutils 1.9.2, a special `BeanIntrospector` class was added which allows suppressing the ability for an attacker to access the `classloader` via the `class` property available on all Java objects. This was not enabled by default and was therefore an incomplete fix for [CVE-2014-0114](https://snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-30077).\n\n## Details\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\r\n\r\n  \r\n\r\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.\r\n\r\n  \r\n\r\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\r\n\r\n  \r\n\r\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\r\n\r\n  \r\n\r\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\r\n\r\n- Apache Blog\r\n\r\n  \r\n\r\nThe vulnerability, also know as _Mad Gadget_\r\n\r\n> Mad Gadget is one of the most pernicious vulnerabilities we’ve seen. By merely existing on the Java classpath, seven “gadget” classes in Apache Commons Collections (versions 3.0, 3.1, 3.2, 3.2.1, and 4.0) make object deserialization for the entire JVM process Turing complete with an exec function. Since many business applications use object deserialization to send messages across the network, it would be like hiring a bank teller who was trained to hand over all the money in the vault if asked to do so politely, and then entrusting that teller with the key. The only thing that would keep a bank safe in such a circumstance is that most people wouldn’t consider asking such a question.\r\n\r\n- Google\n\n\n## Remediation\n\nUpgrade `commons-beanutils:commons-beanutils` to version 1.9.4 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/apache/commons-beanutils/commit/62e82ad92cf4818709d6044aaf257b73d42659a4)\n\n- [Mail Archives (Apache.org)](http://mail-archives.apache.org/mod_mbox/www-announce/201908.mbox/%3cC628798F-315D-4428-8CB1-4ED1ECC958E4@apache.org%3e)\n",
+      "epssDetails": {
+        "percentile": "0.67762",
+        "probability": "0.00348",
+        "modelVersion": "v2023.03.01"
+      },
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-10086"
+        ],
+        "CWE": [
+          "CWE-502"
+        ],
+        "GHSA": [
+          "GHSA-6phf-73q6-gh87"
+        ]
+      },
+      "packageName": "commons-beanutils:commons-beanutils",
+      "proprietary": false,
+      "creationTime": "2019-08-21T16:11:11.406094Z",
+      "functions_new": [
+        {
+          "version": [
+            "[1.9.2,1.9.4)"
+          ],
+          "functionId": {
+            "className": "org.apache.commons.beanutils.PropertyUtilsBean",
+            "functionName": "resetBeanIntrospectors"
+          }
+        }
+      ],
+      "alternativeIds": [],
+      "disclosureTime": "2019-08-20T22:18:37Z",
+      "packageManager": "maven",
+      "mavenModuleName": {
+        "groupId": "commons-beanutils",
+        "artifactId": "commons-beanutils"
+      },
+      "publicationTime": "2019-08-20T22:18:37Z",
+      "modificationTime": "2022-10-25T19:30:22.028347Z",
+      "socialTrendAlert": false,
+      "severityWithCritical": "high",
+      "from": [
+        "foo:com.diamondq.common__common-thirdparty.jcasbin__1.4.0@0.0.1",
+        "com.diamondq.common:common-thirdparty.jcasbin@1.4.0",
+        "commons-beanutils:commons-beanutils@1.9.3"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "commons-beanutils:commons-beanutils",
+      "version": "1.9.3"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 4,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "1 vulnerable dependency path",
+  "remediation": {
+    "unresolved": [
+      {
+        "id": "SNYK-JAVA-COMMONSBEANUTILS-460111",
+        "title": "Deserialization of Untrusted Data",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+        "credit": [
+          "Rob Tompkins"
+        ],
+        "semver": {
+          "vulnerable": [
+            "[1.9.2,1.9.4)"
+          ]
+        },
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.9.4"
+        ],
+        "patches": [],
+        "insights": {
+          "triageAdvice": null
+        },
+        "language": "java",
+        "severity": "high",
+        "cvssScore": 7,
+        "functions": [
+          {
+            "version": [
+              "[1.9.2,1.9.4)"
+            ],
+            "functionId": {
+              "filePath": "org/apache/commons/beanutils/PropertyUtilsBean.java",
+              "className": "PropertyUtilsBean",
+              "functionName": "resetBeanIntrospectors"
+            }
+          }
+        ],
+        "malicious": false,
+        "isDisputed": false,
+        "moduleName": "commons-beanutils:commons-beanutils",
+        "references": [
+          {
+            "url": "https://github.com/apache/commons-beanutils/commit/62e82ad92cf4818709d6044aaf257b73d42659a4",
+            "title": "GitHub Commit"
+          },
+          {
+            "url": "http://mail-archives.apache.org/mod_mbox/www-announce/201908.mbox/%3cC628798F-315D-4428-8CB1-4ED1ECC958E4@apache.org%3e",
+            "title": "Mail Archives (Apache.org)"
+          }
+        ],
+        "cvssDetails": [
+          {
+            "assigner": "NVD",
+            "severity": "high",
+            "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+            "cvssV3BaseScore": 7.3,
+            "modificationTime": "2022-07-26T01:11:38.376078Z"
+          },
+          {
+            "assigner": "SUSE",
+            "severity": "high",
+            "cvssV3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+            "cvssV3BaseScore": 7.3,
+            "modificationTime": "2022-05-04T00:13:48.207325Z"
+          },
+          {
+            "assigner": "Red Hat",
+            "severity": "high",
+            "cvssV3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+            "cvssV3BaseScore": 7.3,
+            "modificationTime": "2022-10-25T19:30:22.028347Z"
+          }
+        ],
+        "description": "## Overview\n\n[commons-beanutils:commons-beanutils](https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils) is a provides an easy-to-use but flexible wrapper around reflection and introspection.\n\n\nAffected versions of this package are vulnerable to Deserialization of Untrusted Data.\nIn Apache Commons Beanutils 1.9.2, a special `BeanIntrospector` class was added which allows suppressing the ability for an attacker to access the `classloader` via the `class` property available on all Java objects. This was not enabled by default and was therefore an incomplete fix for [CVE-2014-0114](https://snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-30077).\n\n## Details\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\r\n\r\n  \r\n\r\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.\r\n\r\n  \r\n\r\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\r\n\r\n  \r\n\r\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\r\n\r\n  \r\n\r\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\r\n\r\n- Apache Blog\r\n\r\n  \r\n\r\nThe vulnerability, also know as _Mad Gadget_\r\n\r\n> Mad Gadget is one of the most pernicious vulnerabilities we’ve seen. By merely existing on the Java classpath, seven “gadget” classes in Apache Commons Collections (versions 3.0, 3.1, 3.2, 3.2.1, and 4.0) make object deserialization for the entire JVM process Turing complete with an exec function. Since many business applications use object deserialization to send messages across the network, it would be like hiring a bank teller who was trained to hand over all the money in the vault if asked to do so politely, and then entrusting that teller with the key. The only thing that would keep a bank safe in such a circumstance is that most people wouldn’t consider asking such a question.\r\n\r\n- Google\n\n\n## Remediation\n\nUpgrade `commons-beanutils:commons-beanutils` to version 1.9.4 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/apache/commons-beanutils/commit/62e82ad92cf4818709d6044aaf257b73d42659a4)\n\n- [Mail Archives (Apache.org)](http://mail-archives.apache.org/mod_mbox/www-announce/201908.mbox/%3cC628798F-315D-4428-8CB1-4ED1ECC958E4@apache.org%3e)\n",
+        "epssDetails": {
+          "percentile": "0.67762",
+          "probability": "0.00348",
+          "modelVersion": "v2023.03.01"
+        },
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-10086"
+          ],
+          "CWE": [
+            "CWE-502"
+          ],
+          "GHSA": [
+            "GHSA-6phf-73q6-gh87"
+          ]
+        },
+        "packageName": "commons-beanutils:commons-beanutils",
+        "proprietary": false,
+        "creationTime": "2019-08-21T16:11:11.406094Z",
+        "functions_new": [
+          {
+            "version": [
+              "[1.9.2,1.9.4)"
+            ],
+            "functionId": {
+              "className": "org.apache.commons.beanutils.PropertyUtilsBean",
+              "functionName": "resetBeanIntrospectors"
+            }
+          }
+        ],
+        "alternativeIds": [],
+        "disclosureTime": "2019-08-20T22:18:37Z",
+        "packageManager": "maven",
+        "mavenModuleName": {
+          "groupId": "commons-beanutils",
+          "artifactId": "commons-beanutils"
+        },
+        "publicationTime": "2019-08-20T22:18:37Z",
+        "modificationTime": "2022-10-25T19:30:22.028347Z",
+        "socialTrendAlert": false,
+        "packagePopularityRank": 99,
+        "from": [
+          "foo:com.diamondq.common__common-thirdparty.jcasbin__1.4.0@0.0.1",
+          "com.diamondq.common:common-thirdparty.jcasbin@1.4.0",
+          "commons-beanutils:commons-beanutils@1.9.3"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "isRuntime": false,
+        "name": "commons-beanutils:commons-beanutils",
+        "version": "1.9.3",
+        "severityWithCritical": "high"
+      }
+    ],
+    "upgrade": {},
+    "patch": {},
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 1,
+  "projectName": "foo:com.diamondq.common__common-thirdparty.jcasbin__1.4.0",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0"
+}

--- a/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/scan-results/steady/steady-report.json
+++ b/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/scan-results/steady/steady-report.json
@@ -1,0 +1,58 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 22:25 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "com.diamondq.common__common-thirdparty.jcasbin__1.4.0",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "TEST, PROVIDED" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+			{
+		
+			"bug":{
+				"id":"CVE-2014-0114",
+				"cvssScore": "7.5" ,
+				"cvssVersion": "2.0" 
+			},
+			"filename": "commons-beanutils-1.9.3.jar",
+			"sha1": "C845703DE334DDC6B4B3CD26835458CB1CBA1F3D",
+			
+			"modules": [
+			
+				{
+			
+				"groupId": "foo",
+				"artifactId": "com.diamondq.common__common-thirdparty.jcasbin__1.4.0",
+				"version": "0.0.1",
+				
+				"href": "http://localhost:8033/backend/../apps/#/$space.getSpaceToken()/foo/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/0.0.1",
+				
+				"scope": "COMPILE",
+				"isTransitive": true,
+				
+					"containsVulnerableCode": "true",
+				
+						"potentiallyExecutesVulnerableCode": "noLibraryCodeAtAll",
+				
+						"actuallyExecutesVulnerableCode": "noLibraryCodeAtAll"
+				}
+			]
+		}
+		]
+	}
+}

--- a/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/src/test/java/FilenameUtilsTestCase.java
+++ b/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/src/test/java/FilenameUtilsTestCase.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+/**
+ * This is used to test FilenameUtils for correctness.
+ *
+ * @see FilenameUtils
+ */
+public class FilenameUtilsTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SEP = "" + File.separatorChar;
+    private static final boolean WINDOWS = File.separatorChar == '\\';
+
+    private File testFile1;
+    private File testFile2;
+
+    private int testFile1Size;
+    private int testFile2Size;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile1 = temporaryFolder.newFile("file1-test.txt");
+        testFile2 = temporaryFolder.newFile("file1a-test.txt");
+
+        testFile1Size = (int) testFile1.length();
+        testFile2Size = (int) testFile2.length();
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1
+                + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output3 =
+                 new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output3, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2
+                + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output2 =
+                 new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output2, testFile2Size);
+        }
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1
+                + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output1 =
+                 new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output1, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2
+                + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output =
+                 new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output, testFile2Size);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void testNormalize() throws Exception {
+        assertEquals(null, FilenameUtils.normalize(null));
+        assertEquals(null, FilenameUtils.normalize(":"));
+        assertEquals(null, FilenameUtils.normalize("1:\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("1:"));
+        assertEquals(null, FilenameUtils.normalize("1:a"));
+        assertEquals(null, FilenameUtils.normalize("\\\\\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\a"));
+
+        assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c.txt"));
+        assertEquals("" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\a\\b/c.txt"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("C:\\a\\b/c.txt"));
+        assertEquals("" + SEP + "" + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server\\a\\b/c.txt"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~\\a\\b/c.txt"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~user\\a\\b/c.txt"));
+
+        assertEquals("a" + SEP + "c", FilenameUtils.normalize("a/b/../c"));
+        assertEquals("c", FilenameUtils.normalize("a/b/../../c"));
+        assertEquals("c" + SEP, FilenameUtils.normalize("a/b/../../c/"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../../c"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/.."));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/../"));
+        assertEquals("", FilenameUtils.normalize("a/b/../.."));
+        assertEquals("", FilenameUtils.normalize("a/b/../../"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../.."));
+        assertEquals("a" + SEP + "d", FilenameUtils.normalize("a/b/../c/../d"));
+        assertEquals("a" + SEP + "d" + SEP, FilenameUtils.normalize("a/b/../c/../d/"));
+        assertEquals("a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("a/b//d"));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/././."));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/./././"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("./a/"));
+        assertEquals("a", FilenameUtils.normalize("./a"));
+        assertEquals("", FilenameUtils.normalize("./"));
+        assertEquals("", FilenameUtils.normalize("."));
+        assertEquals(null, FilenameUtils.normalize("../a"));
+        assertEquals(null, FilenameUtils.normalize(".."));
+        assertEquals("", FilenameUtils.normalize(""));
+
+        assertEquals(SEP + "a", FilenameUtils.normalize("/a"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/"));
+        assertEquals(SEP + "a" + SEP + "c", FilenameUtils.normalize("/a/b/../c"));
+        assertEquals(SEP + "c", FilenameUtils.normalize("/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../../c"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/b/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../.."));
+        assertEquals(SEP + "a" + SEP + "d", FilenameUtils.normalize("/a/b/../c/../d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("/a/b//d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("/a/b/././."));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/./a"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/./"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/."));
+        assertEquals(null, FilenameUtils.normalize("/../a"));
+        assertEquals(null, FilenameUtils.normalize("/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/"));
+
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/a"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/"));
+        assertEquals("~" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~/a/b/../c"));
+        assertEquals("~" + SEP + "c", FilenameUtils.normalize("~/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../../c"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/b/.."));
+        assertEquals("~" + SEP + "", FilenameUtils.normalize("~/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../.."));
+        assertEquals("~" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~/a/b/../c/../d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~/a/b//d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~/a/b/././."));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/./a"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/./"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/."));
+        assertEquals(null, FilenameUtils.normalize("~/../a"));
+        assertEquals(null, FilenameUtils.normalize("~/.."));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~"));
+
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/a"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/"));
+        assertEquals("~user" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~user/a/b/../c"));
+        assertEquals("~user" + SEP + "c", FilenameUtils.normalize("~user/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../../c"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/b/.."));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../.."));
+        assertEquals("~user" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~user/a/b/../c/../d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~user/a/b//d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~user/a/b/././."));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/./a"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/./"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/."));
+        assertEquals(null, FilenameUtils.normalize("~user/../a"));
+        assertEquals(null, FilenameUtils.normalize("~user/.."));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user/"));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user"));
+
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/a"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/"));
+        assertEquals("C:" + SEP + "a" + SEP + "c", FilenameUtils.normalize("C:/a/b/../c"));
+        assertEquals("C:" + SEP + "c", FilenameUtils.normalize("C:/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../../c"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/b/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../.."));
+        assertEquals("C:" + SEP + "a" + SEP + "d", FilenameUtils.normalize("C:/a/b/../c/../d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:/a/b//d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:/a/b/././."));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/./a"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/./"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/."));
+        assertEquals(null, FilenameUtils.normalize("C:/../a"));
+        assertEquals(null, FilenameUtils.normalize("C:/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/"));
+
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:a"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/"));
+        assertEquals("C:" + "a" + SEP + "c", FilenameUtils.normalize("C:a/b/../c"));
+        assertEquals("C:" + "c", FilenameUtils.normalize("C:a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../../c"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/b/.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../.."));
+        assertEquals("C:" + "a" + SEP + "d", FilenameUtils.normalize("C:a/b/../c/../d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:a/b//d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:a/b/././."));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:./a"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:./"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:."));
+        assertEquals(null, FilenameUtils.normalize("C:../a"));
+        assertEquals(null, FilenameUtils.normalize("C:.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:"));
+
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/a"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "c", FilenameUtils.normalize("//server/a/b/../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "c", FilenameUtils.normalize("//server/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/b/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../.."));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "d", FilenameUtils.normalize("//server/a/b/../c/../d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("//server/a/b//d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("//server/a/b/././."));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/./a"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/./"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/."));
+        assertEquals(null, FilenameUtils.normalize("//server/../a"));
+        assertEquals(null, FilenameUtils.normalize("//server/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/"));
+
+        assertEquals(SEP + SEP + "127.0.0.1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\127.0.0.1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "::1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\::1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server.example.org" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.example.org\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server." + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.\\a\\b\\c.txt"));
+
+        assertEquals(null, FilenameUtils.normalize("\\\\-server\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\..\\a\\b\\c.txt"));
+    }
+}

--- a/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/src/test/java/TestUtils.java
+++ b/CVE-2021-29425/com.diamondq.common__common-thirdparty.jcasbin__1.4.0/src/test/java/TestUtils.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.output.ByteArrayOutputStream;
+
+import junit.framework.AssertionFailedError;
+
+/**
+ * Base class for testcases doing tests with files.
+ */
+public abstract class TestUtils {
+
+    private TestUtils() {
+
+    }
+
+    public static void createFile(final File file, final long size)
+        throws IOException {
+        if (!file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file
+                + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output =
+                 new BufferedOutputStream(new java.io.FileOutputStream(file))) {
+            generateTestData(output, size);
+        }
+    }
+
+    public static byte[] generateTestData(final long size) {
+        try {
+            final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+            generateTestData(baout, size);
+            return baout.toByteArray();
+        } catch (final IOException ioe) {
+            throw new RuntimeException("This should never happen: " + ioe.getMessage());
+        }
+    }
+
+    public static void generateTestData(final OutputStream out, final long size)
+        throws IOException {
+        for (int i = 0; i < size; i++) {
+            //output.write((byte)'X');
+
+            // nice varied byte pattern compatible with Readers and Writers
+            out.write((byte) ((i % 127) + 1));
+        }
+    }
+
+    public static void createLineBasedFile(final File file, final String[] data) throws IOException {
+        if (file.getParentFile() != null && !file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final PrintWriter output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))) {
+            for (final String element : data) {
+                output.println(element);
+            }
+        }
+    }
+
+    public static File newFile(final File testDirectory, final String filename) throws IOException {
+        final File destination = new File(testDirectory, filename);
+        /*
+        assertTrue( filename + "Test output data file shouldn't previously exist",
+                    !destination.exists() );
+        */
+        if (destination.exists()) {
+            FileUtils.forceDelete(destination);
+        }
+        return destination;
+    }
+
+    public static void checkFile(final File file, final File referenceFile)
+        throws Exception {
+        assertTrue("Check existence of output file", file.exists());
+        assertEqualContent(referenceFile, file);
+    }
+
+    /**
+     * Assert that the content of two files is the same.
+     */
+    private static void assertEqualContent(final File f0, final File f1)
+        throws IOException {
+        /* This doesn't work because the filesize isn't updated until the file
+         * is closed.
+        assertTrue( "The files " + f0 + " and " + f1 +
+                    " have differing file sizes (" + f0.length() +
+                    " vs " + f1.length() + ")", ( f0.length() == f1.length() ) );
+        */
+        try (InputStream is0 = new FileInputStream(f0)) {
+            try (InputStream is1 = new FileInputStream(f1)) {
+                final byte[] buf0 = new byte[1024];
+                final byte[] buf1 = new byte[1024];
+                int n0 = 0;
+                int n1;
+
+                while (-1 != n0) {
+                    n0 = is0.read(buf0);
+                    n1 = is1.read(buf1);
+                    assertTrue("The files " + f0 + " and " + f1 +
+                        " have differing number of bytes available (" + n0 +
+                        " vs " + n1 + ")", (n0 == n1));
+
+                    assertTrue("The files " + f0 + " and " + f1 +
+                        " have different content", Arrays.equals(buf0, buf1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a byte[].
+     *
+     * @param b0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final byte[] b0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final byte[] b1 = new byte[b0.length];
+        try (InputStream is = new FileInputStream(file)) {
+            while (count < b0.length && numRead >= 0) {
+                numRead = is.read(b1, count, b0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of bytes: ", b0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("byte " + i + " differs", b0[i], b1[i]);
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a char[].
+     *
+     * @param c0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final char[] c0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final char[] c1 = new char[c0.length];
+        try (Reader ir = new FileReader(file)) {
+            while (count < c0.length && numRead >= 0) {
+                numRead = ir.read(c1, count, c0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of chars: ", c0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("char " + i + " differs", c0[i], c1[i]);
+            }
+        }
+    }
+
+    public static void checkWrite(final OutputStream output) throws Exception {
+        try {
+            new java.io.PrintStream(output).write(0);
+        } catch (final Throwable t) {
+            throw new AssertionFailedError(
+                "The copy() method closed the stream "
+                    + "when it shouldn't have. "
+                    + t.getMessage());
+        }
+    }
+
+    public static void checkWrite(final Writer output) throws Exception {
+        try {
+            new java.io.PrintWriter(output).write('a');
+        } catch (final Throwable t) {
+            throw new AssertionFailedError(
+                "The copy() method closed the stream "
+                    + "when it shouldn't have. "
+                    + t.getMessage());
+        }
+    }
+
+    public static void deleteFile(final File file)
+        throws Exception {
+        if (file.exists()) {
+            assertTrue("Couldn't delete file: " + file, file.delete());
+        }
+    }
+
+    /**
+     * Sleep for a guaranteed number of milliseconds unless interrupted.
+     *
+     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
+     * it deems appropriate. Read the docs on Thread.sleep for further details.
+     *
+     * @param ms the number of milliseconds to sleep for
+     * @throws InterruptedException if interrupted
+     */
+    public static void sleep(final long ms) throws InterruptedException {
+        final long finishAt = System.currentTimeMillis() + ms;
+        long remaining = ms;
+        do {
+            Thread.sleep(remaining);
+            remaining = finishAt - System.currentTimeMillis();
+        } while (remaining > 0);
+    }
+
+    public static void sleepQuietly(final long ms) {
+        try {
+            sleep(ms);
+        } catch (final InterruptedException ignored){
+        }
+    }
+
+}


### PR DESCRIPTION
- ❌ **Not a full clone** based on the difference in name from the TPoV (`commons-io:commons-io:2.6`).
- ✔️ **Not critical** since there are [no dependent packages](https://central.sonatype.com/artifact/com.diamondq.common/common-thirdparty.jcasbin/dependents) (even after choosing "Dependency Type: All") -> **OK for public release**
- (❌) Not remediated since there is no later version than `1.4.0` on Maven Central Repo