### PR TITLE
Add the 10 vulnerable versions of `com.virjar:ratel-api` found by shadedetector for CVE-2021-29425

### DIFF
--- a/CVE-2021-29425/com.virjar__ratel-api__1.0.0/README.md
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.0.0/README.md
@@ -1,0 +1,26 @@
+# [CVE-2021-29425 -- Commons-IO] (https://nvd.nist.gov/vuln/detail/CVE-2021-29425)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+
+
+Project uses `commons-io:commons-io:2.6` , tests from https://github.com/apache/commons-io/commit/2736b6fe0b3fa22ec8e2b4184897ecadb021fc78
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. irrelevant tests in class removed
+2. utility methods TestUtils
+3. JUnit version replaced by JUnit5 with JUnit4 vintage support
+4. uses Java 8 (note that compress does not have to be build)
+
+Note that the one test __fails__ indicating the vulnerability! After replacing `commons-io:commons-io:2.6` by `commons-io:commons-io:2.7`
+the respective test passes, indicating that the vulnerability has been fixed.
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2021-29425/com.virjar__ratel-api__1.0.0/pom.xml
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.0.0/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>com.virjar__ratel-api__1.0.0</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2021-29425 POV</description>
+    <name>CVE-2021-29425</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.virjar</groupId>
+            <artifactId>ratel-api</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2021-29425/com.virjar__ratel-api__1.0.0/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.0.0/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,255 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2021-29425",
+    "groupID" : "foo",
+    "artifactID" : "com.virjar__ratel-api__1.0.0",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:29:29.442368Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "ratel-api-1.0.0.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/com/virjar/ratel-api/1.0.0/ratel-api-1.0.0.jar",
+    "md5" : "42c13ee511478cc4b4a6248cd7ad886a",
+    "sha1" : "bf0f096801ade83398248c901e139a90580ef85d",
+    "sha256" : "ae4ad4ce260a01ba73e56907867e0cfe32f6b50d1718c08ad9c6c5d01353e731",
+    "description" : "ratel api,used for developer on ratel system,an extension for xposed framewrok,ratel api compatable with original xposed framework",
+    "license" : "The Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/com.virjar__ratel-api__1.0.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "external"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.0.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.0.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.virjar/ratel-api@1.0.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.virjar/ratel-api@1.0.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  } ]
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.0.0/scan-results/grype/grype-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.0.0/scan-results/grype/grype-report.json
@@ -1,0 +1,96 @@
+{
+ "matches": [],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:12.177693854+13:00"
+ }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.0.0/scan-results/snyk/snyk-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.0.0/scan-results/snyk/snyk-report.json
@@ -1,0 +1,106 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 1,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": false,
+  "uniqueCount": 0,
+  "projectName": "foo:com.virjar__ratel-api__1.0.0",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2021-29425/com.virjar__ratel-api__1.0.0"
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.0.0/scan-results/steady/steady-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.0.0/scan-results/steady/steady-report.json
@@ -1,0 +1,27 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 22:25 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "com.virjar__ratel-api__1.0.0",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "TEST, PROVIDED" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+		]
+	}
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.0.0/src/test/java/FilenameUtilsTestCase.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.0.0/src/test/java/FilenameUtilsTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import external.org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is used to test FilenameUtils for correctness.
+ *
+ * @see FilenameUtils
+ */
+public class FilenameUtilsTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SEP = "" + File.separatorChar;
+
+    private static final boolean WINDOWS = File.separatorChar == '\\';
+
+    private File testFile1;
+
+    private File testFile2;
+
+    private int testFile1Size;
+
+    private int testFile2Size;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile1 = temporaryFolder.newFile("file1-test.txt");
+        testFile2 = temporaryFolder.newFile("file1a-test.txt");
+        testFile1Size = (int) testFile1.length();
+        testFile2Size = (int) testFile2.length();
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output3 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output3, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output2 = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output2, testFile2Size);
+        }
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output1 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output1, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output, testFile2Size);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void testNormalize() throws Exception {
+        assertEquals(null, FilenameUtils.normalize(null));
+        assertEquals(null, FilenameUtils.normalize(":"));
+        assertEquals(null, FilenameUtils.normalize("1:\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("1:"));
+        assertEquals(null, FilenameUtils.normalize("1:a"));
+        assertEquals(null, FilenameUtils.normalize("\\\\\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\a"));
+        assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c.txt"));
+        assertEquals("" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\a\\b/c.txt"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("C:\\a\\b/c.txt"));
+        assertEquals("" + SEP + "" + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server\\a\\b/c.txt"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~\\a\\b/c.txt"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~user\\a\\b/c.txt"));
+        assertEquals("a" + SEP + "c", FilenameUtils.normalize("a/b/../c"));
+        assertEquals("c", FilenameUtils.normalize("a/b/../../c"));
+        assertEquals("c" + SEP, FilenameUtils.normalize("a/b/../../c/"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../../c"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/.."));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/../"));
+        assertEquals("", FilenameUtils.normalize("a/b/../.."));
+        assertEquals("", FilenameUtils.normalize("a/b/../../"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../.."));
+        assertEquals("a" + SEP + "d", FilenameUtils.normalize("a/b/../c/../d"));
+        assertEquals("a" + SEP + "d" + SEP, FilenameUtils.normalize("a/b/../c/../d/"));
+        assertEquals("a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("a/b//d"));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/././."));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/./././"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("./a/"));
+        assertEquals("a", FilenameUtils.normalize("./a"));
+        assertEquals("", FilenameUtils.normalize("./"));
+        assertEquals("", FilenameUtils.normalize("."));
+        assertEquals(null, FilenameUtils.normalize("../a"));
+        assertEquals(null, FilenameUtils.normalize(".."));
+        assertEquals("", FilenameUtils.normalize(""));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/a"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/"));
+        assertEquals(SEP + "a" + SEP + "c", FilenameUtils.normalize("/a/b/../c"));
+        assertEquals(SEP + "c", FilenameUtils.normalize("/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../../c"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/b/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../.."));
+        assertEquals(SEP + "a" + SEP + "d", FilenameUtils.normalize("/a/b/../c/../d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("/a/b//d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("/a/b/././."));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/./a"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/./"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/."));
+        assertEquals(null, FilenameUtils.normalize("/../a"));
+        assertEquals(null, FilenameUtils.normalize("/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/"));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/a"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/"));
+        assertEquals("~" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~/a/b/../c"));
+        assertEquals("~" + SEP + "c", FilenameUtils.normalize("~/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../../c"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/b/.."));
+        assertEquals("~" + SEP + "", FilenameUtils.normalize("~/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../.."));
+        assertEquals("~" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~/a/b/../c/../d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~/a/b//d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~/a/b/././."));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/./a"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/./"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/."));
+        assertEquals(null, FilenameUtils.normalize("~/../a"));
+        assertEquals(null, FilenameUtils.normalize("~/.."));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~"));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/a"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/"));
+        assertEquals("~user" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~user/a/b/../c"));
+        assertEquals("~user" + SEP + "c", FilenameUtils.normalize("~user/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../../c"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/b/.."));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../.."));
+        assertEquals("~user" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~user/a/b/../c/../d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~user/a/b//d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~user/a/b/././."));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/./a"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/./"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/."));
+        assertEquals(null, FilenameUtils.normalize("~user/../a"));
+        assertEquals(null, FilenameUtils.normalize("~user/.."));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user/"));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user"));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/a"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/"));
+        assertEquals("C:" + SEP + "a" + SEP + "c", FilenameUtils.normalize("C:/a/b/../c"));
+        assertEquals("C:" + SEP + "c", FilenameUtils.normalize("C:/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../../c"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/b/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../.."));
+        assertEquals("C:" + SEP + "a" + SEP + "d", FilenameUtils.normalize("C:/a/b/../c/../d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:/a/b//d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:/a/b/././."));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/./a"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/./"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/."));
+        assertEquals(null, FilenameUtils.normalize("C:/../a"));
+        assertEquals(null, FilenameUtils.normalize("C:/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/"));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:a"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/"));
+        assertEquals("C:" + "a" + SEP + "c", FilenameUtils.normalize("C:a/b/../c"));
+        assertEquals("C:" + "c", FilenameUtils.normalize("C:a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../../c"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/b/.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../.."));
+        assertEquals("C:" + "a" + SEP + "d", FilenameUtils.normalize("C:a/b/../c/../d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:a/b//d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:a/b/././."));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:./a"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:./"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:."));
+        assertEquals(null, FilenameUtils.normalize("C:../a"));
+        assertEquals(null, FilenameUtils.normalize("C:.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:"));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/a"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "c", FilenameUtils.normalize("//server/a/b/../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "c", FilenameUtils.normalize("//server/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/b/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../.."));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "d", FilenameUtils.normalize("//server/a/b/../c/../d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("//server/a/b//d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("//server/a/b/././."));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/./a"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/./"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/."));
+        assertEquals(null, FilenameUtils.normalize("//server/../a"));
+        assertEquals(null, FilenameUtils.normalize("//server/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/"));
+        assertEquals(SEP + SEP + "127.0.0.1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\127.0.0.1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "::1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\::1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server.example.org" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.example.org\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server." + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\-server\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\..\\a\\b\\c.txt"));
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.0.0/src/test/java/TestUtils.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.0.0/src/test/java/TestUtils.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import external.org.apache.commons.io.FileUtils;
+import external.org.apache.commons.io.output.ByteArrayOutputStream;
+import junit.framework.AssertionFailedError;
+
+/**
+ * Base class for testcases doing tests with files.
+ */
+public abstract class TestUtils {
+
+    private TestUtils() {
+    }
+
+    public static void createFile(final File file, final long size) throws IOException {
+        if (!file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new java.io.FileOutputStream(file))) {
+            generateTestData(output, size);
+        }
+    }
+
+    public static byte[] generateTestData(final long size) {
+        try {
+            final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+            generateTestData(baout, size);
+            return baout.toByteArray();
+        } catch (final IOException ioe) {
+            throw new RuntimeException("This should never happen: " + ioe.getMessage());
+        }
+    }
+
+    public static void generateTestData(final OutputStream out, final long size) throws IOException {
+        for (int i = 0; i < size; i++) {
+            //output.write((byte)'X');
+            // nice varied byte pattern compatible with Readers and Writers
+            out.write((byte) ((i % 127) + 1));
+        }
+    }
+
+    public static void createLineBasedFile(final File file, final String[] data) throws IOException {
+        if (file.getParentFile() != null && !file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final PrintWriter output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))) {
+            for (final String element : data) {
+                output.println(element);
+            }
+        }
+    }
+
+    public static File newFile(final File testDirectory, final String filename) throws IOException {
+        final File destination = new File(testDirectory, filename);
+        /*
+        assertTrue( filename + "Test output data file shouldn't previously exist",
+                    !destination.exists() );
+        */
+        if (destination.exists()) {
+            FileUtils.forceDelete(destination);
+        }
+        return destination;
+    }
+
+    public static void checkFile(final File file, final File referenceFile) throws Exception {
+        assertTrue("Check existence of output file", file.exists());
+        assertEqualContent(referenceFile, file);
+    }
+
+    /**
+     * Assert that the content of two files is the same.
+     */
+    private static void assertEqualContent(final File f0, final File f1) throws IOException {
+        /* This doesn't work because the filesize isn't updated until the file
+         * is closed.
+        assertTrue( "The files " + f0 + " and " + f1 +
+                    " have differing file sizes (" + f0.length() +
+                    " vs " + f1.length() + ")", ( f0.length() == f1.length() ) );
+        */
+        try (InputStream is0 = new FileInputStream(f0)) {
+            try (InputStream is1 = new FileInputStream(f1)) {
+                final byte[] buf0 = new byte[1024];
+                final byte[] buf1 = new byte[1024];
+                int n0 = 0;
+                int n1;
+                while (-1 != n0) {
+                    n0 = is0.read(buf0);
+                    n1 = is1.read(buf1);
+                    assertTrue("The files " + f0 + " and " + f1 + " have differing number of bytes available (" + n0 + " vs " + n1 + ")", (n0 == n1));
+                    assertTrue("The files " + f0 + " and " + f1 + " have different content", Arrays.equals(buf0, buf1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a byte[].
+     *
+     * @param b0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final byte[] b0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final byte[] b1 = new byte[b0.length];
+        try (InputStream is = new FileInputStream(file)) {
+            while (count < b0.length && numRead >= 0) {
+                numRead = is.read(b1, count, b0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of bytes: ", b0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("byte " + i + " differs", b0[i], b1[i]);
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a char[].
+     *
+     * @param c0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final char[] c0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final char[] c1 = new char[c0.length];
+        try (Reader ir = new FileReader(file)) {
+            while (count < c0.length && numRead >= 0) {
+                numRead = ir.read(c1, count, c0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of chars: ", c0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("char " + i + " differs", c0[i], c1[i]);
+            }
+        }
+    }
+
+    public static void checkWrite(final OutputStream output) throws Exception {
+        try {
+            new java.io.PrintStream(output).write(0);
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void checkWrite(final Writer output) throws Exception {
+        try {
+            new java.io.PrintWriter(output).write('a');
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void deleteFile(final File file) throws Exception {
+        if (file.exists()) {
+            assertTrue("Couldn't delete file: " + file, file.delete());
+        }
+    }
+
+    /**
+     * Sleep for a guaranteed number of milliseconds unless interrupted.
+     *
+     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
+     * it deems appropriate. Read the docs on Thread.sleep for further details.
+     *
+     * @param ms the number of milliseconds to sleep for
+     * @throws InterruptedException if interrupted
+     */
+    public static void sleep(final long ms) throws InterruptedException {
+        final long finishAt = System.currentTimeMillis() + ms;
+        long remaining = ms;
+        do {
+            Thread.sleep(remaining);
+            remaining = finishAt - System.currentTimeMillis();
+        } while (remaining > 0);
+    }
+
+    public static void sleepQuietly(final long ms) {
+        try {
+            sleep(ms);
+        } catch (final InterruptedException ignored) {
+        }
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.1.0/README.md
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.1.0/README.md
@@ -1,0 +1,26 @@
+# [CVE-2021-29425 -- Commons-IO] (https://nvd.nist.gov/vuln/detail/CVE-2021-29425)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+
+
+Project uses `commons-io:commons-io:2.6` , tests from https://github.com/apache/commons-io/commit/2736b6fe0b3fa22ec8e2b4184897ecadb021fc78
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. irrelevant tests in class removed
+2. utility methods TestUtils
+3. JUnit version replaced by JUnit5 with JUnit4 vintage support
+4. uses Java 8 (note that compress does not have to be build)
+
+Note that the one test __fails__ indicating the vulnerability! After replacing `commons-io:commons-io:2.6` by `commons-io:commons-io:2.7`
+the respective test passes, indicating that the vulnerability has been fixed.
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2021-29425/com.virjar__ratel-api__1.1.0/pom.xml
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.1.0/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>com.virjar__ratel-api__1.1.0</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2021-29425 POV</description>
+    <name>CVE-2021-29425</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.virjar</groupId>
+            <artifactId>ratel-api</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2021-29425/com.virjar__ratel-api__1.1.0/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.1.0/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,255 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2021-29425",
+    "groupID" : "foo",
+    "artifactID" : "com.virjar__ratel-api__1.1.0",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:29:36.792193Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "ratel-api-1.1.0.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/com/virjar/ratel-api/1.1.0/ratel-api-1.1.0.jar",
+    "md5" : "1e1cc49c7f3ddb9bedb765537cda686a",
+    "sha1" : "8fcdf2058947eb95acf8690e3a87b28127477b3f",
+    "sha256" : "75d4307ddb7622743dded8680e68b306906837bdf82438009fce8ed6c6ec513e",
+    "description" : "ratel api,used for developer on ratel system,an extension for xposed framewrok,ratel api compatable with original xposed framework",
+    "license" : "The Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/com.virjar__ratel-api__1.1.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "external"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.1.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.1.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.virjar/ratel-api@1.1.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.virjar/ratel-api@1.1.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  } ]
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.1.0/scan-results/grype/grype-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.1.0/scan-results/grype/grype-report.json
@@ -1,0 +1,96 @@
+{
+ "matches": [],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:12.252131688+13:00"
+ }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.1.0/scan-results/snyk/snyk-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.1.0/scan-results/snyk/snyk-report.json
@@ -1,0 +1,106 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 1,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": false,
+  "uniqueCount": 0,
+  "projectName": "foo:com.virjar__ratel-api__1.1.0",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2021-29425/com.virjar__ratel-api__1.1.0"
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.1.0/scan-results/steady/steady-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.1.0/scan-results/steady/steady-report.json
@@ -1,0 +1,27 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 22:25 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "com.virjar__ratel-api__1.1.0",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "TEST, PROVIDED" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+		]
+	}
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.1.0/src/test/java/FilenameUtilsTestCase.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.1.0/src/test/java/FilenameUtilsTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import external.org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is used to test FilenameUtils for correctness.
+ *
+ * @see FilenameUtils
+ */
+public class FilenameUtilsTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SEP = "" + File.separatorChar;
+
+    private static final boolean WINDOWS = File.separatorChar == '\\';
+
+    private File testFile1;
+
+    private File testFile2;
+
+    private int testFile1Size;
+
+    private int testFile2Size;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile1 = temporaryFolder.newFile("file1-test.txt");
+        testFile2 = temporaryFolder.newFile("file1a-test.txt");
+        testFile1Size = (int) testFile1.length();
+        testFile2Size = (int) testFile2.length();
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output3 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output3, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output2 = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output2, testFile2Size);
+        }
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output1 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output1, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output, testFile2Size);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void testNormalize() throws Exception {
+        assertEquals(null, FilenameUtils.normalize(null));
+        assertEquals(null, FilenameUtils.normalize(":"));
+        assertEquals(null, FilenameUtils.normalize("1:\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("1:"));
+        assertEquals(null, FilenameUtils.normalize("1:a"));
+        assertEquals(null, FilenameUtils.normalize("\\\\\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\a"));
+        assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c.txt"));
+        assertEquals("" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\a\\b/c.txt"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("C:\\a\\b/c.txt"));
+        assertEquals("" + SEP + "" + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server\\a\\b/c.txt"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~\\a\\b/c.txt"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~user\\a\\b/c.txt"));
+        assertEquals("a" + SEP + "c", FilenameUtils.normalize("a/b/../c"));
+        assertEquals("c", FilenameUtils.normalize("a/b/../../c"));
+        assertEquals("c" + SEP, FilenameUtils.normalize("a/b/../../c/"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../../c"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/.."));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/../"));
+        assertEquals("", FilenameUtils.normalize("a/b/../.."));
+        assertEquals("", FilenameUtils.normalize("a/b/../../"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../.."));
+        assertEquals("a" + SEP + "d", FilenameUtils.normalize("a/b/../c/../d"));
+        assertEquals("a" + SEP + "d" + SEP, FilenameUtils.normalize("a/b/../c/../d/"));
+        assertEquals("a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("a/b//d"));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/././."));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/./././"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("./a/"));
+        assertEquals("a", FilenameUtils.normalize("./a"));
+        assertEquals("", FilenameUtils.normalize("./"));
+        assertEquals("", FilenameUtils.normalize("."));
+        assertEquals(null, FilenameUtils.normalize("../a"));
+        assertEquals(null, FilenameUtils.normalize(".."));
+        assertEquals("", FilenameUtils.normalize(""));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/a"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/"));
+        assertEquals(SEP + "a" + SEP + "c", FilenameUtils.normalize("/a/b/../c"));
+        assertEquals(SEP + "c", FilenameUtils.normalize("/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../../c"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/b/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../.."));
+        assertEquals(SEP + "a" + SEP + "d", FilenameUtils.normalize("/a/b/../c/../d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("/a/b//d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("/a/b/././."));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/./a"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/./"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/."));
+        assertEquals(null, FilenameUtils.normalize("/../a"));
+        assertEquals(null, FilenameUtils.normalize("/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/"));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/a"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/"));
+        assertEquals("~" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~/a/b/../c"));
+        assertEquals("~" + SEP + "c", FilenameUtils.normalize("~/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../../c"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/b/.."));
+        assertEquals("~" + SEP + "", FilenameUtils.normalize("~/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../.."));
+        assertEquals("~" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~/a/b/../c/../d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~/a/b//d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~/a/b/././."));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/./a"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/./"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/."));
+        assertEquals(null, FilenameUtils.normalize("~/../a"));
+        assertEquals(null, FilenameUtils.normalize("~/.."));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~"));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/a"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/"));
+        assertEquals("~user" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~user/a/b/../c"));
+        assertEquals("~user" + SEP + "c", FilenameUtils.normalize("~user/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../../c"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/b/.."));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../.."));
+        assertEquals("~user" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~user/a/b/../c/../d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~user/a/b//d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~user/a/b/././."));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/./a"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/./"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/."));
+        assertEquals(null, FilenameUtils.normalize("~user/../a"));
+        assertEquals(null, FilenameUtils.normalize("~user/.."));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user/"));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user"));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/a"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/"));
+        assertEquals("C:" + SEP + "a" + SEP + "c", FilenameUtils.normalize("C:/a/b/../c"));
+        assertEquals("C:" + SEP + "c", FilenameUtils.normalize("C:/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../../c"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/b/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../.."));
+        assertEquals("C:" + SEP + "a" + SEP + "d", FilenameUtils.normalize("C:/a/b/../c/../d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:/a/b//d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:/a/b/././."));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/./a"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/./"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/."));
+        assertEquals(null, FilenameUtils.normalize("C:/../a"));
+        assertEquals(null, FilenameUtils.normalize("C:/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/"));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:a"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/"));
+        assertEquals("C:" + "a" + SEP + "c", FilenameUtils.normalize("C:a/b/../c"));
+        assertEquals("C:" + "c", FilenameUtils.normalize("C:a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../../c"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/b/.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../.."));
+        assertEquals("C:" + "a" + SEP + "d", FilenameUtils.normalize("C:a/b/../c/../d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:a/b//d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:a/b/././."));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:./a"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:./"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:."));
+        assertEquals(null, FilenameUtils.normalize("C:../a"));
+        assertEquals(null, FilenameUtils.normalize("C:.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:"));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/a"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "c", FilenameUtils.normalize("//server/a/b/../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "c", FilenameUtils.normalize("//server/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/b/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../.."));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "d", FilenameUtils.normalize("//server/a/b/../c/../d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("//server/a/b//d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("//server/a/b/././."));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/./a"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/./"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/."));
+        assertEquals(null, FilenameUtils.normalize("//server/../a"));
+        assertEquals(null, FilenameUtils.normalize("//server/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/"));
+        assertEquals(SEP + SEP + "127.0.0.1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\127.0.0.1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "::1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\::1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server.example.org" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.example.org\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server." + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\-server\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\..\\a\\b\\c.txt"));
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.1.0/src/test/java/TestUtils.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.1.0/src/test/java/TestUtils.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import external.org.apache.commons.io.FileUtils;
+import external.org.apache.commons.io.output.ByteArrayOutputStream;
+import junit.framework.AssertionFailedError;
+
+/**
+ * Base class for testcases doing tests with files.
+ */
+public abstract class TestUtils {
+
+    private TestUtils() {
+    }
+
+    public static void createFile(final File file, final long size) throws IOException {
+        if (!file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new java.io.FileOutputStream(file))) {
+            generateTestData(output, size);
+        }
+    }
+
+    public static byte[] generateTestData(final long size) {
+        try {
+            final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+            generateTestData(baout, size);
+            return baout.toByteArray();
+        } catch (final IOException ioe) {
+            throw new RuntimeException("This should never happen: " + ioe.getMessage());
+        }
+    }
+
+    public static void generateTestData(final OutputStream out, final long size) throws IOException {
+        for (int i = 0; i < size; i++) {
+            //output.write((byte)'X');
+            // nice varied byte pattern compatible with Readers and Writers
+            out.write((byte) ((i % 127) + 1));
+        }
+    }
+
+    public static void createLineBasedFile(final File file, final String[] data) throws IOException {
+        if (file.getParentFile() != null && !file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final PrintWriter output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))) {
+            for (final String element : data) {
+                output.println(element);
+            }
+        }
+    }
+
+    public static File newFile(final File testDirectory, final String filename) throws IOException {
+        final File destination = new File(testDirectory, filename);
+        /*
+        assertTrue( filename + "Test output data file shouldn't previously exist",
+                    !destination.exists() );
+        */
+        if (destination.exists()) {
+            FileUtils.forceDelete(destination);
+        }
+        return destination;
+    }
+
+    public static void checkFile(final File file, final File referenceFile) throws Exception {
+        assertTrue("Check existence of output file", file.exists());
+        assertEqualContent(referenceFile, file);
+    }
+
+    /**
+     * Assert that the content of two files is the same.
+     */
+    private static void assertEqualContent(final File f0, final File f1) throws IOException {
+        /* This doesn't work because the filesize isn't updated until the file
+         * is closed.
+        assertTrue( "The files " + f0 + " and " + f1 +
+                    " have differing file sizes (" + f0.length() +
+                    " vs " + f1.length() + ")", ( f0.length() == f1.length() ) );
+        */
+        try (InputStream is0 = new FileInputStream(f0)) {
+            try (InputStream is1 = new FileInputStream(f1)) {
+                final byte[] buf0 = new byte[1024];
+                final byte[] buf1 = new byte[1024];
+                int n0 = 0;
+                int n1;
+                while (-1 != n0) {
+                    n0 = is0.read(buf0);
+                    n1 = is1.read(buf1);
+                    assertTrue("The files " + f0 + " and " + f1 + " have differing number of bytes available (" + n0 + " vs " + n1 + ")", (n0 == n1));
+                    assertTrue("The files " + f0 + " and " + f1 + " have different content", Arrays.equals(buf0, buf1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a byte[].
+     *
+     * @param b0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final byte[] b0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final byte[] b1 = new byte[b0.length];
+        try (InputStream is = new FileInputStream(file)) {
+            while (count < b0.length && numRead >= 0) {
+                numRead = is.read(b1, count, b0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of bytes: ", b0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("byte " + i + " differs", b0[i], b1[i]);
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a char[].
+     *
+     * @param c0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final char[] c0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final char[] c1 = new char[c0.length];
+        try (Reader ir = new FileReader(file)) {
+            while (count < c0.length && numRead >= 0) {
+                numRead = ir.read(c1, count, c0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of chars: ", c0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("char " + i + " differs", c0[i], c1[i]);
+            }
+        }
+    }
+
+    public static void checkWrite(final OutputStream output) throws Exception {
+        try {
+            new java.io.PrintStream(output).write(0);
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void checkWrite(final Writer output) throws Exception {
+        try {
+            new java.io.PrintWriter(output).write('a');
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void deleteFile(final File file) throws Exception {
+        if (file.exists()) {
+            assertTrue("Couldn't delete file: " + file, file.delete());
+        }
+    }
+
+    /**
+     * Sleep for a guaranteed number of milliseconds unless interrupted.
+     *
+     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
+     * it deems appropriate. Read the docs on Thread.sleep for further details.
+     *
+     * @param ms the number of milliseconds to sleep for
+     * @throws InterruptedException if interrupted
+     */
+    public static void sleep(final long ms) throws InterruptedException {
+        final long finishAt = System.currentTimeMillis() + ms;
+        long remaining = ms;
+        do {
+            Thread.sleep(remaining);
+            remaining = finishAt - System.currentTimeMillis();
+        } while (remaining > 0);
+    }
+
+    public static void sleepQuietly(final long ms) {
+        try {
+            sleep(ms);
+        } catch (final InterruptedException ignored) {
+        }
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.2.0/README.md
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.2.0/README.md
@@ -1,0 +1,26 @@
+# [CVE-2021-29425 -- Commons-IO] (https://nvd.nist.gov/vuln/detail/CVE-2021-29425)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+
+
+Project uses `commons-io:commons-io:2.6` , tests from https://github.com/apache/commons-io/commit/2736b6fe0b3fa22ec8e2b4184897ecadb021fc78
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. irrelevant tests in class removed
+2. utility methods TestUtils
+3. JUnit version replaced by JUnit5 with JUnit4 vintage support
+4. uses Java 8 (note that compress does not have to be build)
+
+Note that the one test __fails__ indicating the vulnerability! After replacing `commons-io:commons-io:2.6` by `commons-io:commons-io:2.7`
+the respective test passes, indicating that the vulnerability has been fixed.
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2021-29425/com.virjar__ratel-api__1.2.0/pom.xml
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.2.0/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>com.virjar__ratel-api__1.2.0</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2021-29425 POV</description>
+    <name>CVE-2021-29425</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.virjar</groupId>
+            <artifactId>ratel-api</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2021-29425/com.virjar__ratel-api__1.2.0/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.2.0/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,255 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2021-29425",
+    "groupID" : "foo",
+    "artifactID" : "com.virjar__ratel-api__1.2.0",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:29:44.124546Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "ratel-api-1.2.0.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/com/virjar/ratel-api/1.2.0/ratel-api-1.2.0.jar",
+    "md5" : "c35cb5c3ad5a6091c3bbe792aff63574",
+    "sha1" : "2385d84ad3116629e911a9fdffce0a207957c185",
+    "sha256" : "30bb1d5838148fad4e15803145e59a7187dc038afc5445ac8758a523d8f89436",
+    "description" : "ratel api,used for developer on ratel system,an extension for xposed framewrok,ratel api compatable with original xposed framework",
+    "license" : "The Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/com.virjar__ratel-api__1.2.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "external"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.2.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.2.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.virjar/ratel-api@1.2.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.virjar/ratel-api@1.2.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  } ]
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.2.0/scan-results/grype/grype-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.2.0/scan-results/grype/grype-report.json
@@ -1,0 +1,96 @@
+{
+ "matches": [],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:12.311631337+13:00"
+ }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.2.0/scan-results/snyk/snyk-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.2.0/scan-results/snyk/snyk-report.json
@@ -1,0 +1,106 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 1,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": false,
+  "uniqueCount": 0,
+  "projectName": "foo:com.virjar__ratel-api__1.2.0",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2021-29425/com.virjar__ratel-api__1.2.0"
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.2.0/scan-results/steady/steady-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.2.0/scan-results/steady/steady-report.json
@@ -1,0 +1,27 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 22:26 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "com.virjar__ratel-api__1.2.0",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "PROVIDED, TEST" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+		]
+	}
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.2.0/src/test/java/FilenameUtilsTestCase.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.2.0/src/test/java/FilenameUtilsTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import external.org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is used to test FilenameUtils for correctness.
+ *
+ * @see FilenameUtils
+ */
+public class FilenameUtilsTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SEP = "" + File.separatorChar;
+
+    private static final boolean WINDOWS = File.separatorChar == '\\';
+
+    private File testFile1;
+
+    private File testFile2;
+
+    private int testFile1Size;
+
+    private int testFile2Size;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile1 = temporaryFolder.newFile("file1-test.txt");
+        testFile2 = temporaryFolder.newFile("file1a-test.txt");
+        testFile1Size = (int) testFile1.length();
+        testFile2Size = (int) testFile2.length();
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output3 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output3, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output2 = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output2, testFile2Size);
+        }
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output1 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output1, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output, testFile2Size);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void testNormalize() throws Exception {
+        assertEquals(null, FilenameUtils.normalize(null));
+        assertEquals(null, FilenameUtils.normalize(":"));
+        assertEquals(null, FilenameUtils.normalize("1:\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("1:"));
+        assertEquals(null, FilenameUtils.normalize("1:a"));
+        assertEquals(null, FilenameUtils.normalize("\\\\\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\a"));
+        assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c.txt"));
+        assertEquals("" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\a\\b/c.txt"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("C:\\a\\b/c.txt"));
+        assertEquals("" + SEP + "" + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server\\a\\b/c.txt"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~\\a\\b/c.txt"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~user\\a\\b/c.txt"));
+        assertEquals("a" + SEP + "c", FilenameUtils.normalize("a/b/../c"));
+        assertEquals("c", FilenameUtils.normalize("a/b/../../c"));
+        assertEquals("c" + SEP, FilenameUtils.normalize("a/b/../../c/"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../../c"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/.."));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/../"));
+        assertEquals("", FilenameUtils.normalize("a/b/../.."));
+        assertEquals("", FilenameUtils.normalize("a/b/../../"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../.."));
+        assertEquals("a" + SEP + "d", FilenameUtils.normalize("a/b/../c/../d"));
+        assertEquals("a" + SEP + "d" + SEP, FilenameUtils.normalize("a/b/../c/../d/"));
+        assertEquals("a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("a/b//d"));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/././."));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/./././"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("./a/"));
+        assertEquals("a", FilenameUtils.normalize("./a"));
+        assertEquals("", FilenameUtils.normalize("./"));
+        assertEquals("", FilenameUtils.normalize("."));
+        assertEquals(null, FilenameUtils.normalize("../a"));
+        assertEquals(null, FilenameUtils.normalize(".."));
+        assertEquals("", FilenameUtils.normalize(""));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/a"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/"));
+        assertEquals(SEP + "a" + SEP + "c", FilenameUtils.normalize("/a/b/../c"));
+        assertEquals(SEP + "c", FilenameUtils.normalize("/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../../c"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/b/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../.."));
+        assertEquals(SEP + "a" + SEP + "d", FilenameUtils.normalize("/a/b/../c/../d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("/a/b//d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("/a/b/././."));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/./a"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/./"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/."));
+        assertEquals(null, FilenameUtils.normalize("/../a"));
+        assertEquals(null, FilenameUtils.normalize("/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/"));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/a"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/"));
+        assertEquals("~" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~/a/b/../c"));
+        assertEquals("~" + SEP + "c", FilenameUtils.normalize("~/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../../c"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/b/.."));
+        assertEquals("~" + SEP + "", FilenameUtils.normalize("~/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../.."));
+        assertEquals("~" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~/a/b/../c/../d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~/a/b//d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~/a/b/././."));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/./a"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/./"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/."));
+        assertEquals(null, FilenameUtils.normalize("~/../a"));
+        assertEquals(null, FilenameUtils.normalize("~/.."));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~"));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/a"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/"));
+        assertEquals("~user" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~user/a/b/../c"));
+        assertEquals("~user" + SEP + "c", FilenameUtils.normalize("~user/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../../c"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/b/.."));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../.."));
+        assertEquals("~user" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~user/a/b/../c/../d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~user/a/b//d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~user/a/b/././."));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/./a"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/./"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/."));
+        assertEquals(null, FilenameUtils.normalize("~user/../a"));
+        assertEquals(null, FilenameUtils.normalize("~user/.."));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user/"));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user"));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/a"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/"));
+        assertEquals("C:" + SEP + "a" + SEP + "c", FilenameUtils.normalize("C:/a/b/../c"));
+        assertEquals("C:" + SEP + "c", FilenameUtils.normalize("C:/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../../c"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/b/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../.."));
+        assertEquals("C:" + SEP + "a" + SEP + "d", FilenameUtils.normalize("C:/a/b/../c/../d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:/a/b//d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:/a/b/././."));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/./a"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/./"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/."));
+        assertEquals(null, FilenameUtils.normalize("C:/../a"));
+        assertEquals(null, FilenameUtils.normalize("C:/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/"));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:a"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/"));
+        assertEquals("C:" + "a" + SEP + "c", FilenameUtils.normalize("C:a/b/../c"));
+        assertEquals("C:" + "c", FilenameUtils.normalize("C:a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../../c"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/b/.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../.."));
+        assertEquals("C:" + "a" + SEP + "d", FilenameUtils.normalize("C:a/b/../c/../d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:a/b//d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:a/b/././."));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:./a"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:./"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:."));
+        assertEquals(null, FilenameUtils.normalize("C:../a"));
+        assertEquals(null, FilenameUtils.normalize("C:.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:"));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/a"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "c", FilenameUtils.normalize("//server/a/b/../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "c", FilenameUtils.normalize("//server/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/b/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../.."));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "d", FilenameUtils.normalize("//server/a/b/../c/../d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("//server/a/b//d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("//server/a/b/././."));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/./a"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/./"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/."));
+        assertEquals(null, FilenameUtils.normalize("//server/../a"));
+        assertEquals(null, FilenameUtils.normalize("//server/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/"));
+        assertEquals(SEP + SEP + "127.0.0.1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\127.0.0.1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "::1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\::1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server.example.org" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.example.org\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server." + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\-server\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\..\\a\\b\\c.txt"));
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.2.0/src/test/java/TestUtils.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.2.0/src/test/java/TestUtils.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import external.org.apache.commons.io.FileUtils;
+import external.org.apache.commons.io.output.ByteArrayOutputStream;
+import junit.framework.AssertionFailedError;
+
+/**
+ * Base class for testcases doing tests with files.
+ */
+public abstract class TestUtils {
+
+    private TestUtils() {
+    }
+
+    public static void createFile(final File file, final long size) throws IOException {
+        if (!file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new java.io.FileOutputStream(file))) {
+            generateTestData(output, size);
+        }
+    }
+
+    public static byte[] generateTestData(final long size) {
+        try {
+            final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+            generateTestData(baout, size);
+            return baout.toByteArray();
+        } catch (final IOException ioe) {
+            throw new RuntimeException("This should never happen: " + ioe.getMessage());
+        }
+    }
+
+    public static void generateTestData(final OutputStream out, final long size) throws IOException {
+        for (int i = 0; i < size; i++) {
+            //output.write((byte)'X');
+            // nice varied byte pattern compatible with Readers and Writers
+            out.write((byte) ((i % 127) + 1));
+        }
+    }
+
+    public static void createLineBasedFile(final File file, final String[] data) throws IOException {
+        if (file.getParentFile() != null && !file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final PrintWriter output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))) {
+            for (final String element : data) {
+                output.println(element);
+            }
+        }
+    }
+
+    public static File newFile(final File testDirectory, final String filename) throws IOException {
+        final File destination = new File(testDirectory, filename);
+        /*
+        assertTrue( filename + "Test output data file shouldn't previously exist",
+                    !destination.exists() );
+        */
+        if (destination.exists()) {
+            FileUtils.forceDelete(destination);
+        }
+        return destination;
+    }
+
+    public static void checkFile(final File file, final File referenceFile) throws Exception {
+        assertTrue("Check existence of output file", file.exists());
+        assertEqualContent(referenceFile, file);
+    }
+
+    /**
+     * Assert that the content of two files is the same.
+     */
+    private static void assertEqualContent(final File f0, final File f1) throws IOException {
+        /* This doesn't work because the filesize isn't updated until the file
+         * is closed.
+        assertTrue( "The files " + f0 + " and " + f1 +
+                    " have differing file sizes (" + f0.length() +
+                    " vs " + f1.length() + ")", ( f0.length() == f1.length() ) );
+        */
+        try (InputStream is0 = new FileInputStream(f0)) {
+            try (InputStream is1 = new FileInputStream(f1)) {
+                final byte[] buf0 = new byte[1024];
+                final byte[] buf1 = new byte[1024];
+                int n0 = 0;
+                int n1;
+                while (-1 != n0) {
+                    n0 = is0.read(buf0);
+                    n1 = is1.read(buf1);
+                    assertTrue("The files " + f0 + " and " + f1 + " have differing number of bytes available (" + n0 + " vs " + n1 + ")", (n0 == n1));
+                    assertTrue("The files " + f0 + " and " + f1 + " have different content", Arrays.equals(buf0, buf1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a byte[].
+     *
+     * @param b0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final byte[] b0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final byte[] b1 = new byte[b0.length];
+        try (InputStream is = new FileInputStream(file)) {
+            while (count < b0.length && numRead >= 0) {
+                numRead = is.read(b1, count, b0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of bytes: ", b0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("byte " + i + " differs", b0[i], b1[i]);
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a char[].
+     *
+     * @param c0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final char[] c0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final char[] c1 = new char[c0.length];
+        try (Reader ir = new FileReader(file)) {
+            while (count < c0.length && numRead >= 0) {
+                numRead = ir.read(c1, count, c0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of chars: ", c0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("char " + i + " differs", c0[i], c1[i]);
+            }
+        }
+    }
+
+    public static void checkWrite(final OutputStream output) throws Exception {
+        try {
+            new java.io.PrintStream(output).write(0);
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void checkWrite(final Writer output) throws Exception {
+        try {
+            new java.io.PrintWriter(output).write('a');
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void deleteFile(final File file) throws Exception {
+        if (file.exists()) {
+            assertTrue("Couldn't delete file: " + file, file.delete());
+        }
+    }
+
+    /**
+     * Sleep for a guaranteed number of milliseconds unless interrupted.
+     *
+     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
+     * it deems appropriate. Read the docs on Thread.sleep for further details.
+     *
+     * @param ms the number of milliseconds to sleep for
+     * @throws InterruptedException if interrupted
+     */
+    public static void sleep(final long ms) throws InterruptedException {
+        final long finishAt = System.currentTimeMillis() + ms;
+        long remaining = ms;
+        do {
+            Thread.sleep(remaining);
+            remaining = finishAt - System.currentTimeMillis();
+        } while (remaining > 0);
+    }
+
+    public static void sleepQuietly(final long ms) {
+        try {
+            sleep(ms);
+        } catch (final InterruptedException ignored) {
+        }
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.0/README.md
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.0/README.md
@@ -1,0 +1,26 @@
+# [CVE-2021-29425 -- Commons-IO] (https://nvd.nist.gov/vuln/detail/CVE-2021-29425)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+
+
+Project uses `commons-io:commons-io:2.6` , tests from https://github.com/apache/commons-io/commit/2736b6fe0b3fa22ec8e2b4184897ecadb021fc78
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. irrelevant tests in class removed
+2. utility methods TestUtils
+3. JUnit version replaced by JUnit5 with JUnit4 vintage support
+4. uses Java 8 (note that compress does not have to be build)
+
+Note that the one test __fails__ indicating the vulnerability! After replacing `commons-io:commons-io:2.6` by `commons-io:commons-io:2.7`
+the respective test passes, indicating that the vulnerability has been fixed.
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.0/pom.xml
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.0/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>com.virjar__ratel-api__1.3.0</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2021-29425 POV</description>
+    <name>CVE-2021-29425</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.virjar</groupId>
+            <artifactId>ratel-api</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.0/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.0/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,255 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2021-29425",
+    "groupID" : "foo",
+    "artifactID" : "com.virjar__ratel-api__1.3.0",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:29:51.661034Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "ratel-api-1.3.0.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/com/virjar/ratel-api/1.3.0/ratel-api-1.3.0.jar",
+    "md5" : "1447fe738746de3d5de7000059c68ed6",
+    "sha1" : "19260750c65c130aeaef387bcb010e3698ba4ddb",
+    "sha256" : "9a9181ce2f761e8e8ee3e3ac266c9a34bf12ee8ae15338ac8053cc32aa53082f",
+    "description" : "ratel api,used for developer on ratel system,an extension for xposed framewrok,ratel api compatable with original xposed framework",
+    "license" : "The Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/com.virjar__ratel-api__1.3.0@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "external"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.3.0"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.3.0"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.virjar/ratel-api@1.3.0",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.virjar/ratel-api@1.3.0?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  } ]
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.0/scan-results/grype/grype-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.0/scan-results/grype/grype-report.json
@@ -1,0 +1,96 @@
+{
+ "matches": [],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:12.374910518+13:00"
+ }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.0/scan-results/snyk/snyk-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.0/scan-results/snyk/snyk-report.json
@@ -1,0 +1,106 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 1,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": false,
+  "uniqueCount": 0,
+  "projectName": "foo:com.virjar__ratel-api__1.3.0",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2021-29425/com.virjar__ratel-api__1.3.0"
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.0/scan-results/steady/steady-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.0/scan-results/steady/steady-report.json
@@ -1,0 +1,27 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 22:26 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "com.virjar__ratel-api__1.3.0",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "TEST, PROVIDED" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+		]
+	}
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.0/src/test/java/FilenameUtilsTestCase.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.0/src/test/java/FilenameUtilsTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import external.org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is used to test FilenameUtils for correctness.
+ *
+ * @see FilenameUtils
+ */
+public class FilenameUtilsTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SEP = "" + File.separatorChar;
+
+    private static final boolean WINDOWS = File.separatorChar == '\\';
+
+    private File testFile1;
+
+    private File testFile2;
+
+    private int testFile1Size;
+
+    private int testFile2Size;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile1 = temporaryFolder.newFile("file1-test.txt");
+        testFile2 = temporaryFolder.newFile("file1a-test.txt");
+        testFile1Size = (int) testFile1.length();
+        testFile2Size = (int) testFile2.length();
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output3 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output3, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output2 = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output2, testFile2Size);
+        }
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output1 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output1, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output, testFile2Size);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void testNormalize() throws Exception {
+        assertEquals(null, FilenameUtils.normalize(null));
+        assertEquals(null, FilenameUtils.normalize(":"));
+        assertEquals(null, FilenameUtils.normalize("1:\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("1:"));
+        assertEquals(null, FilenameUtils.normalize("1:a"));
+        assertEquals(null, FilenameUtils.normalize("\\\\\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\a"));
+        assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c.txt"));
+        assertEquals("" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\a\\b/c.txt"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("C:\\a\\b/c.txt"));
+        assertEquals("" + SEP + "" + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server\\a\\b/c.txt"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~\\a\\b/c.txt"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~user\\a\\b/c.txt"));
+        assertEquals("a" + SEP + "c", FilenameUtils.normalize("a/b/../c"));
+        assertEquals("c", FilenameUtils.normalize("a/b/../../c"));
+        assertEquals("c" + SEP, FilenameUtils.normalize("a/b/../../c/"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../../c"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/.."));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/../"));
+        assertEquals("", FilenameUtils.normalize("a/b/../.."));
+        assertEquals("", FilenameUtils.normalize("a/b/../../"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../.."));
+        assertEquals("a" + SEP + "d", FilenameUtils.normalize("a/b/../c/../d"));
+        assertEquals("a" + SEP + "d" + SEP, FilenameUtils.normalize("a/b/../c/../d/"));
+        assertEquals("a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("a/b//d"));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/././."));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/./././"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("./a/"));
+        assertEquals("a", FilenameUtils.normalize("./a"));
+        assertEquals("", FilenameUtils.normalize("./"));
+        assertEquals("", FilenameUtils.normalize("."));
+        assertEquals(null, FilenameUtils.normalize("../a"));
+        assertEquals(null, FilenameUtils.normalize(".."));
+        assertEquals("", FilenameUtils.normalize(""));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/a"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/"));
+        assertEquals(SEP + "a" + SEP + "c", FilenameUtils.normalize("/a/b/../c"));
+        assertEquals(SEP + "c", FilenameUtils.normalize("/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../../c"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/b/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../.."));
+        assertEquals(SEP + "a" + SEP + "d", FilenameUtils.normalize("/a/b/../c/../d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("/a/b//d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("/a/b/././."));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/./a"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/./"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/."));
+        assertEquals(null, FilenameUtils.normalize("/../a"));
+        assertEquals(null, FilenameUtils.normalize("/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/"));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/a"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/"));
+        assertEquals("~" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~/a/b/../c"));
+        assertEquals("~" + SEP + "c", FilenameUtils.normalize("~/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../../c"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/b/.."));
+        assertEquals("~" + SEP + "", FilenameUtils.normalize("~/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../.."));
+        assertEquals("~" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~/a/b/../c/../d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~/a/b//d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~/a/b/././."));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/./a"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/./"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/."));
+        assertEquals(null, FilenameUtils.normalize("~/../a"));
+        assertEquals(null, FilenameUtils.normalize("~/.."));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~"));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/a"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/"));
+        assertEquals("~user" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~user/a/b/../c"));
+        assertEquals("~user" + SEP + "c", FilenameUtils.normalize("~user/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../../c"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/b/.."));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../.."));
+        assertEquals("~user" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~user/a/b/../c/../d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~user/a/b//d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~user/a/b/././."));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/./a"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/./"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/."));
+        assertEquals(null, FilenameUtils.normalize("~user/../a"));
+        assertEquals(null, FilenameUtils.normalize("~user/.."));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user/"));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user"));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/a"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/"));
+        assertEquals("C:" + SEP + "a" + SEP + "c", FilenameUtils.normalize("C:/a/b/../c"));
+        assertEquals("C:" + SEP + "c", FilenameUtils.normalize("C:/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../../c"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/b/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../.."));
+        assertEquals("C:" + SEP + "a" + SEP + "d", FilenameUtils.normalize("C:/a/b/../c/../d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:/a/b//d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:/a/b/././."));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/./a"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/./"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/."));
+        assertEquals(null, FilenameUtils.normalize("C:/../a"));
+        assertEquals(null, FilenameUtils.normalize("C:/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/"));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:a"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/"));
+        assertEquals("C:" + "a" + SEP + "c", FilenameUtils.normalize("C:a/b/../c"));
+        assertEquals("C:" + "c", FilenameUtils.normalize("C:a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../../c"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/b/.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../.."));
+        assertEquals("C:" + "a" + SEP + "d", FilenameUtils.normalize("C:a/b/../c/../d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:a/b//d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:a/b/././."));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:./a"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:./"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:."));
+        assertEquals(null, FilenameUtils.normalize("C:../a"));
+        assertEquals(null, FilenameUtils.normalize("C:.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:"));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/a"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "c", FilenameUtils.normalize("//server/a/b/../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "c", FilenameUtils.normalize("//server/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/b/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../.."));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "d", FilenameUtils.normalize("//server/a/b/../c/../d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("//server/a/b//d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("//server/a/b/././."));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/./a"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/./"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/."));
+        assertEquals(null, FilenameUtils.normalize("//server/../a"));
+        assertEquals(null, FilenameUtils.normalize("//server/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/"));
+        assertEquals(SEP + SEP + "127.0.0.1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\127.0.0.1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "::1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\::1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server.example.org" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.example.org\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server." + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\-server\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\..\\a\\b\\c.txt"));
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.0/src/test/java/TestUtils.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.0/src/test/java/TestUtils.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import external.org.apache.commons.io.FileUtils;
+import external.org.apache.commons.io.output.ByteArrayOutputStream;
+import junit.framework.AssertionFailedError;
+
+/**
+ * Base class for testcases doing tests with files.
+ */
+public abstract class TestUtils {
+
+    private TestUtils() {
+    }
+
+    public static void createFile(final File file, final long size) throws IOException {
+        if (!file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new java.io.FileOutputStream(file))) {
+            generateTestData(output, size);
+        }
+    }
+
+    public static byte[] generateTestData(final long size) {
+        try {
+            final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+            generateTestData(baout, size);
+            return baout.toByteArray();
+        } catch (final IOException ioe) {
+            throw new RuntimeException("This should never happen: " + ioe.getMessage());
+        }
+    }
+
+    public static void generateTestData(final OutputStream out, final long size) throws IOException {
+        for (int i = 0; i < size; i++) {
+            //output.write((byte)'X');
+            // nice varied byte pattern compatible with Readers and Writers
+            out.write((byte) ((i % 127) + 1));
+        }
+    }
+
+    public static void createLineBasedFile(final File file, final String[] data) throws IOException {
+        if (file.getParentFile() != null && !file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final PrintWriter output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))) {
+            for (final String element : data) {
+                output.println(element);
+            }
+        }
+    }
+
+    public static File newFile(final File testDirectory, final String filename) throws IOException {
+        final File destination = new File(testDirectory, filename);
+        /*
+        assertTrue( filename + "Test output data file shouldn't previously exist",
+                    !destination.exists() );
+        */
+        if (destination.exists()) {
+            FileUtils.forceDelete(destination);
+        }
+        return destination;
+    }
+
+    public static void checkFile(final File file, final File referenceFile) throws Exception {
+        assertTrue("Check existence of output file", file.exists());
+        assertEqualContent(referenceFile, file);
+    }
+
+    /**
+     * Assert that the content of two files is the same.
+     */
+    private static void assertEqualContent(final File f0, final File f1) throws IOException {
+        /* This doesn't work because the filesize isn't updated until the file
+         * is closed.
+        assertTrue( "The files " + f0 + " and " + f1 +
+                    " have differing file sizes (" + f0.length() +
+                    " vs " + f1.length() + ")", ( f0.length() == f1.length() ) );
+        */
+        try (InputStream is0 = new FileInputStream(f0)) {
+            try (InputStream is1 = new FileInputStream(f1)) {
+                final byte[] buf0 = new byte[1024];
+                final byte[] buf1 = new byte[1024];
+                int n0 = 0;
+                int n1;
+                while (-1 != n0) {
+                    n0 = is0.read(buf0);
+                    n1 = is1.read(buf1);
+                    assertTrue("The files " + f0 + " and " + f1 + " have differing number of bytes available (" + n0 + " vs " + n1 + ")", (n0 == n1));
+                    assertTrue("The files " + f0 + " and " + f1 + " have different content", Arrays.equals(buf0, buf1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a byte[].
+     *
+     * @param b0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final byte[] b0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final byte[] b1 = new byte[b0.length];
+        try (InputStream is = new FileInputStream(file)) {
+            while (count < b0.length && numRead >= 0) {
+                numRead = is.read(b1, count, b0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of bytes: ", b0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("byte " + i + " differs", b0[i], b1[i]);
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a char[].
+     *
+     * @param c0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final char[] c0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final char[] c1 = new char[c0.length];
+        try (Reader ir = new FileReader(file)) {
+            while (count < c0.length && numRead >= 0) {
+                numRead = ir.read(c1, count, c0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of chars: ", c0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("char " + i + " differs", c0[i], c1[i]);
+            }
+        }
+    }
+
+    public static void checkWrite(final OutputStream output) throws Exception {
+        try {
+            new java.io.PrintStream(output).write(0);
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void checkWrite(final Writer output) throws Exception {
+        try {
+            new java.io.PrintWriter(output).write('a');
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void deleteFile(final File file) throws Exception {
+        if (file.exists()) {
+            assertTrue("Couldn't delete file: " + file, file.delete());
+        }
+    }
+
+    /**
+     * Sleep for a guaranteed number of milliseconds unless interrupted.
+     *
+     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
+     * it deems appropriate. Read the docs on Thread.sleep for further details.
+     *
+     * @param ms the number of milliseconds to sleep for
+     * @throws InterruptedException if interrupted
+     */
+    public static void sleep(final long ms) throws InterruptedException {
+        final long finishAt = System.currentTimeMillis() + ms;
+        long remaining = ms;
+        do {
+            Thread.sleep(remaining);
+            remaining = finishAt - System.currentTimeMillis();
+        } while (remaining > 0);
+    }
+
+    public static void sleepQuietly(final long ms) {
+        try {
+            sleep(ms);
+        } catch (final InterruptedException ignored) {
+        }
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.1/README.md
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.1/README.md
@@ -1,0 +1,26 @@
+# [CVE-2021-29425 -- Commons-IO] (https://nvd.nist.gov/vuln/detail/CVE-2021-29425)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+
+
+Project uses `commons-io:commons-io:2.6` , tests from https://github.com/apache/commons-io/commit/2736b6fe0b3fa22ec8e2b4184897ecadb021fc78
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. irrelevant tests in class removed
+2. utility methods TestUtils
+3. JUnit version replaced by JUnit5 with JUnit4 vintage support
+4. uses Java 8 (note that compress does not have to be build)
+
+Note that the one test __fails__ indicating the vulnerability! After replacing `commons-io:commons-io:2.6` by `commons-io:commons-io:2.7`
+the respective test passes, indicating that the vulnerability has been fixed.
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.1/pom.xml
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.1/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>com.virjar__ratel-api__1.3.1</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2021-29425 POV</description>
+    <name>CVE-2021-29425</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.virjar</groupId>
+            <artifactId>ratel-api</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.1/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.1/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,255 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2021-29425",
+    "groupID" : "foo",
+    "artifactID" : "com.virjar__ratel-api__1.3.1",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:29:59.084670Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "ratel-api-1.3.1.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/com/virjar/ratel-api/1.3.1/ratel-api-1.3.1.jar",
+    "md5" : "1355cc25aa5f842b0b99f0ec2129dd75",
+    "sha1" : "1762046425ab7acc1b6db28793ce84a72a4528a1",
+    "sha256" : "1a0654b40d82b7f6729e38b3eca8b14d7d234e69e97ad8dc1e8c4e9589336fa7",
+    "description" : "ratel api,used for developer on ratel system,an extension for xposed framewrok,ratel api compatable with original xposed framework",
+    "license" : "The Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/com.virjar__ratel-api__1.3.1@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "external"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.3.1"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.3.1"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.virjar/ratel-api@1.3.1",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.virjar/ratel-api@1.3.1?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  } ]
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.1/scan-results/grype/grype-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.1/scan-results/grype/grype-report.json
@@ -1,0 +1,96 @@
+{
+ "matches": [],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:12.435331414+13:00"
+ }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.1/scan-results/snyk/snyk-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.1/scan-results/snyk/snyk-report.json
@@ -1,0 +1,106 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 1,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": false,
+  "uniqueCount": 0,
+  "projectName": "foo:com.virjar__ratel-api__1.3.1",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2021-29425/com.virjar__ratel-api__1.3.1"
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.1/scan-results/steady/steady-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.1/scan-results/steady/steady-report.json
@@ -1,0 +1,27 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 22:26 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "com.virjar__ratel-api__1.3.1",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "TEST, PROVIDED" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+		]
+	}
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.1/src/test/java/FilenameUtilsTestCase.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.1/src/test/java/FilenameUtilsTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import external.org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is used to test FilenameUtils for correctness.
+ *
+ * @see FilenameUtils
+ */
+public class FilenameUtilsTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SEP = "" + File.separatorChar;
+
+    private static final boolean WINDOWS = File.separatorChar == '\\';
+
+    private File testFile1;
+
+    private File testFile2;
+
+    private int testFile1Size;
+
+    private int testFile2Size;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile1 = temporaryFolder.newFile("file1-test.txt");
+        testFile2 = temporaryFolder.newFile("file1a-test.txt");
+        testFile1Size = (int) testFile1.length();
+        testFile2Size = (int) testFile2.length();
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output3 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output3, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output2 = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output2, testFile2Size);
+        }
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output1 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output1, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output, testFile2Size);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void testNormalize() throws Exception {
+        assertEquals(null, FilenameUtils.normalize(null));
+        assertEquals(null, FilenameUtils.normalize(":"));
+        assertEquals(null, FilenameUtils.normalize("1:\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("1:"));
+        assertEquals(null, FilenameUtils.normalize("1:a"));
+        assertEquals(null, FilenameUtils.normalize("\\\\\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\a"));
+        assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c.txt"));
+        assertEquals("" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\a\\b/c.txt"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("C:\\a\\b/c.txt"));
+        assertEquals("" + SEP + "" + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server\\a\\b/c.txt"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~\\a\\b/c.txt"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~user\\a\\b/c.txt"));
+        assertEquals("a" + SEP + "c", FilenameUtils.normalize("a/b/../c"));
+        assertEquals("c", FilenameUtils.normalize("a/b/../../c"));
+        assertEquals("c" + SEP, FilenameUtils.normalize("a/b/../../c/"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../../c"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/.."));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/../"));
+        assertEquals("", FilenameUtils.normalize("a/b/../.."));
+        assertEquals("", FilenameUtils.normalize("a/b/../../"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../.."));
+        assertEquals("a" + SEP + "d", FilenameUtils.normalize("a/b/../c/../d"));
+        assertEquals("a" + SEP + "d" + SEP, FilenameUtils.normalize("a/b/../c/../d/"));
+        assertEquals("a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("a/b//d"));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/././."));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/./././"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("./a/"));
+        assertEquals("a", FilenameUtils.normalize("./a"));
+        assertEquals("", FilenameUtils.normalize("./"));
+        assertEquals("", FilenameUtils.normalize("."));
+        assertEquals(null, FilenameUtils.normalize("../a"));
+        assertEquals(null, FilenameUtils.normalize(".."));
+        assertEquals("", FilenameUtils.normalize(""));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/a"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/"));
+        assertEquals(SEP + "a" + SEP + "c", FilenameUtils.normalize("/a/b/../c"));
+        assertEquals(SEP + "c", FilenameUtils.normalize("/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../../c"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/b/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../.."));
+        assertEquals(SEP + "a" + SEP + "d", FilenameUtils.normalize("/a/b/../c/../d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("/a/b//d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("/a/b/././."));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/./a"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/./"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/."));
+        assertEquals(null, FilenameUtils.normalize("/../a"));
+        assertEquals(null, FilenameUtils.normalize("/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/"));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/a"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/"));
+        assertEquals("~" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~/a/b/../c"));
+        assertEquals("~" + SEP + "c", FilenameUtils.normalize("~/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../../c"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/b/.."));
+        assertEquals("~" + SEP + "", FilenameUtils.normalize("~/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../.."));
+        assertEquals("~" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~/a/b/../c/../d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~/a/b//d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~/a/b/././."));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/./a"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/./"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/."));
+        assertEquals(null, FilenameUtils.normalize("~/../a"));
+        assertEquals(null, FilenameUtils.normalize("~/.."));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~"));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/a"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/"));
+        assertEquals("~user" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~user/a/b/../c"));
+        assertEquals("~user" + SEP + "c", FilenameUtils.normalize("~user/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../../c"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/b/.."));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../.."));
+        assertEquals("~user" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~user/a/b/../c/../d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~user/a/b//d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~user/a/b/././."));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/./a"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/./"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/."));
+        assertEquals(null, FilenameUtils.normalize("~user/../a"));
+        assertEquals(null, FilenameUtils.normalize("~user/.."));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user/"));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user"));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/a"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/"));
+        assertEquals("C:" + SEP + "a" + SEP + "c", FilenameUtils.normalize("C:/a/b/../c"));
+        assertEquals("C:" + SEP + "c", FilenameUtils.normalize("C:/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../../c"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/b/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../.."));
+        assertEquals("C:" + SEP + "a" + SEP + "d", FilenameUtils.normalize("C:/a/b/../c/../d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:/a/b//d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:/a/b/././."));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/./a"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/./"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/."));
+        assertEquals(null, FilenameUtils.normalize("C:/../a"));
+        assertEquals(null, FilenameUtils.normalize("C:/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/"));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:a"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/"));
+        assertEquals("C:" + "a" + SEP + "c", FilenameUtils.normalize("C:a/b/../c"));
+        assertEquals("C:" + "c", FilenameUtils.normalize("C:a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../../c"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/b/.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../.."));
+        assertEquals("C:" + "a" + SEP + "d", FilenameUtils.normalize("C:a/b/../c/../d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:a/b//d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:a/b/././."));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:./a"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:./"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:."));
+        assertEquals(null, FilenameUtils.normalize("C:../a"));
+        assertEquals(null, FilenameUtils.normalize("C:.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:"));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/a"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "c", FilenameUtils.normalize("//server/a/b/../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "c", FilenameUtils.normalize("//server/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/b/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../.."));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "d", FilenameUtils.normalize("//server/a/b/../c/../d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("//server/a/b//d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("//server/a/b/././."));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/./a"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/./"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/."));
+        assertEquals(null, FilenameUtils.normalize("//server/../a"));
+        assertEquals(null, FilenameUtils.normalize("//server/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/"));
+        assertEquals(SEP + SEP + "127.0.0.1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\127.0.0.1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "::1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\::1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server.example.org" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.example.org\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server." + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\-server\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\..\\a\\b\\c.txt"));
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.1/src/test/java/TestUtils.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.1/src/test/java/TestUtils.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import external.org.apache.commons.io.FileUtils;
+import external.org.apache.commons.io.output.ByteArrayOutputStream;
+import junit.framework.AssertionFailedError;
+
+/**
+ * Base class for testcases doing tests with files.
+ */
+public abstract class TestUtils {
+
+    private TestUtils() {
+    }
+
+    public static void createFile(final File file, final long size) throws IOException {
+        if (!file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new java.io.FileOutputStream(file))) {
+            generateTestData(output, size);
+        }
+    }
+
+    public static byte[] generateTestData(final long size) {
+        try {
+            final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+            generateTestData(baout, size);
+            return baout.toByteArray();
+        } catch (final IOException ioe) {
+            throw new RuntimeException("This should never happen: " + ioe.getMessage());
+        }
+    }
+
+    public static void generateTestData(final OutputStream out, final long size) throws IOException {
+        for (int i = 0; i < size; i++) {
+            //output.write((byte)'X');
+            // nice varied byte pattern compatible with Readers and Writers
+            out.write((byte) ((i % 127) + 1));
+        }
+    }
+
+    public static void createLineBasedFile(final File file, final String[] data) throws IOException {
+        if (file.getParentFile() != null && !file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final PrintWriter output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))) {
+            for (final String element : data) {
+                output.println(element);
+            }
+        }
+    }
+
+    public static File newFile(final File testDirectory, final String filename) throws IOException {
+        final File destination = new File(testDirectory, filename);
+        /*
+        assertTrue( filename + "Test output data file shouldn't previously exist",
+                    !destination.exists() );
+        */
+        if (destination.exists()) {
+            FileUtils.forceDelete(destination);
+        }
+        return destination;
+    }
+
+    public static void checkFile(final File file, final File referenceFile) throws Exception {
+        assertTrue("Check existence of output file", file.exists());
+        assertEqualContent(referenceFile, file);
+    }
+
+    /**
+     * Assert that the content of two files is the same.
+     */
+    private static void assertEqualContent(final File f0, final File f1) throws IOException {
+        /* This doesn't work because the filesize isn't updated until the file
+         * is closed.
+        assertTrue( "The files " + f0 + " and " + f1 +
+                    " have differing file sizes (" + f0.length() +
+                    " vs " + f1.length() + ")", ( f0.length() == f1.length() ) );
+        */
+        try (InputStream is0 = new FileInputStream(f0)) {
+            try (InputStream is1 = new FileInputStream(f1)) {
+                final byte[] buf0 = new byte[1024];
+                final byte[] buf1 = new byte[1024];
+                int n0 = 0;
+                int n1;
+                while (-1 != n0) {
+                    n0 = is0.read(buf0);
+                    n1 = is1.read(buf1);
+                    assertTrue("The files " + f0 + " and " + f1 + " have differing number of bytes available (" + n0 + " vs " + n1 + ")", (n0 == n1));
+                    assertTrue("The files " + f0 + " and " + f1 + " have different content", Arrays.equals(buf0, buf1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a byte[].
+     *
+     * @param b0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final byte[] b0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final byte[] b1 = new byte[b0.length];
+        try (InputStream is = new FileInputStream(file)) {
+            while (count < b0.length && numRead >= 0) {
+                numRead = is.read(b1, count, b0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of bytes: ", b0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("byte " + i + " differs", b0[i], b1[i]);
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a char[].
+     *
+     * @param c0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final char[] c0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final char[] c1 = new char[c0.length];
+        try (Reader ir = new FileReader(file)) {
+            while (count < c0.length && numRead >= 0) {
+                numRead = ir.read(c1, count, c0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of chars: ", c0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("char " + i + " differs", c0[i], c1[i]);
+            }
+        }
+    }
+
+    public static void checkWrite(final OutputStream output) throws Exception {
+        try {
+            new java.io.PrintStream(output).write(0);
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void checkWrite(final Writer output) throws Exception {
+        try {
+            new java.io.PrintWriter(output).write('a');
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void deleteFile(final File file) throws Exception {
+        if (file.exists()) {
+            assertTrue("Couldn't delete file: " + file, file.delete());
+        }
+    }
+
+    /**
+     * Sleep for a guaranteed number of milliseconds unless interrupted.
+     *
+     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
+     * it deems appropriate. Read the docs on Thread.sleep for further details.
+     *
+     * @param ms the number of milliseconds to sleep for
+     * @throws InterruptedException if interrupted
+     */
+    public static void sleep(final long ms) throws InterruptedException {
+        final long finishAt = System.currentTimeMillis() + ms;
+        long remaining = ms;
+        do {
+            Thread.sleep(remaining);
+            remaining = finishAt - System.currentTimeMillis();
+        } while (remaining > 0);
+    }
+
+    public static void sleepQuietly(final long ms) {
+        try {
+            sleep(ms);
+        } catch (final InterruptedException ignored) {
+        }
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.2/README.md
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.2/README.md
@@ -1,0 +1,26 @@
+# [CVE-2021-29425 -- Commons-IO] (https://nvd.nist.gov/vuln/detail/CVE-2021-29425)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+
+
+Project uses `commons-io:commons-io:2.6` , tests from https://github.com/apache/commons-io/commit/2736b6fe0b3fa22ec8e2b4184897ecadb021fc78
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. irrelevant tests in class removed
+2. utility methods TestUtils
+3. JUnit version replaced by JUnit5 with JUnit4 vintage support
+4. uses Java 8 (note that compress does not have to be build)
+
+Note that the one test __fails__ indicating the vulnerability! After replacing `commons-io:commons-io:2.6` by `commons-io:commons-io:2.7`
+the respective test passes, indicating that the vulnerability has been fixed.
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.2/pom.xml
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.2/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>com.virjar__ratel-api__1.3.2</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2021-29425 POV</description>
+    <name>CVE-2021-29425</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.virjar</groupId>
+            <artifactId>ratel-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.2/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.2/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,255 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2021-29425",
+    "groupID" : "foo",
+    "artifactID" : "com.virjar__ratel-api__1.3.2",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:30:06.480390Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "ratel-api-1.3.2.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/com/virjar/ratel-api/1.3.2/ratel-api-1.3.2.jar",
+    "md5" : "2798519d890aaa211aba29d1d231ab7e",
+    "sha1" : "89842748251a75e1bb836265792635cc11316cb2",
+    "sha256" : "f35f795da5183d9324e6e251be0540d880ce71738853b39e3c0e96656f345243",
+    "description" : "ratel api,used for developer on ratel system,an extension for xposed framewrok,ratel api compatable with original xposed framework",
+    "license" : "The Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/com.virjar__ratel-api__1.3.2@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "external"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.3.2"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.3.2"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.virjar/ratel-api@1.3.2",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.virjar/ratel-api@1.3.2?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  } ]
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.2/scan-results/grype/grype-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.2/scan-results/grype/grype-report.json
@@ -1,0 +1,96 @@
+{
+ "matches": [],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:12.49301811+13:00"
+ }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.2/scan-results/snyk/snyk-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.2/scan-results/snyk/snyk-report.json
@@ -1,0 +1,106 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 1,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": false,
+  "uniqueCount": 0,
+  "projectName": "foo:com.virjar__ratel-api__1.3.2",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2021-29425/com.virjar__ratel-api__1.3.2"
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.2/scan-results/steady/steady-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.2/scan-results/steady/steady-report.json
@@ -1,0 +1,27 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 22:26 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "com.virjar__ratel-api__1.3.2",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "PROVIDED, TEST" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+		]
+	}
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.2/src/test/java/FilenameUtilsTestCase.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.2/src/test/java/FilenameUtilsTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import external.org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is used to test FilenameUtils for correctness.
+ *
+ * @see FilenameUtils
+ */
+public class FilenameUtilsTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SEP = "" + File.separatorChar;
+
+    private static final boolean WINDOWS = File.separatorChar == '\\';
+
+    private File testFile1;
+
+    private File testFile2;
+
+    private int testFile1Size;
+
+    private int testFile2Size;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile1 = temporaryFolder.newFile("file1-test.txt");
+        testFile2 = temporaryFolder.newFile("file1a-test.txt");
+        testFile1Size = (int) testFile1.length();
+        testFile2Size = (int) testFile2.length();
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output3 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output3, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output2 = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output2, testFile2Size);
+        }
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output1 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output1, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output, testFile2Size);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void testNormalize() throws Exception {
+        assertEquals(null, FilenameUtils.normalize(null));
+        assertEquals(null, FilenameUtils.normalize(":"));
+        assertEquals(null, FilenameUtils.normalize("1:\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("1:"));
+        assertEquals(null, FilenameUtils.normalize("1:a"));
+        assertEquals(null, FilenameUtils.normalize("\\\\\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\a"));
+        assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c.txt"));
+        assertEquals("" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\a\\b/c.txt"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("C:\\a\\b/c.txt"));
+        assertEquals("" + SEP + "" + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server\\a\\b/c.txt"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~\\a\\b/c.txt"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~user\\a\\b/c.txt"));
+        assertEquals("a" + SEP + "c", FilenameUtils.normalize("a/b/../c"));
+        assertEquals("c", FilenameUtils.normalize("a/b/../../c"));
+        assertEquals("c" + SEP, FilenameUtils.normalize("a/b/../../c/"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../../c"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/.."));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/../"));
+        assertEquals("", FilenameUtils.normalize("a/b/../.."));
+        assertEquals("", FilenameUtils.normalize("a/b/../../"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../.."));
+        assertEquals("a" + SEP + "d", FilenameUtils.normalize("a/b/../c/../d"));
+        assertEquals("a" + SEP + "d" + SEP, FilenameUtils.normalize("a/b/../c/../d/"));
+        assertEquals("a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("a/b//d"));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/././."));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/./././"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("./a/"));
+        assertEquals("a", FilenameUtils.normalize("./a"));
+        assertEquals("", FilenameUtils.normalize("./"));
+        assertEquals("", FilenameUtils.normalize("."));
+        assertEquals(null, FilenameUtils.normalize("../a"));
+        assertEquals(null, FilenameUtils.normalize(".."));
+        assertEquals("", FilenameUtils.normalize(""));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/a"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/"));
+        assertEquals(SEP + "a" + SEP + "c", FilenameUtils.normalize("/a/b/../c"));
+        assertEquals(SEP + "c", FilenameUtils.normalize("/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../../c"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/b/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../.."));
+        assertEquals(SEP + "a" + SEP + "d", FilenameUtils.normalize("/a/b/../c/../d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("/a/b//d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("/a/b/././."));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/./a"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/./"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/."));
+        assertEquals(null, FilenameUtils.normalize("/../a"));
+        assertEquals(null, FilenameUtils.normalize("/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/"));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/a"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/"));
+        assertEquals("~" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~/a/b/../c"));
+        assertEquals("~" + SEP + "c", FilenameUtils.normalize("~/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../../c"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/b/.."));
+        assertEquals("~" + SEP + "", FilenameUtils.normalize("~/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../.."));
+        assertEquals("~" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~/a/b/../c/../d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~/a/b//d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~/a/b/././."));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/./a"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/./"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/."));
+        assertEquals(null, FilenameUtils.normalize("~/../a"));
+        assertEquals(null, FilenameUtils.normalize("~/.."));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~"));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/a"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/"));
+        assertEquals("~user" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~user/a/b/../c"));
+        assertEquals("~user" + SEP + "c", FilenameUtils.normalize("~user/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../../c"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/b/.."));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../.."));
+        assertEquals("~user" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~user/a/b/../c/../d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~user/a/b//d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~user/a/b/././."));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/./a"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/./"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/."));
+        assertEquals(null, FilenameUtils.normalize("~user/../a"));
+        assertEquals(null, FilenameUtils.normalize("~user/.."));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user/"));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user"));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/a"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/"));
+        assertEquals("C:" + SEP + "a" + SEP + "c", FilenameUtils.normalize("C:/a/b/../c"));
+        assertEquals("C:" + SEP + "c", FilenameUtils.normalize("C:/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../../c"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/b/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../.."));
+        assertEquals("C:" + SEP + "a" + SEP + "d", FilenameUtils.normalize("C:/a/b/../c/../d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:/a/b//d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:/a/b/././."));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/./a"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/./"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/."));
+        assertEquals(null, FilenameUtils.normalize("C:/../a"));
+        assertEquals(null, FilenameUtils.normalize("C:/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/"));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:a"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/"));
+        assertEquals("C:" + "a" + SEP + "c", FilenameUtils.normalize("C:a/b/../c"));
+        assertEquals("C:" + "c", FilenameUtils.normalize("C:a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../../c"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/b/.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../.."));
+        assertEquals("C:" + "a" + SEP + "d", FilenameUtils.normalize("C:a/b/../c/../d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:a/b//d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:a/b/././."));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:./a"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:./"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:."));
+        assertEquals(null, FilenameUtils.normalize("C:../a"));
+        assertEquals(null, FilenameUtils.normalize("C:.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:"));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/a"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "c", FilenameUtils.normalize("//server/a/b/../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "c", FilenameUtils.normalize("//server/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/b/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../.."));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "d", FilenameUtils.normalize("//server/a/b/../c/../d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("//server/a/b//d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("//server/a/b/././."));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/./a"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/./"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/."));
+        assertEquals(null, FilenameUtils.normalize("//server/../a"));
+        assertEquals(null, FilenameUtils.normalize("//server/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/"));
+        assertEquals(SEP + SEP + "127.0.0.1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\127.0.0.1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "::1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\::1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server.example.org" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.example.org\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server." + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\-server\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\..\\a\\b\\c.txt"));
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.2/src/test/java/TestUtils.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.2/src/test/java/TestUtils.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import external.org.apache.commons.io.FileUtils;
+import external.org.apache.commons.io.output.ByteArrayOutputStream;
+import junit.framework.AssertionFailedError;
+
+/**
+ * Base class for testcases doing tests with files.
+ */
+public abstract class TestUtils {
+
+    private TestUtils() {
+    }
+
+    public static void createFile(final File file, final long size) throws IOException {
+        if (!file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new java.io.FileOutputStream(file))) {
+            generateTestData(output, size);
+        }
+    }
+
+    public static byte[] generateTestData(final long size) {
+        try {
+            final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+            generateTestData(baout, size);
+            return baout.toByteArray();
+        } catch (final IOException ioe) {
+            throw new RuntimeException("This should never happen: " + ioe.getMessage());
+        }
+    }
+
+    public static void generateTestData(final OutputStream out, final long size) throws IOException {
+        for (int i = 0; i < size; i++) {
+            //output.write((byte)'X');
+            // nice varied byte pattern compatible with Readers and Writers
+            out.write((byte) ((i % 127) + 1));
+        }
+    }
+
+    public static void createLineBasedFile(final File file, final String[] data) throws IOException {
+        if (file.getParentFile() != null && !file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final PrintWriter output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))) {
+            for (final String element : data) {
+                output.println(element);
+            }
+        }
+    }
+
+    public static File newFile(final File testDirectory, final String filename) throws IOException {
+        final File destination = new File(testDirectory, filename);
+        /*
+        assertTrue( filename + "Test output data file shouldn't previously exist",
+                    !destination.exists() );
+        */
+        if (destination.exists()) {
+            FileUtils.forceDelete(destination);
+        }
+        return destination;
+    }
+
+    public static void checkFile(final File file, final File referenceFile) throws Exception {
+        assertTrue("Check existence of output file", file.exists());
+        assertEqualContent(referenceFile, file);
+    }
+
+    /**
+     * Assert that the content of two files is the same.
+     */
+    private static void assertEqualContent(final File f0, final File f1) throws IOException {
+        /* This doesn't work because the filesize isn't updated until the file
+         * is closed.
+        assertTrue( "The files " + f0 + " and " + f1 +
+                    " have differing file sizes (" + f0.length() +
+                    " vs " + f1.length() + ")", ( f0.length() == f1.length() ) );
+        */
+        try (InputStream is0 = new FileInputStream(f0)) {
+            try (InputStream is1 = new FileInputStream(f1)) {
+                final byte[] buf0 = new byte[1024];
+                final byte[] buf1 = new byte[1024];
+                int n0 = 0;
+                int n1;
+                while (-1 != n0) {
+                    n0 = is0.read(buf0);
+                    n1 = is1.read(buf1);
+                    assertTrue("The files " + f0 + " and " + f1 + " have differing number of bytes available (" + n0 + " vs " + n1 + ")", (n0 == n1));
+                    assertTrue("The files " + f0 + " and " + f1 + " have different content", Arrays.equals(buf0, buf1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a byte[].
+     *
+     * @param b0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final byte[] b0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final byte[] b1 = new byte[b0.length];
+        try (InputStream is = new FileInputStream(file)) {
+            while (count < b0.length && numRead >= 0) {
+                numRead = is.read(b1, count, b0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of bytes: ", b0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("byte " + i + " differs", b0[i], b1[i]);
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a char[].
+     *
+     * @param c0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final char[] c0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final char[] c1 = new char[c0.length];
+        try (Reader ir = new FileReader(file)) {
+            while (count < c0.length && numRead >= 0) {
+                numRead = ir.read(c1, count, c0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of chars: ", c0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("char " + i + " differs", c0[i], c1[i]);
+            }
+        }
+    }
+
+    public static void checkWrite(final OutputStream output) throws Exception {
+        try {
+            new java.io.PrintStream(output).write(0);
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void checkWrite(final Writer output) throws Exception {
+        try {
+            new java.io.PrintWriter(output).write('a');
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void deleteFile(final File file) throws Exception {
+        if (file.exists()) {
+            assertTrue("Couldn't delete file: " + file, file.delete());
+        }
+    }
+
+    /**
+     * Sleep for a guaranteed number of milliseconds unless interrupted.
+     *
+     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
+     * it deems appropriate. Read the docs on Thread.sleep for further details.
+     *
+     * @param ms the number of milliseconds to sleep for
+     * @throws InterruptedException if interrupted
+     */
+    public static void sleep(final long ms) throws InterruptedException {
+        final long finishAt = System.currentTimeMillis() + ms;
+        long remaining = ms;
+        do {
+            Thread.sleep(remaining);
+            remaining = finishAt - System.currentTimeMillis();
+        } while (remaining > 0);
+    }
+
+    public static void sleepQuietly(final long ms) {
+        try {
+            sleep(ms);
+        } catch (final InterruptedException ignored) {
+        }
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.3/README.md
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.3/README.md
@@ -1,0 +1,26 @@
+# [CVE-2021-29425 -- Commons-IO] (https://nvd.nist.gov/vuln/detail/CVE-2021-29425)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+
+
+Project uses `commons-io:commons-io:2.6` , tests from https://github.com/apache/commons-io/commit/2736b6fe0b3fa22ec8e2b4184897ecadb021fc78
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. irrelevant tests in class removed
+2. utility methods TestUtils
+3. JUnit version replaced by JUnit5 with JUnit4 vintage support
+4. uses Java 8 (note that compress does not have to be build)
+
+Note that the one test __fails__ indicating the vulnerability! After replacing `commons-io:commons-io:2.6` by `commons-io:commons-io:2.7`
+the respective test passes, indicating that the vulnerability has been fixed.
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.3/pom.xml
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.3/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>com.virjar__ratel-api__1.3.3</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2021-29425 POV</description>
+    <name>CVE-2021-29425</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.virjar</groupId>
+            <artifactId>ratel-api</artifactId>
+            <version>1.3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.3/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.3/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,255 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T23:08:15"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T18:00:02"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2021-29425",
+    "groupID" : "foo",
+    "artifactID" : "com.virjar__ratel-api__1.3.3",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T10:09:01.646449Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "ratel-api-1.3.3.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/com/virjar/ratel-api/1.3.3/ratel-api-1.3.3.jar",
+    "md5" : "bab6ffe4ce2fe25fad14813b692ab3d2",
+    "sha1" : "6b3908d8ef08d0cd90c95521e9eeb510f3258f0c",
+    "sha256" : "5e487978e8974b09755af5d5743ae5f547f37964beaf00245cbb2d40af11e987",
+    "description" : "ratel api,used for developer on ratel system,an extension for xposed framewrok,ratel api compatable with original xposed framework",
+    "license" : "The Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/com.virjar__ratel-api__1.3.3@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "external"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.3.3"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.3.3"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.virjar/ratel-api@1.3.3",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.virjar/ratel-api@1.3.3?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  } ]
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.3/scan-results/grype/grype-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.3/scan-results/grype/grype-report.json
@@ -1,0 +1,96 @@
+{
+ "matches": [],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:12.56347883+13:00"
+ }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.3/scan-results/snyk/snyk-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.3/scan-results/snyk/snyk-report.json
@@ -1,0 +1,106 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 1,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": false,
+  "uniqueCount": 0,
+  "projectName": "foo:com.virjar__ratel-api__1.3.3",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2021-29425/com.virjar__ratel-api__1.3.3"
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.3/scan-results/steady/steady-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.3/scan-results/steady/steady-report.json
@@ -1,0 +1,27 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 22:26 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "com.virjar__ratel-api__1.3.3",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "PROVIDED, TEST" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+		]
+	}
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.3/src/test/java/FilenameUtilsTestCase.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.3/src/test/java/FilenameUtilsTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import external.org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is used to test FilenameUtils for correctness.
+ *
+ * @see FilenameUtils
+ */
+public class FilenameUtilsTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SEP = "" + File.separatorChar;
+
+    private static final boolean WINDOWS = File.separatorChar == '\\';
+
+    private File testFile1;
+
+    private File testFile2;
+
+    private int testFile1Size;
+
+    private int testFile2Size;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile1 = temporaryFolder.newFile("file1-test.txt");
+        testFile2 = temporaryFolder.newFile("file1a-test.txt");
+        testFile1Size = (int) testFile1.length();
+        testFile2Size = (int) testFile2.length();
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output3 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output3, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output2 = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output2, testFile2Size);
+        }
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output1 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output1, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output, testFile2Size);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void testNormalize() throws Exception {
+        assertEquals(null, FilenameUtils.normalize(null));
+        assertEquals(null, FilenameUtils.normalize(":"));
+        assertEquals(null, FilenameUtils.normalize("1:\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("1:"));
+        assertEquals(null, FilenameUtils.normalize("1:a"));
+        assertEquals(null, FilenameUtils.normalize("\\\\\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\a"));
+        assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c.txt"));
+        assertEquals("" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\a\\b/c.txt"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("C:\\a\\b/c.txt"));
+        assertEquals("" + SEP + "" + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server\\a\\b/c.txt"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~\\a\\b/c.txt"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~user\\a\\b/c.txt"));
+        assertEquals("a" + SEP + "c", FilenameUtils.normalize("a/b/../c"));
+        assertEquals("c", FilenameUtils.normalize("a/b/../../c"));
+        assertEquals("c" + SEP, FilenameUtils.normalize("a/b/../../c/"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../../c"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/.."));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/../"));
+        assertEquals("", FilenameUtils.normalize("a/b/../.."));
+        assertEquals("", FilenameUtils.normalize("a/b/../../"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../.."));
+        assertEquals("a" + SEP + "d", FilenameUtils.normalize("a/b/../c/../d"));
+        assertEquals("a" + SEP + "d" + SEP, FilenameUtils.normalize("a/b/../c/../d/"));
+        assertEquals("a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("a/b//d"));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/././."));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/./././"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("./a/"));
+        assertEquals("a", FilenameUtils.normalize("./a"));
+        assertEquals("", FilenameUtils.normalize("./"));
+        assertEquals("", FilenameUtils.normalize("."));
+        assertEquals(null, FilenameUtils.normalize("../a"));
+        assertEquals(null, FilenameUtils.normalize(".."));
+        assertEquals("", FilenameUtils.normalize(""));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/a"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/"));
+        assertEquals(SEP + "a" + SEP + "c", FilenameUtils.normalize("/a/b/../c"));
+        assertEquals(SEP + "c", FilenameUtils.normalize("/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../../c"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/b/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../.."));
+        assertEquals(SEP + "a" + SEP + "d", FilenameUtils.normalize("/a/b/../c/../d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("/a/b//d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("/a/b/././."));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/./a"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/./"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/."));
+        assertEquals(null, FilenameUtils.normalize("/../a"));
+        assertEquals(null, FilenameUtils.normalize("/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/"));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/a"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/"));
+        assertEquals("~" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~/a/b/../c"));
+        assertEquals("~" + SEP + "c", FilenameUtils.normalize("~/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../../c"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/b/.."));
+        assertEquals("~" + SEP + "", FilenameUtils.normalize("~/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../.."));
+        assertEquals("~" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~/a/b/../c/../d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~/a/b//d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~/a/b/././."));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/./a"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/./"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/."));
+        assertEquals(null, FilenameUtils.normalize("~/../a"));
+        assertEquals(null, FilenameUtils.normalize("~/.."));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~"));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/a"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/"));
+        assertEquals("~user" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~user/a/b/../c"));
+        assertEquals("~user" + SEP + "c", FilenameUtils.normalize("~user/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../../c"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/b/.."));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../.."));
+        assertEquals("~user" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~user/a/b/../c/../d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~user/a/b//d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~user/a/b/././."));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/./a"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/./"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/."));
+        assertEquals(null, FilenameUtils.normalize("~user/../a"));
+        assertEquals(null, FilenameUtils.normalize("~user/.."));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user/"));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user"));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/a"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/"));
+        assertEquals("C:" + SEP + "a" + SEP + "c", FilenameUtils.normalize("C:/a/b/../c"));
+        assertEquals("C:" + SEP + "c", FilenameUtils.normalize("C:/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../../c"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/b/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../.."));
+        assertEquals("C:" + SEP + "a" + SEP + "d", FilenameUtils.normalize("C:/a/b/../c/../d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:/a/b//d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:/a/b/././."));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/./a"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/./"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/."));
+        assertEquals(null, FilenameUtils.normalize("C:/../a"));
+        assertEquals(null, FilenameUtils.normalize("C:/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/"));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:a"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/"));
+        assertEquals("C:" + "a" + SEP + "c", FilenameUtils.normalize("C:a/b/../c"));
+        assertEquals("C:" + "c", FilenameUtils.normalize("C:a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../../c"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/b/.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../.."));
+        assertEquals("C:" + "a" + SEP + "d", FilenameUtils.normalize("C:a/b/../c/../d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:a/b//d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:a/b/././."));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:./a"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:./"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:."));
+        assertEquals(null, FilenameUtils.normalize("C:../a"));
+        assertEquals(null, FilenameUtils.normalize("C:.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:"));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/a"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "c", FilenameUtils.normalize("//server/a/b/../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "c", FilenameUtils.normalize("//server/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/b/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../.."));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "d", FilenameUtils.normalize("//server/a/b/../c/../d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("//server/a/b//d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("//server/a/b/././."));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/./a"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/./"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/."));
+        assertEquals(null, FilenameUtils.normalize("//server/../a"));
+        assertEquals(null, FilenameUtils.normalize("//server/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/"));
+        assertEquals(SEP + SEP + "127.0.0.1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\127.0.0.1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "::1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\::1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server.example.org" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.example.org\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server." + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\-server\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\..\\a\\b\\c.txt"));
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.3/src/test/java/TestUtils.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.3/src/test/java/TestUtils.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import external.org.apache.commons.io.FileUtils;
+import external.org.apache.commons.io.output.ByteArrayOutputStream;
+import junit.framework.AssertionFailedError;
+
+/**
+ * Base class for testcases doing tests with files.
+ */
+public abstract class TestUtils {
+
+    private TestUtils() {
+    }
+
+    public static void createFile(final File file, final long size) throws IOException {
+        if (!file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new java.io.FileOutputStream(file))) {
+            generateTestData(output, size);
+        }
+    }
+
+    public static byte[] generateTestData(final long size) {
+        try {
+            final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+            generateTestData(baout, size);
+            return baout.toByteArray();
+        } catch (final IOException ioe) {
+            throw new RuntimeException("This should never happen: " + ioe.getMessage());
+        }
+    }
+
+    public static void generateTestData(final OutputStream out, final long size) throws IOException {
+        for (int i = 0; i < size; i++) {
+            //output.write((byte)'X');
+            // nice varied byte pattern compatible with Readers and Writers
+            out.write((byte) ((i % 127) + 1));
+        }
+    }
+
+    public static void createLineBasedFile(final File file, final String[] data) throws IOException {
+        if (file.getParentFile() != null && !file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final PrintWriter output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))) {
+            for (final String element : data) {
+                output.println(element);
+            }
+        }
+    }
+
+    public static File newFile(final File testDirectory, final String filename) throws IOException {
+        final File destination = new File(testDirectory, filename);
+        /*
+        assertTrue( filename + "Test output data file shouldn't previously exist",
+                    !destination.exists() );
+        */
+        if (destination.exists()) {
+            FileUtils.forceDelete(destination);
+        }
+        return destination;
+    }
+
+    public static void checkFile(final File file, final File referenceFile) throws Exception {
+        assertTrue("Check existence of output file", file.exists());
+        assertEqualContent(referenceFile, file);
+    }
+
+    /**
+     * Assert that the content of two files is the same.
+     */
+    private static void assertEqualContent(final File f0, final File f1) throws IOException {
+        /* This doesn't work because the filesize isn't updated until the file
+         * is closed.
+        assertTrue( "The files " + f0 + " and " + f1 +
+                    " have differing file sizes (" + f0.length() +
+                    " vs " + f1.length() + ")", ( f0.length() == f1.length() ) );
+        */
+        try (InputStream is0 = new FileInputStream(f0)) {
+            try (InputStream is1 = new FileInputStream(f1)) {
+                final byte[] buf0 = new byte[1024];
+                final byte[] buf1 = new byte[1024];
+                int n0 = 0;
+                int n1;
+                while (-1 != n0) {
+                    n0 = is0.read(buf0);
+                    n1 = is1.read(buf1);
+                    assertTrue("The files " + f0 + " and " + f1 + " have differing number of bytes available (" + n0 + " vs " + n1 + ")", (n0 == n1));
+                    assertTrue("The files " + f0 + " and " + f1 + " have different content", Arrays.equals(buf0, buf1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a byte[].
+     *
+     * @param b0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final byte[] b0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final byte[] b1 = new byte[b0.length];
+        try (InputStream is = new FileInputStream(file)) {
+            while (count < b0.length && numRead >= 0) {
+                numRead = is.read(b1, count, b0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of bytes: ", b0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("byte " + i + " differs", b0[i], b1[i]);
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a char[].
+     *
+     * @param c0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final char[] c0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final char[] c1 = new char[c0.length];
+        try (Reader ir = new FileReader(file)) {
+            while (count < c0.length && numRead >= 0) {
+                numRead = ir.read(c1, count, c0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of chars: ", c0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("char " + i + " differs", c0[i], c1[i]);
+            }
+        }
+    }
+
+    public static void checkWrite(final OutputStream output) throws Exception {
+        try {
+            new java.io.PrintStream(output).write(0);
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void checkWrite(final Writer output) throws Exception {
+        try {
+            new java.io.PrintWriter(output).write('a');
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void deleteFile(final File file) throws Exception {
+        if (file.exists()) {
+            assertTrue("Couldn't delete file: " + file, file.delete());
+        }
+    }
+
+    /**
+     * Sleep for a guaranteed number of milliseconds unless interrupted.
+     *
+     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
+     * it deems appropriate. Read the docs on Thread.sleep for further details.
+     *
+     * @param ms the number of milliseconds to sleep for
+     * @throws InterruptedException if interrupted
+     */
+    public static void sleep(final long ms) throws InterruptedException {
+        final long finishAt = System.currentTimeMillis() + ms;
+        long remaining = ms;
+        do {
+            Thread.sleep(remaining);
+            remaining = finishAt - System.currentTimeMillis();
+        } while (remaining > 0);
+    }
+
+    public static void sleepQuietly(final long ms) {
+        try {
+            sleep(ms);
+        } catch (final InterruptedException ignored) {
+        }
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.4/README.md
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.4/README.md
@@ -1,0 +1,26 @@
+# [CVE-2021-29425 -- Commons-IO] (https://nvd.nist.gov/vuln/detail/CVE-2021-29425)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+
+
+Project uses `commons-io:commons-io:2.6` , tests from https://github.com/apache/commons-io/commit/2736b6fe0b3fa22ec8e2b4184897ecadb021fc78
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. irrelevant tests in class removed
+2. utility methods TestUtils
+3. JUnit version replaced by JUnit5 with JUnit4 vintage support
+4. uses Java 8 (note that compress does not have to be build)
+
+Note that the one test __fails__ indicating the vulnerability! After replacing `commons-io:commons-io:2.6` by `commons-io:commons-io:2.7`
+the respective test passes, indicating that the vulnerability has been fixed.
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.4/pom.xml
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.4/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>com.virjar__ratel-api__1.3.4</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2021-29425 POV</description>
+    <name>CVE-2021-29425</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.virjar</groupId>
+            <artifactId>ratel-api</artifactId>
+            <version>1.3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.4/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.4/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,255 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2021-29425",
+    "groupID" : "foo",
+    "artifactID" : "com.virjar__ratel-api__1.3.4",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:30:21.377139Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "ratel-api-1.3.4.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/com/virjar/ratel-api/1.3.4/ratel-api-1.3.4.jar",
+    "md5" : "08b33fa9f17a6bd126a78e8553d6db20",
+    "sha1" : "66d7163ab0f7c84448710bf57d53b63104736fc2",
+    "sha256" : "7fe784c55adbe8bec0502fd9e13f9b0f3aa02ca3274ac232e7a492bdde8970f5",
+    "description" : "ratel api,used for developer on ratel system,an extension for xposed framewrok,ratel api compatable with original xposed framework",
+    "license" : "The Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/com.virjar__ratel-api__1.3.4@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "external"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.3.4"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.3.4"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.virjar/ratel-api@1.3.4",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.virjar/ratel-api@1.3.4?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  } ]
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.4/scan-results/grype/grype-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.4/scan-results/grype/grype-report.json
@@ -1,0 +1,96 @@
+{
+ "matches": [],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:12.623909713+13:00"
+ }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.4/scan-results/snyk/snyk-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.4/scan-results/snyk/snyk-report.json
@@ -1,0 +1,106 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 1,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": false,
+  "uniqueCount": 0,
+  "projectName": "foo:com.virjar__ratel-api__1.3.4",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2021-29425/com.virjar__ratel-api__1.3.4"
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.4/scan-results/steady/steady-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.4/scan-results/steady/steady-report.json
@@ -1,0 +1,27 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 22:26 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "com.virjar__ratel-api__1.3.4",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "TEST, PROVIDED" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+		]
+	}
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.4/src/test/java/FilenameUtilsTestCase.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.4/src/test/java/FilenameUtilsTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import external.org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is used to test FilenameUtils for correctness.
+ *
+ * @see FilenameUtils
+ */
+public class FilenameUtilsTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SEP = "" + File.separatorChar;
+
+    private static final boolean WINDOWS = File.separatorChar == '\\';
+
+    private File testFile1;
+
+    private File testFile2;
+
+    private int testFile1Size;
+
+    private int testFile2Size;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile1 = temporaryFolder.newFile("file1-test.txt");
+        testFile2 = temporaryFolder.newFile("file1a-test.txt");
+        testFile1Size = (int) testFile1.length();
+        testFile2Size = (int) testFile2.length();
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output3 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output3, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output2 = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output2, testFile2Size);
+        }
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output1 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output1, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output, testFile2Size);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void testNormalize() throws Exception {
+        assertEquals(null, FilenameUtils.normalize(null));
+        assertEquals(null, FilenameUtils.normalize(":"));
+        assertEquals(null, FilenameUtils.normalize("1:\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("1:"));
+        assertEquals(null, FilenameUtils.normalize("1:a"));
+        assertEquals(null, FilenameUtils.normalize("\\\\\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\a"));
+        assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c.txt"));
+        assertEquals("" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\a\\b/c.txt"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("C:\\a\\b/c.txt"));
+        assertEquals("" + SEP + "" + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server\\a\\b/c.txt"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~\\a\\b/c.txt"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~user\\a\\b/c.txt"));
+        assertEquals("a" + SEP + "c", FilenameUtils.normalize("a/b/../c"));
+        assertEquals("c", FilenameUtils.normalize("a/b/../../c"));
+        assertEquals("c" + SEP, FilenameUtils.normalize("a/b/../../c/"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../../c"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/.."));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/../"));
+        assertEquals("", FilenameUtils.normalize("a/b/../.."));
+        assertEquals("", FilenameUtils.normalize("a/b/../../"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../.."));
+        assertEquals("a" + SEP + "d", FilenameUtils.normalize("a/b/../c/../d"));
+        assertEquals("a" + SEP + "d" + SEP, FilenameUtils.normalize("a/b/../c/../d/"));
+        assertEquals("a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("a/b//d"));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/././."));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/./././"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("./a/"));
+        assertEquals("a", FilenameUtils.normalize("./a"));
+        assertEquals("", FilenameUtils.normalize("./"));
+        assertEquals("", FilenameUtils.normalize("."));
+        assertEquals(null, FilenameUtils.normalize("../a"));
+        assertEquals(null, FilenameUtils.normalize(".."));
+        assertEquals("", FilenameUtils.normalize(""));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/a"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/"));
+        assertEquals(SEP + "a" + SEP + "c", FilenameUtils.normalize("/a/b/../c"));
+        assertEquals(SEP + "c", FilenameUtils.normalize("/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../../c"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/b/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../.."));
+        assertEquals(SEP + "a" + SEP + "d", FilenameUtils.normalize("/a/b/../c/../d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("/a/b//d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("/a/b/././."));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/./a"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/./"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/."));
+        assertEquals(null, FilenameUtils.normalize("/../a"));
+        assertEquals(null, FilenameUtils.normalize("/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/"));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/a"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/"));
+        assertEquals("~" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~/a/b/../c"));
+        assertEquals("~" + SEP + "c", FilenameUtils.normalize("~/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../../c"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/b/.."));
+        assertEquals("~" + SEP + "", FilenameUtils.normalize("~/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../.."));
+        assertEquals("~" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~/a/b/../c/../d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~/a/b//d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~/a/b/././."));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/./a"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/./"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/."));
+        assertEquals(null, FilenameUtils.normalize("~/../a"));
+        assertEquals(null, FilenameUtils.normalize("~/.."));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~"));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/a"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/"));
+        assertEquals("~user" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~user/a/b/../c"));
+        assertEquals("~user" + SEP + "c", FilenameUtils.normalize("~user/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../../c"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/b/.."));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../.."));
+        assertEquals("~user" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~user/a/b/../c/../d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~user/a/b//d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~user/a/b/././."));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/./a"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/./"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/."));
+        assertEquals(null, FilenameUtils.normalize("~user/../a"));
+        assertEquals(null, FilenameUtils.normalize("~user/.."));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user/"));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user"));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/a"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/"));
+        assertEquals("C:" + SEP + "a" + SEP + "c", FilenameUtils.normalize("C:/a/b/../c"));
+        assertEquals("C:" + SEP + "c", FilenameUtils.normalize("C:/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../../c"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/b/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../.."));
+        assertEquals("C:" + SEP + "a" + SEP + "d", FilenameUtils.normalize("C:/a/b/../c/../d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:/a/b//d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:/a/b/././."));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/./a"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/./"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/."));
+        assertEquals(null, FilenameUtils.normalize("C:/../a"));
+        assertEquals(null, FilenameUtils.normalize("C:/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/"));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:a"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/"));
+        assertEquals("C:" + "a" + SEP + "c", FilenameUtils.normalize("C:a/b/../c"));
+        assertEquals("C:" + "c", FilenameUtils.normalize("C:a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../../c"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/b/.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../.."));
+        assertEquals("C:" + "a" + SEP + "d", FilenameUtils.normalize("C:a/b/../c/../d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:a/b//d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:a/b/././."));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:./a"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:./"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:."));
+        assertEquals(null, FilenameUtils.normalize("C:../a"));
+        assertEquals(null, FilenameUtils.normalize("C:.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:"));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/a"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "c", FilenameUtils.normalize("//server/a/b/../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "c", FilenameUtils.normalize("//server/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/b/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../.."));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "d", FilenameUtils.normalize("//server/a/b/../c/../d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("//server/a/b//d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("//server/a/b/././."));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/./a"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/./"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/."));
+        assertEquals(null, FilenameUtils.normalize("//server/../a"));
+        assertEquals(null, FilenameUtils.normalize("//server/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/"));
+        assertEquals(SEP + SEP + "127.0.0.1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\127.0.0.1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "::1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\::1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server.example.org" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.example.org\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server." + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\-server\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\..\\a\\b\\c.txt"));
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.4/src/test/java/TestUtils.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.4/src/test/java/TestUtils.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import external.org.apache.commons.io.FileUtils;
+import external.org.apache.commons.io.output.ByteArrayOutputStream;
+import junit.framework.AssertionFailedError;
+
+/**
+ * Base class for testcases doing tests with files.
+ */
+public abstract class TestUtils {
+
+    private TestUtils() {
+    }
+
+    public static void createFile(final File file, final long size) throws IOException {
+        if (!file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new java.io.FileOutputStream(file))) {
+            generateTestData(output, size);
+        }
+    }
+
+    public static byte[] generateTestData(final long size) {
+        try {
+            final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+            generateTestData(baout, size);
+            return baout.toByteArray();
+        } catch (final IOException ioe) {
+            throw new RuntimeException("This should never happen: " + ioe.getMessage());
+        }
+    }
+
+    public static void generateTestData(final OutputStream out, final long size) throws IOException {
+        for (int i = 0; i < size; i++) {
+            //output.write((byte)'X');
+            // nice varied byte pattern compatible with Readers and Writers
+            out.write((byte) ((i % 127) + 1));
+        }
+    }
+
+    public static void createLineBasedFile(final File file, final String[] data) throws IOException {
+        if (file.getParentFile() != null && !file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final PrintWriter output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))) {
+            for (final String element : data) {
+                output.println(element);
+            }
+        }
+    }
+
+    public static File newFile(final File testDirectory, final String filename) throws IOException {
+        final File destination = new File(testDirectory, filename);
+        /*
+        assertTrue( filename + "Test output data file shouldn't previously exist",
+                    !destination.exists() );
+        */
+        if (destination.exists()) {
+            FileUtils.forceDelete(destination);
+        }
+        return destination;
+    }
+
+    public static void checkFile(final File file, final File referenceFile) throws Exception {
+        assertTrue("Check existence of output file", file.exists());
+        assertEqualContent(referenceFile, file);
+    }
+
+    /**
+     * Assert that the content of two files is the same.
+     */
+    private static void assertEqualContent(final File f0, final File f1) throws IOException {
+        /* This doesn't work because the filesize isn't updated until the file
+         * is closed.
+        assertTrue( "The files " + f0 + " and " + f1 +
+                    " have differing file sizes (" + f0.length() +
+                    " vs " + f1.length() + ")", ( f0.length() == f1.length() ) );
+        */
+        try (InputStream is0 = new FileInputStream(f0)) {
+            try (InputStream is1 = new FileInputStream(f1)) {
+                final byte[] buf0 = new byte[1024];
+                final byte[] buf1 = new byte[1024];
+                int n0 = 0;
+                int n1;
+                while (-1 != n0) {
+                    n0 = is0.read(buf0);
+                    n1 = is1.read(buf1);
+                    assertTrue("The files " + f0 + " and " + f1 + " have differing number of bytes available (" + n0 + " vs " + n1 + ")", (n0 == n1));
+                    assertTrue("The files " + f0 + " and " + f1 + " have different content", Arrays.equals(buf0, buf1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a byte[].
+     *
+     * @param b0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final byte[] b0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final byte[] b1 = new byte[b0.length];
+        try (InputStream is = new FileInputStream(file)) {
+            while (count < b0.length && numRead >= 0) {
+                numRead = is.read(b1, count, b0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of bytes: ", b0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("byte " + i + " differs", b0[i], b1[i]);
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a char[].
+     *
+     * @param c0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final char[] c0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final char[] c1 = new char[c0.length];
+        try (Reader ir = new FileReader(file)) {
+            while (count < c0.length && numRead >= 0) {
+                numRead = ir.read(c1, count, c0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of chars: ", c0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("char " + i + " differs", c0[i], c1[i]);
+            }
+        }
+    }
+
+    public static void checkWrite(final OutputStream output) throws Exception {
+        try {
+            new java.io.PrintStream(output).write(0);
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void checkWrite(final Writer output) throws Exception {
+        try {
+            new java.io.PrintWriter(output).write('a');
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void deleteFile(final File file) throws Exception {
+        if (file.exists()) {
+            assertTrue("Couldn't delete file: " + file, file.delete());
+        }
+    }
+
+    /**
+     * Sleep for a guaranteed number of milliseconds unless interrupted.
+     *
+     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
+     * it deems appropriate. Read the docs on Thread.sleep for further details.
+     *
+     * @param ms the number of milliseconds to sleep for
+     * @throws InterruptedException if interrupted
+     */
+    public static void sleep(final long ms) throws InterruptedException {
+        final long finishAt = System.currentTimeMillis() + ms;
+        long remaining = ms;
+        do {
+            Thread.sleep(remaining);
+            remaining = finishAt - System.currentTimeMillis();
+        } while (remaining > 0);
+    }
+
+    public static void sleepQuietly(final long ms) {
+        try {
+            sleep(ms);
+        } catch (final InterruptedException ignored) {
+        }
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.5/README.md
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.5/README.md
@@ -1,0 +1,26 @@
+# [CVE-2021-29425 -- Commons-IO] (https://nvd.nist.gov/vuln/detail/CVE-2021-29425)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+
+
+Project uses `commons-io:commons-io:2.6` , tests from https://github.com/apache/commons-io/commit/2736b6fe0b3fa22ec8e2b4184897ecadb021fc78
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. irrelevant tests in class removed
+2. utility methods TestUtils
+3. JUnit version replaced by JUnit5 with JUnit4 vintage support
+4. uses Java 8 (note that compress does not have to be build)
+
+Note that the one test __fails__ indicating the vulnerability! After replacing `commons-io:commons-io:2.6` by `commons-io:commons-io:2.7`
+the respective test passes, indicating that the vulnerability has been fixed.
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.5/pom.xml
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.5/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>com.virjar__ratel-api__1.3.5</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2021-29425 POV</description>
+    <name>CVE-2021-29425</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.virjar</groupId>
+            <artifactId>ratel-api</artifactId>
+            <version>1.3.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.5/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.5/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,255 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2021-29425",
+    "groupID" : "foo",
+    "artifactID" : "com.virjar__ratel-api__1.3.5",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:30:28.532094Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "ratel-api-1.3.5.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/com/virjar/ratel-api/1.3.5/ratel-api-1.3.5.jar",
+    "md5" : "67bab5601bd5c04fd9e4780f71ef0adf",
+    "sha1" : "0369c7338d5c56c0c83aa7d42d3e49be222ec1b3",
+    "sha256" : "f229659f83a14ab63b1e8060f20dfe0ae89ccf12ec7064e992ea448642e0a22b",
+    "description" : "ratel api,used for developer on ratel system,an extension for xposed framewrok,ratel api compatable with original xposed framework",
+    "license" : "The Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/com.virjar__ratel-api__1.3.5@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "external"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "apache"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "commons"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "org"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.3.5"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.3.5"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.virjar/ratel-api@1.3.5",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.virjar/ratel-api@1.3.5?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  } ]
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.5/scan-results/grype/grype-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.5/scan-results/grype/grype-report.json
@@ -1,0 +1,96 @@
+{
+ "matches": [],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:12.681536689+13:00"
+ }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.5/scan-results/snyk/snyk-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.5/scan-results/snyk/snyk-report.json
@@ -1,0 +1,106 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 1,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": false,
+  "uniqueCount": 0,
+  "projectName": "foo:com.virjar__ratel-api__1.3.5",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2021-29425/com.virjar__ratel-api__1.3.5"
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.5/scan-results/steady/steady-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.5/scan-results/steady/steady-report.json
@@ -1,0 +1,27 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 22:26 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "com.virjar__ratel-api__1.3.5",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "PROVIDED, TEST" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+		]
+	}
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.5/src/test/java/FilenameUtilsTestCase.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.5/src/test/java/FilenameUtilsTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import external.org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is used to test FilenameUtils for correctness.
+ *
+ * @see FilenameUtils
+ */
+public class FilenameUtilsTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SEP = "" + File.separatorChar;
+
+    private static final boolean WINDOWS = File.separatorChar == '\\';
+
+    private File testFile1;
+
+    private File testFile2;
+
+    private int testFile1Size;
+
+    private int testFile2Size;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile1 = temporaryFolder.newFile("file1-test.txt");
+        testFile2 = temporaryFolder.newFile("file1a-test.txt");
+        testFile1Size = (int) testFile1.length();
+        testFile2Size = (int) testFile2.length();
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output3 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output3, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output2 = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output2, testFile2Size);
+        }
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output1 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output1, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output, testFile2Size);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void testNormalize() throws Exception {
+        assertEquals(null, FilenameUtils.normalize(null));
+        assertEquals(null, FilenameUtils.normalize(":"));
+        assertEquals(null, FilenameUtils.normalize("1:\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("1:"));
+        assertEquals(null, FilenameUtils.normalize("1:a"));
+        assertEquals(null, FilenameUtils.normalize("\\\\\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\a"));
+        assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c.txt"));
+        assertEquals("" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\a\\b/c.txt"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("C:\\a\\b/c.txt"));
+        assertEquals("" + SEP + "" + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server\\a\\b/c.txt"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~\\a\\b/c.txt"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~user\\a\\b/c.txt"));
+        assertEquals("a" + SEP + "c", FilenameUtils.normalize("a/b/../c"));
+        assertEquals("c", FilenameUtils.normalize("a/b/../../c"));
+        assertEquals("c" + SEP, FilenameUtils.normalize("a/b/../../c/"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../../c"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/.."));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/../"));
+        assertEquals("", FilenameUtils.normalize("a/b/../.."));
+        assertEquals("", FilenameUtils.normalize("a/b/../../"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../.."));
+        assertEquals("a" + SEP + "d", FilenameUtils.normalize("a/b/../c/../d"));
+        assertEquals("a" + SEP + "d" + SEP, FilenameUtils.normalize("a/b/../c/../d/"));
+        assertEquals("a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("a/b//d"));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/././."));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/./././"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("./a/"));
+        assertEquals("a", FilenameUtils.normalize("./a"));
+        assertEquals("", FilenameUtils.normalize("./"));
+        assertEquals("", FilenameUtils.normalize("."));
+        assertEquals(null, FilenameUtils.normalize("../a"));
+        assertEquals(null, FilenameUtils.normalize(".."));
+        assertEquals("", FilenameUtils.normalize(""));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/a"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/"));
+        assertEquals(SEP + "a" + SEP + "c", FilenameUtils.normalize("/a/b/../c"));
+        assertEquals(SEP + "c", FilenameUtils.normalize("/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../../c"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/b/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../.."));
+        assertEquals(SEP + "a" + SEP + "d", FilenameUtils.normalize("/a/b/../c/../d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("/a/b//d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("/a/b/././."));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/./a"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/./"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/."));
+        assertEquals(null, FilenameUtils.normalize("/../a"));
+        assertEquals(null, FilenameUtils.normalize("/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/"));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/a"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/"));
+        assertEquals("~" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~/a/b/../c"));
+        assertEquals("~" + SEP + "c", FilenameUtils.normalize("~/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../../c"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/b/.."));
+        assertEquals("~" + SEP + "", FilenameUtils.normalize("~/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../.."));
+        assertEquals("~" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~/a/b/../c/../d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~/a/b//d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~/a/b/././."));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/./a"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/./"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/."));
+        assertEquals(null, FilenameUtils.normalize("~/../a"));
+        assertEquals(null, FilenameUtils.normalize("~/.."));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~"));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/a"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/"));
+        assertEquals("~user" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~user/a/b/../c"));
+        assertEquals("~user" + SEP + "c", FilenameUtils.normalize("~user/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../../c"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/b/.."));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../.."));
+        assertEquals("~user" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~user/a/b/../c/../d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~user/a/b//d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~user/a/b/././."));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/./a"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/./"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/."));
+        assertEquals(null, FilenameUtils.normalize("~user/../a"));
+        assertEquals(null, FilenameUtils.normalize("~user/.."));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user/"));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user"));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/a"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/"));
+        assertEquals("C:" + SEP + "a" + SEP + "c", FilenameUtils.normalize("C:/a/b/../c"));
+        assertEquals("C:" + SEP + "c", FilenameUtils.normalize("C:/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../../c"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/b/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../.."));
+        assertEquals("C:" + SEP + "a" + SEP + "d", FilenameUtils.normalize("C:/a/b/../c/../d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:/a/b//d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:/a/b/././."));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/./a"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/./"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/."));
+        assertEquals(null, FilenameUtils.normalize("C:/../a"));
+        assertEquals(null, FilenameUtils.normalize("C:/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/"));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:a"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/"));
+        assertEquals("C:" + "a" + SEP + "c", FilenameUtils.normalize("C:a/b/../c"));
+        assertEquals("C:" + "c", FilenameUtils.normalize("C:a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../../c"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/b/.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../.."));
+        assertEquals("C:" + "a" + SEP + "d", FilenameUtils.normalize("C:a/b/../c/../d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:a/b//d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:a/b/././."));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:./a"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:./"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:."));
+        assertEquals(null, FilenameUtils.normalize("C:../a"));
+        assertEquals(null, FilenameUtils.normalize("C:.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:"));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/a"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "c", FilenameUtils.normalize("//server/a/b/../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "c", FilenameUtils.normalize("//server/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/b/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../.."));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "d", FilenameUtils.normalize("//server/a/b/../c/../d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("//server/a/b//d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("//server/a/b/././."));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/./a"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/./"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/."));
+        assertEquals(null, FilenameUtils.normalize("//server/../a"));
+        assertEquals(null, FilenameUtils.normalize("//server/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/"));
+        assertEquals(SEP + SEP + "127.0.0.1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\127.0.0.1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "::1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\::1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server.example.org" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.example.org\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server." + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\-server\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\..\\a\\b\\c.txt"));
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.5/src/test/java/TestUtils.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.5/src/test/java/TestUtils.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import external.org.apache.commons.io.FileUtils;
+import external.org.apache.commons.io.output.ByteArrayOutputStream;
+import junit.framework.AssertionFailedError;
+
+/**
+ * Base class for testcases doing tests with files.
+ */
+public abstract class TestUtils {
+
+    private TestUtils() {
+    }
+
+    public static void createFile(final File file, final long size) throws IOException {
+        if (!file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new java.io.FileOutputStream(file))) {
+            generateTestData(output, size);
+        }
+    }
+
+    public static byte[] generateTestData(final long size) {
+        try {
+            final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+            generateTestData(baout, size);
+            return baout.toByteArray();
+        } catch (final IOException ioe) {
+            throw new RuntimeException("This should never happen: " + ioe.getMessage());
+        }
+    }
+
+    public static void generateTestData(final OutputStream out, final long size) throws IOException {
+        for (int i = 0; i < size; i++) {
+            //output.write((byte)'X');
+            // nice varied byte pattern compatible with Readers and Writers
+            out.write((byte) ((i % 127) + 1));
+        }
+    }
+
+    public static void createLineBasedFile(final File file, final String[] data) throws IOException {
+        if (file.getParentFile() != null && !file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final PrintWriter output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))) {
+            for (final String element : data) {
+                output.println(element);
+            }
+        }
+    }
+
+    public static File newFile(final File testDirectory, final String filename) throws IOException {
+        final File destination = new File(testDirectory, filename);
+        /*
+        assertTrue( filename + "Test output data file shouldn't previously exist",
+                    !destination.exists() );
+        */
+        if (destination.exists()) {
+            FileUtils.forceDelete(destination);
+        }
+        return destination;
+    }
+
+    public static void checkFile(final File file, final File referenceFile) throws Exception {
+        assertTrue("Check existence of output file", file.exists());
+        assertEqualContent(referenceFile, file);
+    }
+
+    /**
+     * Assert that the content of two files is the same.
+     */
+    private static void assertEqualContent(final File f0, final File f1) throws IOException {
+        /* This doesn't work because the filesize isn't updated until the file
+         * is closed.
+        assertTrue( "The files " + f0 + " and " + f1 +
+                    " have differing file sizes (" + f0.length() +
+                    " vs " + f1.length() + ")", ( f0.length() == f1.length() ) );
+        */
+        try (InputStream is0 = new FileInputStream(f0)) {
+            try (InputStream is1 = new FileInputStream(f1)) {
+                final byte[] buf0 = new byte[1024];
+                final byte[] buf1 = new byte[1024];
+                int n0 = 0;
+                int n1;
+                while (-1 != n0) {
+                    n0 = is0.read(buf0);
+                    n1 = is1.read(buf1);
+                    assertTrue("The files " + f0 + " and " + f1 + " have differing number of bytes available (" + n0 + " vs " + n1 + ")", (n0 == n1));
+                    assertTrue("The files " + f0 + " and " + f1 + " have different content", Arrays.equals(buf0, buf1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a byte[].
+     *
+     * @param b0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final byte[] b0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final byte[] b1 = new byte[b0.length];
+        try (InputStream is = new FileInputStream(file)) {
+            while (count < b0.length && numRead >= 0) {
+                numRead = is.read(b1, count, b0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of bytes: ", b0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("byte " + i + " differs", b0[i], b1[i]);
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a char[].
+     *
+     * @param c0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final char[] c0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final char[] c1 = new char[c0.length];
+        try (Reader ir = new FileReader(file)) {
+            while (count < c0.length && numRead >= 0) {
+                numRead = ir.read(c1, count, c0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of chars: ", c0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("char " + i + " differs", c0[i], c1[i]);
+            }
+        }
+    }
+
+    public static void checkWrite(final OutputStream output) throws Exception {
+        try {
+            new java.io.PrintStream(output).write(0);
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void checkWrite(final Writer output) throws Exception {
+        try {
+            new java.io.PrintWriter(output).write('a');
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void deleteFile(final File file) throws Exception {
+        if (file.exists()) {
+            assertTrue("Couldn't delete file: " + file, file.delete());
+        }
+    }
+
+    /**
+     * Sleep for a guaranteed number of milliseconds unless interrupted.
+     *
+     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
+     * it deems appropriate. Read the docs on Thread.sleep for further details.
+     *
+     * @param ms the number of milliseconds to sleep for
+     * @throws InterruptedException if interrupted
+     */
+    public static void sleep(final long ms) throws InterruptedException {
+        final long finishAt = System.currentTimeMillis() + ms;
+        long remaining = ms;
+        do {
+            Thread.sleep(remaining);
+            remaining = finishAt - System.currentTimeMillis();
+        } while (remaining > 0);
+    }
+
+    public static void sleepQuietly(final long ms) {
+        try {
+            sleep(ms);
+        } catch (final InterruptedException ignored) {
+        }
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.6/README.md
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.6/README.md
@@ -1,0 +1,26 @@
+# [CVE-2021-29425 -- Commons-IO] (https://nvd.nist.gov/vuln/detail/CVE-2021-29425)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+
+
+Project uses `commons-io:commons-io:2.6` , tests from https://github.com/apache/commons-io/commit/2736b6fe0b3fa22ec8e2b4184897ecadb021fc78
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. irrelevant tests in class removed
+2. utility methods TestUtils
+3. JUnit version replaced by JUnit5 with JUnit4 vintage support
+4. uses Java 8 (note that compress does not have to be build)
+
+Note that the one test __fails__ indicating the vulnerability! After replacing `commons-io:commons-io:2.6` by `commons-io:commons-io:2.7`
+the respective test passes, indicating that the vulnerability has been fixed.
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.6/pom.xml
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.6/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>com.virjar__ratel-api__1.3.6</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2021-29425 POV</description>
+    <name>CVE-2021-29425</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.virjar</groupId>
+            <artifactId>ratel-api</artifactId>
+            <version>1.3.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.6/scan-results/dependency-check/dependency-check-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.6/scan-results/dependency-check/dependency-check-report.json
@@ -1,0 +1,225 @@
+{
+  "reportSchema" : "1.1",
+  "scanInfo" : {
+    "engineVersion" : "8.2.1",
+    "dataSource" : [ {
+      "name" : "NVD CVE Checked",
+      "timestamp" : "2023-10-04T16:15:28"
+    }, {
+      "name" : "NVD CVE Modified",
+      "timestamp" : "2023-10-04T13:00:01"
+    }, {
+      "name" : "VersionCheckOn",
+      "timestamp" : "2023-10-04T16:15:34"
+    }, {
+      "name" : "kev.checked",
+      "timestamp" : "1696389337"
+    } ]
+  },
+  "projectInfo" : {
+    "name" : "CVE-2021-29425",
+    "groupID" : "foo",
+    "artifactID" : "com.virjar__ratel-api__1.3.6",
+    "version" : "0.0.1",
+    "reportDate" : "2023-10-04T03:30:35.780390Z",
+    "credits" : {
+      "NVD" : "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA" : "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM" : "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS" : "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX" : "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies" : [ {
+    "isVirtual" : false,
+    "fileName" : "ratel-api-1.3.6.jar",
+    "filePath" : "/home/wtwhite/.m2/repository/com/virjar/ratel-api/1.3.6/ratel-api-1.3.6.jar",
+    "md5" : "6cd13b6cb3d600b98ac3aff08aab0148",
+    "sha1" : "2b167d650faf3f953664c9a3cfaf4f4a09c723ee",
+    "sha256" : "e6932c6b3e8955c81191a9f545bfe4b0ed7f5fced36d632619e8d0b92d1e587d",
+    "description" : "ratel api,used for developer on ratel system,an extension for xposed framewrok,ratel api compatable with original xposed framework",
+    "license" : "The Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt",
+    "projectReferences" : [ "CVE-2021-29425:compile" ],
+    "includedBy" : [ {
+      "reference" : "pkg:maven/foo/com.virjar__ratel-api__1.3.6@0.0.1"
+    } ],
+    "evidenceCollected" : {
+      "vendorEvidence" : [ {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "external"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "vendor",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "vendor",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "vendor",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "productEvidence" : [ {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "name",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "api"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "ratel"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "jar",
+        "name" : "package name",
+        "value" : "xposed"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "artifactid",
+        "value" : "ratel-api"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer email",
+        "value" : "virjar@virjar.com"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer id",
+        "value" : "weijia.deng"
+      }, {
+        "type" : "product",
+        "confidence" : "LOW",
+        "source" : "pom",
+        "name" : "developer name",
+        "value" : "dengweijia"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "groupid",
+        "value" : "com.virjar"
+      }, {
+        "type" : "product",
+        "confidence" : "HIGH",
+        "source" : "pom",
+        "name" : "name",
+        "value" : "Ratel API"
+      }, {
+        "type" : "product",
+        "confidence" : "MEDIUM",
+        "source" : "pom",
+        "name" : "url",
+        "value" : "https://git.virjar.com:ratel/ratel"
+      } ],
+      "versionEvidence" : [ {
+        "type" : "version",
+        "confidence" : "HIGH",
+        "source" : "file",
+        "name" : "version",
+        "value" : "1.3.6"
+      }, {
+        "type" : "version",
+        "confidence" : "HIGHEST",
+        "source" : "pom",
+        "name" : "version",
+        "value" : "1.3.6"
+      } ]
+    },
+    "packages" : [ {
+      "id" : "pkg:maven/com.virjar/ratel-api@1.3.6",
+      "confidence" : "HIGH",
+      "url" : "https://ossindex.sonatype.org/component/pkg:maven/com.virjar/ratel-api@1.3.6?utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1"
+    } ]
+  } ]
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.6/scan-results/grype/grype-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.6/scan-results/grype/grype-report.json
@@ -1,0 +1,96 @@
+{
+ "matches": [],
+ "source": {
+  "type": "directory",
+  "target": "."
+ },
+ "distro": {
+  "name": "",
+  "version": "",
+  "idLike": null
+ },
+ "descriptor": {
+  "name": "",
+  "version": "",
+  "configuration": {
+   "output": [
+    "json"
+   ],
+   "file": "scan-results/grype/grype-report.json",
+   "distro": "",
+   "add-cpes-if-none": false,
+   "output-template-file": "",
+   "check-for-app-update": false,
+   "only-fixed": false,
+   "only-notfixed": false,
+   "platform": "",
+   "search": {
+    "scope": "Squashed",
+    "unindexed-archives": false,
+    "indexed-archives": true
+   },
+   "ignore": null,
+   "exclude": [],
+   "db": {
+    "cache-dir": "/home/wtwhite/.cache/grype/db",
+    "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+    "ca-cert": "",
+    "auto-update": false,
+    "validate-by-hash-on-start": false,
+    "validate-age": true,
+    "max-allowed-built-age": 3600000000000000000
+   },
+   "externalSources": {
+    "enable": false,
+    "maven": {
+     "searchUpstreamBySha1": true,
+     "baseUrl": "https://search.maven.org/solrsearch/select"
+    }
+   },
+   "match": {
+    "java": {
+     "using-cpes": true
+    },
+    "dotnet": {
+     "using-cpes": true
+    },
+    "golang": {
+     "using-cpes": true
+    },
+    "javascript": {
+     "using-cpes": true
+    },
+    "python": {
+     "using-cpes": true
+    },
+    "ruby": {
+     "using-cpes": true
+    },
+    "stock": {
+     "using-cpes": true
+    }
+   },
+   "fail-on-severity": "",
+   "registry": {
+    "insecure-skip-tls-verify": false,
+    "insecure-use-http": false,
+    "auth": null,
+    "ca-cert": ""
+   },
+   "show-suppressed": false,
+   "by-cve": false,
+   "name": "",
+   "default-image-pull-source": "",
+   "vex-documents": [],
+   "vex-add": []
+  },
+  "db": {
+   "built": "2023-04-27T10:34:58Z",
+   "schemaVersion": 5,
+   "location": "/home/wtwhite/.cache/grype/db/5",
+   "checksum": "sha256:db85d95f6b5924c38d690f7b6a9743cc6ef58e7a100707749ab28792b573e9a9",
+   "error": null
+  },
+  "timestamp": "2023-10-02T15:24:12.771459842+13:00"
+ }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.6/scan-results/snyk/snyk-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.6/scan-results/snyk/snyk-report.json
@@ -1,0 +1,106 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 1,
+  "org": "wtwhite",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": false,
+  "uniqueCount": 0,
+  "projectName": "foo:com.virjar__ratel-api__1.3.6",
+  "displayTargetFile": "pom.xml",
+  "hasUnknownVersions": false,
+  "path": "/home/wtwhite/code/shadedetector/runs/42_rerun_all_with_better_Makefile/vuln_final/CVE-2021-29425/com.virjar__ratel-api__1.3.6"
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.6/scan-results/steady/steady-report.json
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.6/scan-results/steady/steady-report.json
@@ -1,0 +1,27 @@
+{
+	"vulasReport": {
+		"generatedAt": "02.10.2023 22:27 +1300",
+		"generatedFor": {
+			"space": "$space.getSpaceToken()",
+			"groupId": "foo",
+			"artifactId": "com.virjar__ratel-api__1.3.6",
+			"version": "0.0.1"
+		},
+		"isAggregated": false,
+	
+		"aggregatedModules": [],
+	
+		"configuration": [
+			{ "name": "exceptionThreshold",
+			  "value": "dependsOn" },
+			{ "name": "exemptScopes",
+			  "value": "PROVIDED, TEST" },
+			{ "name": "exemptBugs",
+			  "value": "" }
+		],
+	
+		"vulnerabilities": [
+		
+		]
+	}
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.6/src/test/java/FilenameUtilsTestCase.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.6/src/test/java/FilenameUtilsTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import external.org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is used to test FilenameUtils for correctness.
+ *
+ * @see FilenameUtils
+ */
+public class FilenameUtilsTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SEP = "" + File.separatorChar;
+
+    private static final boolean WINDOWS = File.separatorChar == '\\';
+
+    private File testFile1;
+
+    private File testFile2;
+
+    private int testFile1Size;
+
+    private int testFile2Size;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile1 = temporaryFolder.newFile("file1-test.txt");
+        testFile2 = temporaryFolder.newFile("file1a-test.txt");
+        testFile1Size = (int) testFile1.length();
+        testFile2Size = (int) testFile2.length();
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output3 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output3, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output2 = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output2, testFile2Size);
+        }
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output1 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output1, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output, testFile2Size);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void testNormalize() throws Exception {
+        assertEquals(null, FilenameUtils.normalize(null));
+        assertEquals(null, FilenameUtils.normalize(":"));
+        assertEquals(null, FilenameUtils.normalize("1:\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("1:"));
+        assertEquals(null, FilenameUtils.normalize("1:a"));
+        assertEquals(null, FilenameUtils.normalize("\\\\\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\a"));
+        assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c.txt"));
+        assertEquals("" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\a\\b/c.txt"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("C:\\a\\b/c.txt"));
+        assertEquals("" + SEP + "" + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server\\a\\b/c.txt"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~\\a\\b/c.txt"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~user\\a\\b/c.txt"));
+        assertEquals("a" + SEP + "c", FilenameUtils.normalize("a/b/../c"));
+        assertEquals("c", FilenameUtils.normalize("a/b/../../c"));
+        assertEquals("c" + SEP, FilenameUtils.normalize("a/b/../../c/"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../../c"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/.."));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/../"));
+        assertEquals("", FilenameUtils.normalize("a/b/../.."));
+        assertEquals("", FilenameUtils.normalize("a/b/../../"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../.."));
+        assertEquals("a" + SEP + "d", FilenameUtils.normalize("a/b/../c/../d"));
+        assertEquals("a" + SEP + "d" + SEP, FilenameUtils.normalize("a/b/../c/../d/"));
+        assertEquals("a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("a/b//d"));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/././."));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/./././"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("./a/"));
+        assertEquals("a", FilenameUtils.normalize("./a"));
+        assertEquals("", FilenameUtils.normalize("./"));
+        assertEquals("", FilenameUtils.normalize("."));
+        assertEquals(null, FilenameUtils.normalize("../a"));
+        assertEquals(null, FilenameUtils.normalize(".."));
+        assertEquals("", FilenameUtils.normalize(""));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/a"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/"));
+        assertEquals(SEP + "a" + SEP + "c", FilenameUtils.normalize("/a/b/../c"));
+        assertEquals(SEP + "c", FilenameUtils.normalize("/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../../c"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/b/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../.."));
+        assertEquals(SEP + "a" + SEP + "d", FilenameUtils.normalize("/a/b/../c/../d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("/a/b//d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("/a/b/././."));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/./a"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/./"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/."));
+        assertEquals(null, FilenameUtils.normalize("/../a"));
+        assertEquals(null, FilenameUtils.normalize("/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/"));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/a"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/"));
+        assertEquals("~" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~/a/b/../c"));
+        assertEquals("~" + SEP + "c", FilenameUtils.normalize("~/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../../c"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/b/.."));
+        assertEquals("~" + SEP + "", FilenameUtils.normalize("~/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../.."));
+        assertEquals("~" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~/a/b/../c/../d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~/a/b//d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~/a/b/././."));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/./a"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/./"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/."));
+        assertEquals(null, FilenameUtils.normalize("~/../a"));
+        assertEquals(null, FilenameUtils.normalize("~/.."));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~"));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/a"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/"));
+        assertEquals("~user" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~user/a/b/../c"));
+        assertEquals("~user" + SEP + "c", FilenameUtils.normalize("~user/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../../c"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/b/.."));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../.."));
+        assertEquals("~user" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~user/a/b/../c/../d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~user/a/b//d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~user/a/b/././."));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/./a"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/./"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/."));
+        assertEquals(null, FilenameUtils.normalize("~user/../a"));
+        assertEquals(null, FilenameUtils.normalize("~user/.."));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user/"));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user"));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/a"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/"));
+        assertEquals("C:" + SEP + "a" + SEP + "c", FilenameUtils.normalize("C:/a/b/../c"));
+        assertEquals("C:" + SEP + "c", FilenameUtils.normalize("C:/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../../c"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/b/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../.."));
+        assertEquals("C:" + SEP + "a" + SEP + "d", FilenameUtils.normalize("C:/a/b/../c/../d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:/a/b//d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:/a/b/././."));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/./a"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/./"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/."));
+        assertEquals(null, FilenameUtils.normalize("C:/../a"));
+        assertEquals(null, FilenameUtils.normalize("C:/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/"));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:a"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/"));
+        assertEquals("C:" + "a" + SEP + "c", FilenameUtils.normalize("C:a/b/../c"));
+        assertEquals("C:" + "c", FilenameUtils.normalize("C:a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../../c"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/b/.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../.."));
+        assertEquals("C:" + "a" + SEP + "d", FilenameUtils.normalize("C:a/b/../c/../d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:a/b//d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:a/b/././."));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:./a"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:./"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:."));
+        assertEquals(null, FilenameUtils.normalize("C:../a"));
+        assertEquals(null, FilenameUtils.normalize("C:.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:"));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/a"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "c", FilenameUtils.normalize("//server/a/b/../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "c", FilenameUtils.normalize("//server/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/b/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../.."));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "d", FilenameUtils.normalize("//server/a/b/../c/../d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("//server/a/b//d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("//server/a/b/././."));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/./a"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/./"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/."));
+        assertEquals(null, FilenameUtils.normalize("//server/../a"));
+        assertEquals(null, FilenameUtils.normalize("//server/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/"));
+        assertEquals(SEP + SEP + "127.0.0.1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\127.0.0.1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "::1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\::1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server.example.org" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.example.org\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server." + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\-server\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\..\\a\\b\\c.txt"));
+    }
+}

--- a/CVE-2021-29425/com.virjar__ratel-api__1.3.6/src/test/java/TestUtils.java
+++ b/CVE-2021-29425/com.virjar__ratel-api__1.3.6/src/test/java/TestUtils.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import external.org.apache.commons.io.FileUtils;
+import external.org.apache.commons.io.output.ByteArrayOutputStream;
+import junit.framework.AssertionFailedError;
+
+/**
+ * Base class for testcases doing tests with files.
+ */
+public abstract class TestUtils {
+
+    private TestUtils() {
+    }
+
+    public static void createFile(final File file, final long size) throws IOException {
+        if (!file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new java.io.FileOutputStream(file))) {
+            generateTestData(output, size);
+        }
+    }
+
+    public static byte[] generateTestData(final long size) {
+        try {
+            final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+            generateTestData(baout, size);
+            return baout.toByteArray();
+        } catch (final IOException ioe) {
+            throw new RuntimeException("This should never happen: " + ioe.getMessage());
+        }
+    }
+
+    public static void generateTestData(final OutputStream out, final long size) throws IOException {
+        for (int i = 0; i < size; i++) {
+            //output.write((byte)'X');
+            // nice varied byte pattern compatible with Readers and Writers
+            out.write((byte) ((i % 127) + 1));
+        }
+    }
+
+    public static void createLineBasedFile(final File file, final String[] data) throws IOException {
+        if (file.getParentFile() != null && !file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final PrintWriter output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))) {
+            for (final String element : data) {
+                output.println(element);
+            }
+        }
+    }
+
+    public static File newFile(final File testDirectory, final String filename) throws IOException {
+        final File destination = new File(testDirectory, filename);
+        /*
+        assertTrue( filename + "Test output data file shouldn't previously exist",
+                    !destination.exists() );
+        */
+        if (destination.exists()) {
+            FileUtils.forceDelete(destination);
+        }
+        return destination;
+    }
+
+    public static void checkFile(final File file, final File referenceFile) throws Exception {
+        assertTrue("Check existence of output file", file.exists());
+        assertEqualContent(referenceFile, file);
+    }
+
+    /**
+     * Assert that the content of two files is the same.
+     */
+    private static void assertEqualContent(final File f0, final File f1) throws IOException {
+        /* This doesn't work because the filesize isn't updated until the file
+         * is closed.
+        assertTrue( "The files " + f0 + " and " + f1 +
+                    " have differing file sizes (" + f0.length() +
+                    " vs " + f1.length() + ")", ( f0.length() == f1.length() ) );
+        */
+        try (InputStream is0 = new FileInputStream(f0)) {
+            try (InputStream is1 = new FileInputStream(f1)) {
+                final byte[] buf0 = new byte[1024];
+                final byte[] buf1 = new byte[1024];
+                int n0 = 0;
+                int n1;
+                while (-1 != n0) {
+                    n0 = is0.read(buf0);
+                    n1 = is1.read(buf1);
+                    assertTrue("The files " + f0 + " and " + f1 + " have differing number of bytes available (" + n0 + " vs " + n1 + ")", (n0 == n1));
+                    assertTrue("The files " + f0 + " and " + f1 + " have different content", Arrays.equals(buf0, buf1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a byte[].
+     *
+     * @param b0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final byte[] b0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final byte[] b1 = new byte[b0.length];
+        try (InputStream is = new FileInputStream(file)) {
+            while (count < b0.length && numRead >= 0) {
+                numRead = is.read(b1, count, b0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of bytes: ", b0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("byte " + i + " differs", b0[i], b1[i]);
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a char[].
+     *
+     * @param c0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final char[] c0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final char[] c1 = new char[c0.length];
+        try (Reader ir = new FileReader(file)) {
+            while (count < c0.length && numRead >= 0) {
+                numRead = ir.read(c1, count, c0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of chars: ", c0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("char " + i + " differs", c0[i], c1[i]);
+            }
+        }
+    }
+
+    public static void checkWrite(final OutputStream output) throws Exception {
+        try {
+            new java.io.PrintStream(output).write(0);
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void checkWrite(final Writer output) throws Exception {
+        try {
+            new java.io.PrintWriter(output).write('a');
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void deleteFile(final File file) throws Exception {
+        if (file.exists()) {
+            assertTrue("Couldn't delete file: " + file, file.delete());
+        }
+    }
+
+    /**
+     * Sleep for a guaranteed number of milliseconds unless interrupted.
+     *
+     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
+     * it deems appropriate. Read the docs on Thread.sleep for further details.
+     *
+     * @param ms the number of milliseconds to sleep for
+     * @throws InterruptedException if interrupted
+     */
+    public static void sleep(final long ms) throws InterruptedException {
+        final long finishAt = System.currentTimeMillis() + ms;
+        long remaining = ms;
+        do {
+            Thread.sleep(remaining);
+            remaining = finishAt - System.currentTimeMillis();
+        } while (remaining > 0);
+    }
+
+    public static void sleepQuietly(final long ms) {
+        try {
+            sleep(ms);
+        } catch (final InterruptedException ignored) {
+        }
+    }
+}


### PR DESCRIPTION
- ❌ **Not a full clone** based on the difference in name from the TPoV (`commons-io:commons-io:2.6`).
- ✔️ **Not critical** since although there is [1 dependent package](https://central.sonatype.com/artifact/com.virjar/ratel-api/dependents), namely [`com.virjar.sekiro.business/sekiro-ratel`](https://central.sonatype.com/artifact/com.virjar.sekiro.business/sekiro-ratel/1.1), it is in the organisation `com.virjar.sekiro.business` which seems clearly to belong to the same owner as `com.virjar` **-> OK for public release**
- (❌) **Not remediated** since there is no later version than `1.3.6` on Maven Central Repo