### PR TITLE
Add PoV projects manually demonstrating 2 more artifact versions of `org.smartboot.servlet:servlet-core` vulnerable to CVE-2021-29425

### DIFF
--- a/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.5/README.md
+++ b/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.5/README.md
@@ -1,0 +1,26 @@
+# [CVE-2021-29425 -- Commons-IO] (https://nvd.nist.gov/vuln/detail/CVE-2021-29425)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+
+
+Project uses `commons-io:commons-io:2.6` , tests from https://github.com/apache/commons-io/commit/2736b6fe0b3fa22ec8e2b4184897ecadb021fc78
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. irrelevant tests in class removed
+2. utility methods TestUtils
+3. JUnit version replaced by JUnit5 with JUnit4 vintage support
+4. uses Java 8 (note that compress does not have to be build)
+
+Note that the one test __fails__ indicating the vulnerability! After replacing `commons-io:commons-io:2.6` by `commons-io:commons-io:2.7`
+the respective test passes, indicating that the vulnerability has been fixed.
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.5/pom.xml
+++ b/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.5/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>org.smartboot.servlet__servlet-core__0.5</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2021-29425 POV</description>
+    <name>CVE-2021-29425</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.smartboot.servlet</groupId>
+            <artifactId>servlet-core</artifactId>
+            <version>0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.5/src/test/java/FilenameUtilsTestCase.java
+++ b/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.5/src/test/java/FilenameUtilsTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import org.smartboot.servlet.third.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is used to test FilenameUtils for correctness.
+ *
+ * @see FilenameUtils
+ */
+public class FilenameUtilsTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SEP = "" + File.separatorChar;
+
+    private static final boolean WINDOWS = File.separatorChar == '\\';
+
+    private File testFile1;
+
+    private File testFile2;
+
+    private int testFile1Size;
+
+    private int testFile2Size;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile1 = temporaryFolder.newFile("file1-test.txt");
+        testFile2 = temporaryFolder.newFile("file1a-test.txt");
+        testFile1Size = (int) testFile1.length();
+        testFile2Size = (int) testFile2.length();
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output3 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output3, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output2 = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output2, testFile2Size);
+        }
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output1 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output1, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output, testFile2Size);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void testNormalize() throws Exception {
+        assertEquals(null, FilenameUtils.normalize(null));
+        assertEquals(null, FilenameUtils.normalize(":"));
+        assertEquals(null, FilenameUtils.normalize("1:\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("1:"));
+        assertEquals(null, FilenameUtils.normalize("1:a"));
+        assertEquals(null, FilenameUtils.normalize("\\\\\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\a"));
+        assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c.txt"));
+        assertEquals("" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\a\\b/c.txt"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("C:\\a\\b/c.txt"));
+        assertEquals("" + SEP + "" + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server\\a\\b/c.txt"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~\\a\\b/c.txt"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~user\\a\\b/c.txt"));
+        assertEquals("a" + SEP + "c", FilenameUtils.normalize("a/b/../c"));
+        assertEquals("c", FilenameUtils.normalize("a/b/../../c"));
+        assertEquals("c" + SEP, FilenameUtils.normalize("a/b/../../c/"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../../c"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/.."));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/../"));
+        assertEquals("", FilenameUtils.normalize("a/b/../.."));
+        assertEquals("", FilenameUtils.normalize("a/b/../../"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../.."));
+        assertEquals("a" + SEP + "d", FilenameUtils.normalize("a/b/../c/../d"));
+        assertEquals("a" + SEP + "d" + SEP, FilenameUtils.normalize("a/b/../c/../d/"));
+        assertEquals("a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("a/b//d"));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/././."));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/./././"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("./a/"));
+        assertEquals("a", FilenameUtils.normalize("./a"));
+        assertEquals("", FilenameUtils.normalize("./"));
+        assertEquals("", FilenameUtils.normalize("."));
+        assertEquals(null, FilenameUtils.normalize("../a"));
+        assertEquals(null, FilenameUtils.normalize(".."));
+        assertEquals("", FilenameUtils.normalize(""));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/a"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/"));
+        assertEquals(SEP + "a" + SEP + "c", FilenameUtils.normalize("/a/b/../c"));
+        assertEquals(SEP + "c", FilenameUtils.normalize("/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../../c"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/b/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../.."));
+        assertEquals(SEP + "a" + SEP + "d", FilenameUtils.normalize("/a/b/../c/../d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("/a/b//d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("/a/b/././."));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/./a"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/./"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/."));
+        assertEquals(null, FilenameUtils.normalize("/../a"));
+        assertEquals(null, FilenameUtils.normalize("/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/"));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/a"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/"));
+        assertEquals("~" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~/a/b/../c"));
+        assertEquals("~" + SEP + "c", FilenameUtils.normalize("~/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../../c"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/b/.."));
+        assertEquals("~" + SEP + "", FilenameUtils.normalize("~/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../.."));
+        assertEquals("~" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~/a/b/../c/../d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~/a/b//d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~/a/b/././."));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/./a"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/./"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/."));
+        assertEquals(null, FilenameUtils.normalize("~/../a"));
+        assertEquals(null, FilenameUtils.normalize("~/.."));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~"));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/a"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/"));
+        assertEquals("~user" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~user/a/b/../c"));
+        assertEquals("~user" + SEP + "c", FilenameUtils.normalize("~user/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../../c"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/b/.."));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../.."));
+        assertEquals("~user" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~user/a/b/../c/../d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~user/a/b//d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~user/a/b/././."));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/./a"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/./"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/."));
+        assertEquals(null, FilenameUtils.normalize("~user/../a"));
+        assertEquals(null, FilenameUtils.normalize("~user/.."));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user/"));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user"));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/a"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/"));
+        assertEquals("C:" + SEP + "a" + SEP + "c", FilenameUtils.normalize("C:/a/b/../c"));
+        assertEquals("C:" + SEP + "c", FilenameUtils.normalize("C:/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../../c"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/b/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../.."));
+        assertEquals("C:" + SEP + "a" + SEP + "d", FilenameUtils.normalize("C:/a/b/../c/../d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:/a/b//d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:/a/b/././."));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/./a"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/./"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/."));
+        assertEquals(null, FilenameUtils.normalize("C:/../a"));
+        assertEquals(null, FilenameUtils.normalize("C:/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/"));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:a"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/"));
+        assertEquals("C:" + "a" + SEP + "c", FilenameUtils.normalize("C:a/b/../c"));
+        assertEquals("C:" + "c", FilenameUtils.normalize("C:a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../../c"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/b/.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../.."));
+        assertEquals("C:" + "a" + SEP + "d", FilenameUtils.normalize("C:a/b/../c/../d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:a/b//d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:a/b/././."));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:./a"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:./"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:."));
+        assertEquals(null, FilenameUtils.normalize("C:../a"));
+        assertEquals(null, FilenameUtils.normalize("C:.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:"));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/a"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "c", FilenameUtils.normalize("//server/a/b/../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "c", FilenameUtils.normalize("//server/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/b/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../.."));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "d", FilenameUtils.normalize("//server/a/b/../c/../d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("//server/a/b//d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("//server/a/b/././."));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/./a"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/./"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/."));
+        assertEquals(null, FilenameUtils.normalize("//server/../a"));
+        assertEquals(null, FilenameUtils.normalize("//server/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/"));
+        assertEquals(SEP + SEP + "127.0.0.1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\127.0.0.1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "::1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\::1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server.example.org" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.example.org\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server." + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\-server\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\..\\a\\b\\c.txt"));
+    }
+}

--- a/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.5/src/test/java/TestUtils.java
+++ b/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.5/src/test/java/TestUtils.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import org.smartboot.servlet.third.commons.io.FileUtils;
+import org.smartboot.servlet.third.commons.io.output.ByteArrayOutputStream;
+import junit.framework.AssertionFailedError;
+
+/**
+ * Base class for testcases doing tests with files.
+ */
+public abstract class TestUtils {
+
+    private TestUtils() {
+    }
+
+    public static void createFile(final File file, final long size) throws IOException {
+        if (!file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new java.io.FileOutputStream(file))) {
+            generateTestData(output, size);
+        }
+    }
+
+    public static byte[] generateTestData(final long size) {
+        try {
+            final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+            generateTestData(baout, size);
+            return baout.toByteArray();
+        } catch (final IOException ioe) {
+            throw new RuntimeException("This should never happen: " + ioe.getMessage());
+        }
+    }
+
+    public static void generateTestData(final OutputStream out, final long size) throws IOException {
+        for (int i = 0; i < size; i++) {
+            //output.write((byte)'X');
+            // nice varied byte pattern compatible with Readers and Writers
+            out.write((byte) ((i % 127) + 1));
+        }
+    }
+
+    public static void createLineBasedFile(final File file, final String[] data) throws IOException {
+        if (file.getParentFile() != null && !file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final PrintWriter output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))) {
+            for (final String element : data) {
+                output.println(element);
+            }
+        }
+    }
+
+    public static File newFile(final File testDirectory, final String filename) throws IOException {
+        final File destination = new File(testDirectory, filename);
+        /*
+        assertTrue( filename + "Test output data file shouldn't previously exist",
+                    !destination.exists() );
+        */
+        if (destination.exists()) {
+            FileUtils.forceDelete(destination);
+        }
+        return destination;
+    }
+
+    public static void checkFile(final File file, final File referenceFile) throws Exception {
+        assertTrue("Check existence of output file", file.exists());
+        assertEqualContent(referenceFile, file);
+    }
+
+    /**
+     * Assert that the content of two files is the same.
+     */
+    private static void assertEqualContent(final File f0, final File f1) throws IOException {
+        /* This doesn't work because the filesize isn't updated until the file
+         * is closed.
+        assertTrue( "The files " + f0 + " and " + f1 +
+                    " have differing file sizes (" + f0.length() +
+                    " vs " + f1.length() + ")", ( f0.length() == f1.length() ) );
+        */
+        try (InputStream is0 = new FileInputStream(f0)) {
+            try (InputStream is1 = new FileInputStream(f1)) {
+                final byte[] buf0 = new byte[1024];
+                final byte[] buf1 = new byte[1024];
+                int n0 = 0;
+                int n1;
+                while (-1 != n0) {
+                    n0 = is0.read(buf0);
+                    n1 = is1.read(buf1);
+                    assertTrue("The files " + f0 + " and " + f1 + " have differing number of bytes available (" + n0 + " vs " + n1 + ")", (n0 == n1));
+                    assertTrue("The files " + f0 + " and " + f1 + " have different content", Arrays.equals(buf0, buf1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a byte[].
+     *
+     * @param b0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final byte[] b0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final byte[] b1 = new byte[b0.length];
+        try (InputStream is = new FileInputStream(file)) {
+            while (count < b0.length && numRead >= 0) {
+                numRead = is.read(b1, count, b0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of bytes: ", b0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("byte " + i + " differs", b0[i], b1[i]);
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a char[].
+     *
+     * @param c0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final char[] c0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final char[] c1 = new char[c0.length];
+        try (Reader ir = new FileReader(file)) {
+            while (count < c0.length && numRead >= 0) {
+                numRead = ir.read(c1, count, c0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of chars: ", c0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("char " + i + " differs", c0[i], c1[i]);
+            }
+        }
+    }
+
+    public static void checkWrite(final OutputStream output) throws Exception {
+        try {
+            new java.io.PrintStream(output).write(0);
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void checkWrite(final Writer output) throws Exception {
+        try {
+            new java.io.PrintWriter(output).write('a');
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void deleteFile(final File file) throws Exception {
+        if (file.exists()) {
+            assertTrue("Couldn't delete file: " + file, file.delete());
+        }
+    }
+
+    /**
+     * Sleep for a guaranteed number of milliseconds unless interrupted.
+     *
+     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
+     * it deems appropriate. Read the docs on Thread.sleep for further details.
+     *
+     * @param ms the number of milliseconds to sleep for
+     * @throws InterruptedException if interrupted
+     */
+    public static void sleep(final long ms) throws InterruptedException {
+        final long finishAt = System.currentTimeMillis() + ms;
+        long remaining = ms;
+        do {
+            Thread.sleep(remaining);
+            remaining = finishAt - System.currentTimeMillis();
+        } while (remaining > 0);
+    }
+
+    public static void sleepQuietly(final long ms) {
+        try {
+            sleep(ms);
+        } catch (final InterruptedException ignored) {
+        }
+    }
+}

--- a/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.6/README.md
+++ b/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.6/README.md
@@ -1,0 +1,26 @@
+# [CVE-2021-29425 -- Commons-IO] (https://nvd.nist.gov/vuln/detail/CVE-2021-29425)  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+
+
+
+Project uses `commons-io:commons-io:2.6` , tests from https://github.com/apache/commons-io/commit/2736b6fe0b3fa22ec8e2b4184897ecadb021fc78
+as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
+
+Some minor changes made: 
+1. irrelevant tests in class removed
+2. utility methods TestUtils
+3. JUnit version replaced by JUnit5 with JUnit4 vintage support
+4. uses Java 8 (note that compress does not have to be build)
+
+Note that the one test __fails__ indicating the vulnerability! After replacing `commons-io:commons-io:2.6` by `commons-io:commons-io:2.7`
+the respective test passes, indicating that the vulnerability has been fixed.
+
+
+
+
+  
+
+
+ 
+
+ 
+

--- a/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.6/pom.xml
+++ b/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.6/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>foo</groupId>
+    <artifactId>org.smartboot.servlet__servlet-core__0.6</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2021-29425 POV</description>
+    <name>CVE-2021-29425</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.smartboot.servlet</groupId>
+            <artifactId>servlet-core</artifactId>
+            <version>0.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.6/src/test/java/FilenameUtilsTestCase.java
+++ b/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.6/src/test/java/FilenameUtilsTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import org.smartboot.servlet.third.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is used to test FilenameUtils for correctness.
+ *
+ * @see FilenameUtils
+ */
+public class FilenameUtilsTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SEP = "" + File.separatorChar;
+
+    private static final boolean WINDOWS = File.separatorChar == '\\';
+
+    private File testFile1;
+
+    private File testFile2;
+
+    private int testFile1Size;
+
+    private int testFile2Size;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile1 = temporaryFolder.newFile("file1-test.txt");
+        testFile2 = temporaryFolder.newFile("file1a-test.txt");
+        testFile1Size = (int) testFile1.length();
+        testFile2Size = (int) testFile2.length();
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output3 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output3, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output2 = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output2, testFile2Size);
+        }
+        if (!testFile1.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output1 = new BufferedOutputStream(new FileOutputStream(testFile1))) {
+            TestUtils.generateTestData(output1, testFile1Size);
+        }
+        if (!testFile2.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(testFile2))) {
+            TestUtils.generateTestData(output, testFile2Size);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void testNormalize() throws Exception {
+        assertEquals(null, FilenameUtils.normalize(null));
+        assertEquals(null, FilenameUtils.normalize(":"));
+        assertEquals(null, FilenameUtils.normalize("1:\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("1:"));
+        assertEquals(null, FilenameUtils.normalize("1:a"));
+        assertEquals(null, FilenameUtils.normalize("\\\\\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\a"));
+        assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c.txt"));
+        assertEquals("" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\a\\b/c.txt"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("C:\\a\\b/c.txt"));
+        assertEquals("" + SEP + "" + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server\\a\\b/c.txt"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~\\a\\b/c.txt"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("~user\\a\\b/c.txt"));
+        assertEquals("a" + SEP + "c", FilenameUtils.normalize("a/b/../c"));
+        assertEquals("c", FilenameUtils.normalize("a/b/../../c"));
+        assertEquals("c" + SEP, FilenameUtils.normalize("a/b/../../c/"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../../c"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/.."));
+        assertEquals("a" + SEP, FilenameUtils.normalize("a/b/../"));
+        assertEquals("", FilenameUtils.normalize("a/b/../.."));
+        assertEquals("", FilenameUtils.normalize("a/b/../../"));
+        assertEquals(null, FilenameUtils.normalize("a/b/../../.."));
+        assertEquals("a" + SEP + "d", FilenameUtils.normalize("a/b/../c/../d"));
+        assertEquals("a" + SEP + "d" + SEP, FilenameUtils.normalize("a/b/../c/../d/"));
+        assertEquals("a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("a/b//d"));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/././."));
+        assertEquals("a" + SEP + "b" + SEP, FilenameUtils.normalize("a/b/./././"));
+        assertEquals("a" + SEP, FilenameUtils.normalize("./a/"));
+        assertEquals("a", FilenameUtils.normalize("./a"));
+        assertEquals("", FilenameUtils.normalize("./"));
+        assertEquals("", FilenameUtils.normalize("."));
+        assertEquals(null, FilenameUtils.normalize("../a"));
+        assertEquals(null, FilenameUtils.normalize(".."));
+        assertEquals("", FilenameUtils.normalize(""));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/a"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/"));
+        assertEquals(SEP + "a" + SEP + "c", FilenameUtils.normalize("/a/b/../c"));
+        assertEquals(SEP + "c", FilenameUtils.normalize("/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../../c"));
+        assertEquals(SEP + "a" + SEP, FilenameUtils.normalize("/a/b/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("/a/b/../../.."));
+        assertEquals(SEP + "a" + SEP + "d", FilenameUtils.normalize("/a/b/../c/../d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("/a/b//d"));
+        assertEquals(SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("/a/b/././."));
+        assertEquals(SEP + "a", FilenameUtils.normalize("/./a"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/./"));
+        assertEquals(SEP + "", FilenameUtils.normalize("/."));
+        assertEquals(null, FilenameUtils.normalize("/../a"));
+        assertEquals(null, FilenameUtils.normalize("/.."));
+        assertEquals(SEP + "", FilenameUtils.normalize("/"));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/a"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/"));
+        assertEquals("~" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~/a/b/../c"));
+        assertEquals("~" + SEP + "c", FilenameUtils.normalize("~/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../../c"));
+        assertEquals("~" + SEP + "a" + SEP, FilenameUtils.normalize("~/a/b/.."));
+        assertEquals("~" + SEP + "", FilenameUtils.normalize("~/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~/a/b/../../.."));
+        assertEquals("~" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~/a/b/../c/../d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~/a/b//d"));
+        assertEquals("~" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~/a/b/././."));
+        assertEquals("~" + SEP + "a", FilenameUtils.normalize("~/./a"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/./"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/."));
+        assertEquals(null, FilenameUtils.normalize("~/../a"));
+        assertEquals(null, FilenameUtils.normalize("~/.."));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~/"));
+        assertEquals("~" + SEP, FilenameUtils.normalize("~"));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/a"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/"));
+        assertEquals("~user" + SEP + "a" + SEP + "c", FilenameUtils.normalize("~user/a/b/../c"));
+        assertEquals("~user" + SEP + "c", FilenameUtils.normalize("~user/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../../c"));
+        assertEquals("~user" + SEP + "a" + SEP, FilenameUtils.normalize("~user/a/b/.."));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("~user/a/b/../../.."));
+        assertEquals("~user" + SEP + "a" + SEP + "d", FilenameUtils.normalize("~user/a/b/../c/../d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("~user/a/b//d"));
+        assertEquals("~user" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("~user/a/b/././."));
+        assertEquals("~user" + SEP + "a", FilenameUtils.normalize("~user/./a"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/./"));
+        assertEquals("~user" + SEP + "", FilenameUtils.normalize("~user/."));
+        assertEquals(null, FilenameUtils.normalize("~user/../a"));
+        assertEquals(null, FilenameUtils.normalize("~user/.."));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user/"));
+        assertEquals("~user" + SEP, FilenameUtils.normalize("~user"));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/a"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/"));
+        assertEquals("C:" + SEP + "a" + SEP + "c", FilenameUtils.normalize("C:/a/b/../c"));
+        assertEquals("C:" + SEP + "c", FilenameUtils.normalize("C:/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../../c"));
+        assertEquals("C:" + SEP + "a" + SEP, FilenameUtils.normalize("C:/a/b/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:/a/b/../../.."));
+        assertEquals("C:" + SEP + "a" + SEP + "d", FilenameUtils.normalize("C:/a/b/../c/../d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:/a/b//d"));
+        assertEquals("C:" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:/a/b/././."));
+        assertEquals("C:" + SEP + "a", FilenameUtils.normalize("C:/./a"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/./"));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/."));
+        assertEquals(null, FilenameUtils.normalize("C:/../a"));
+        assertEquals(null, FilenameUtils.normalize("C:/.."));
+        assertEquals("C:" + SEP + "", FilenameUtils.normalize("C:/"));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:a"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/"));
+        assertEquals("C:" + "a" + SEP + "c", FilenameUtils.normalize("C:a/b/../c"));
+        assertEquals("C:" + "c", FilenameUtils.normalize("C:a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../../c"));
+        assertEquals("C:" + "a" + SEP, FilenameUtils.normalize("C:a/b/.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("C:a/b/../../.."));
+        assertEquals("C:" + "a" + SEP + "d", FilenameUtils.normalize("C:a/b/../c/../d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("C:a/b//d"));
+        assertEquals("C:" + "a" + SEP + "b" + SEP, FilenameUtils.normalize("C:a/b/././."));
+        assertEquals("C:" + "a", FilenameUtils.normalize("C:./a"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:./"));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:."));
+        assertEquals(null, FilenameUtils.normalize("C:../a"));
+        assertEquals(null, FilenameUtils.normalize("C:.."));
+        assertEquals("C:" + "", FilenameUtils.normalize("C:"));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/a"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "c", FilenameUtils.normalize("//server/a/b/../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "c", FilenameUtils.normalize("//server/a/b/../../c"));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../../c"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP, FilenameUtils.normalize("//server/a/b/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/a/b/../.."));
+        assertEquals(null, FilenameUtils.normalize("//server/a/b/../../.."));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "d", FilenameUtils.normalize("//server/a/b/../c/../d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP + "d", FilenameUtils.normalize("//server/a/b//d"));
+        assertEquals(SEP + SEP + "server" + SEP + "a" + SEP + "b" + SEP, FilenameUtils.normalize("//server/a/b/././."));
+        assertEquals(SEP + SEP + "server" + SEP + "a", FilenameUtils.normalize("//server/./a"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/./"));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/."));
+        assertEquals(null, FilenameUtils.normalize("//server/../a"));
+        assertEquals(null, FilenameUtils.normalize("//server/.."));
+        assertEquals(SEP + SEP + "server" + SEP + "", FilenameUtils.normalize("//server/"));
+        assertEquals(SEP + SEP + "127.0.0.1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\127.0.0.1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "::1" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\::1\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server.example.org" + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.example.org\\a\\b\\c.txt"));
+        assertEquals(SEP + SEP + "server." + SEP + "a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("\\\\server.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\-server\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\.\\a\\b\\c.txt"));
+        assertEquals(null, FilenameUtils.normalize("\\\\..\\a\\b\\c.txt"));
+    }
+}

--- a/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.6/src/test/java/TestUtils.java
+++ b/CVE-2021-29425/VULN-CONFIRMED-MANUALLY/org.smartboot.servlet__servlet-core__0.6/src/test/java/TestUtils.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import org.smartboot.servlet.third.commons.io.FileUtils;
+import org.smartboot.servlet.third.commons.io.output.ByteArrayOutputStream;
+import junit.framework.AssertionFailedError;
+
+/**
+ * Base class for testcases doing tests with files.
+ */
+public abstract class TestUtils {
+
+    private TestUtils() {
+    }
+
+    public static void createFile(final File file, final long size) throws IOException {
+        if (!file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final BufferedOutputStream output = new BufferedOutputStream(new java.io.FileOutputStream(file))) {
+            generateTestData(output, size);
+        }
+    }
+
+    public static byte[] generateTestData(final long size) {
+        try {
+            final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+            generateTestData(baout, size);
+            return baout.toByteArray();
+        } catch (final IOException ioe) {
+            throw new RuntimeException("This should never happen: " + ioe.getMessage());
+        }
+    }
+
+    public static void generateTestData(final OutputStream out, final long size) throws IOException {
+        for (int i = 0; i < size; i++) {
+            //output.write((byte)'X');
+            // nice varied byte pattern compatible with Readers and Writers
+            out.write((byte) ((i % 127) + 1));
+        }
+    }
+
+    public static void createLineBasedFile(final File file, final String[] data) throws IOException {
+        if (file.getParentFile() != null && !file.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + file + " as the parent directory does not exist");
+        }
+        try (final PrintWriter output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))) {
+            for (final String element : data) {
+                output.println(element);
+            }
+        }
+    }
+
+    public static File newFile(final File testDirectory, final String filename) throws IOException {
+        final File destination = new File(testDirectory, filename);
+        /*
+        assertTrue( filename + "Test output data file shouldn't previously exist",
+                    !destination.exists() );
+        */
+        if (destination.exists()) {
+            FileUtils.forceDelete(destination);
+        }
+        return destination;
+    }
+
+    public static void checkFile(final File file, final File referenceFile) throws Exception {
+        assertTrue("Check existence of output file", file.exists());
+        assertEqualContent(referenceFile, file);
+    }
+
+    /**
+     * Assert that the content of two files is the same.
+     */
+    private static void assertEqualContent(final File f0, final File f1) throws IOException {
+        /* This doesn't work because the filesize isn't updated until the file
+         * is closed.
+        assertTrue( "The files " + f0 + " and " + f1 +
+                    " have differing file sizes (" + f0.length() +
+                    " vs " + f1.length() + ")", ( f0.length() == f1.length() ) );
+        */
+        try (InputStream is0 = new FileInputStream(f0)) {
+            try (InputStream is1 = new FileInputStream(f1)) {
+                final byte[] buf0 = new byte[1024];
+                final byte[] buf1 = new byte[1024];
+                int n0 = 0;
+                int n1;
+                while (-1 != n0) {
+                    n0 = is0.read(buf0);
+                    n1 = is1.read(buf1);
+                    assertTrue("The files " + f0 + " and " + f1 + " have differing number of bytes available (" + n0 + " vs " + n1 + ")", (n0 == n1));
+                    assertTrue("The files " + f0 + " and " + f1 + " have different content", Arrays.equals(buf0, buf1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a byte[].
+     *
+     * @param b0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final byte[] b0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final byte[] b1 = new byte[b0.length];
+        try (InputStream is = new FileInputStream(file)) {
+            while (count < b0.length && numRead >= 0) {
+                numRead = is.read(b1, count, b0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of bytes: ", b0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("byte " + i + " differs", b0[i], b1[i]);
+            }
+        }
+    }
+
+    /**
+     * Assert that the content of a file is equal to that in a char[].
+     *
+     * @param c0   the expected contents
+     * @param file the file to check
+     * @throws IOException If an I/O error occurs while reading the file contents
+     */
+    public static void assertEqualContent(final char[] c0, final File file) throws IOException {
+        int count = 0, numRead = 0;
+        final char[] c1 = new char[c0.length];
+        try (Reader ir = new FileReader(file)) {
+            while (count < c0.length && numRead >= 0) {
+                numRead = ir.read(c1, count, c0.length);
+                count += numRead;
+            }
+            assertEquals("Different number of chars: ", c0.length, count);
+            for (int i = 0; i < count; i++) {
+                assertEquals("char " + i + " differs", c0[i], c1[i]);
+            }
+        }
+    }
+
+    public static void checkWrite(final OutputStream output) throws Exception {
+        try {
+            new java.io.PrintStream(output).write(0);
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void checkWrite(final Writer output) throws Exception {
+        try {
+            new java.io.PrintWriter(output).write('a');
+        } catch (final Throwable t) {
+            throw new AssertionFailedError("The copy() method closed the stream " + "when it shouldn't have. " + t.getMessage());
+        }
+    }
+
+    public static void deleteFile(final File file) throws Exception {
+        if (file.exists()) {
+            assertTrue("Couldn't delete file: " + file, file.delete());
+        }
+    }
+
+    /**
+     * Sleep for a guaranteed number of milliseconds unless interrupted.
+     *
+     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
+     * it deems appropriate. Read the docs on Thread.sleep for further details.
+     *
+     * @param ms the number of milliseconds to sleep for
+     * @throws InterruptedException if interrupted
+     */
+    public static void sleep(final long ms) throws InterruptedException {
+        final long finishAt = System.currentTimeMillis() + ms;
+        long remaining = ms;
+        do {
+            Thread.sleep(remaining);
+            remaining = finishAt - System.currentTimeMillis();
+        } while (remaining > 0);
+    }
+
+    public static void sleepQuietly(final long ms) {
+        try {
+            sleep(ms);
+        } catch (final InterruptedException ignored) {
+        }
+    }
+}


### PR DESCRIPTION
More details in #17.

`shadedetector` automatically tested versions up to `0.4`, and they are all vulnerable:

```
[whitewa@piccolo ~/code/shadedetector/runs/68_big_run_accidentally_included_CVE-2019-44228_and_it_worked]$ zgrep 'org.smartboot.servlet.* -> vuln' log122-CVE-2021-29425.log.gz
2023-09-29 14:54:18,738 INFO [main] n.a.w.s.Main [Main.java:601] tests in /local/scratch/whitewa/shadedetector/.cache/build/env-d41d8cd98f00b204e9800998ecf8427e/CVE-2021-29425/org.smartboot.servlet__servlet-core__0.4: 0 passed, 1 failed, 0 errors, 0 skipped -> vuln is present
2023-09-29 14:54:22,544 INFO [main] n.a.w.s.Main [Main.java:601] tests in /local/scratch/whitewa/shadedetector/.cache/build/env-d41d8cd98f00b204e9800998ecf8427e/CVE-2021-29425/org.smartboot.servlet__servlet-core__0.1.9: 0 passed, 1 failed, 0 errors, 0 skipped -> vuln is present
2023-09-29 14:55:16,491 INFO [main] n.a.w.s.Main [Main.java:601] tests in /local/scratch/whitewa/shadedetector/.cache/build/env-d41d8cd98f00b204e9800998ecf8427e/CVE-2021-29425/org.smartboot.servlet__servlet-core__0.3: 0 passed, 1 failed, 0 errors, 0 skipped -> vuln is present
2023-09-29 14:57:40,191 INFO [main] n.a.w.s.Main [Main.java:601] tests in /local/scratch/whitewa/shadedetector/.cache/build/env-d41d8cd98f00b204e9800998ecf8427e/CVE-2021-29425/org.smartboot.servlet__servlet-core__0.2: 0 passed, 1 failed, 0 errors, 0 skipped -> vuln is present
2023-09-29 14:58:31,159 INFO [main] n.a.w.s.Main [Main.java:601] tests in /local/scratch/whitewa/shadedetector/.cache/build/env-d41d8cd98f00b204e9800998ecf8427e/CVE-2021-29425/org.smartboot.servlet__servlet-core__0.2.1: 0 passed, 1 failed, 0 errors, 0 skipped -> vuln is present
2023-09-29 15:00:01,041 INFO [main] n.a.w.s.Main [Main.java:601] tests in /local/scratch/whitewa/shadedetector/.cache/build/env-d41d8cd98f00b204e9800998ecf8427e/CVE-2021-29425/org.smartboot.servlet__servlet-core__0.3.1: 0 passed, 1 failed, 0 errors, 0 skipped -> vuln is present
```

Earlier versions (namely `0.1.0`, `0.1.1`, `0.1.2`, `0.1.3`, `0.1.4`, `0.1.5`, `0.1.6`, `0.1.8`) weren't tested, presumably due to there being too many other matching artifacts.

There are now also 2 later versions, `0.5` and `0.6`, which did not exist at the time the `shadedetector` analysis was run -- and indeed would not have worked, since they require JDK21 and the run was performed with JDK11. Manually modifying `pom.xml` and rerunning confirms that **these two versions are also vulnerable:**

## Version `0.5` is also vulnerable

```
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/investigate_org.smartboot.servlet__servlet-core__0.5_on_JDK21$ cp -ar ../.cache/build/env-d41d8cd98f00b204e9800998ecf8427e/CVE-2021-29425/org.smartboot.servlet__servlet-core__0.4/ .
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/investigate_org.smartboot.servlet__servlet-core__0.5_on_JDK21$ mv org.smartboot.servlet__servlet-core__0.4/ org.smartboot.servlet__servlet-core__0.5
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/investigate_org.smartboot.servlet__servlet-core__0.5_on_JDK21$ cd org.smartboot.servlet__servlet-core__0.5
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/investigate_org.smartboot.servlet__servlet-core__0.5_on_JDK21/org.smartboot.servlet__servlet-core__0.5$ mvn clean 
--snip--
core__0.5_on_JDK21/org.smartboot.servlet__servlet-core__0.5$ vi pom.xml # Change "0.4" to "0.5"
```

Running the actual test:
```
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/investigate_org.smartboot.servlet__servlet-core__0.5_on_JDK21/org.smartboot.servlet__servlet-core__0.5$ java --version
openjdk 21.0.1 2023-10-17
OpenJDK Runtime Environment (build 21.0.1+12-Ubuntu-222.04)
OpenJDK 64-Bit Server VM (build 21.0.1+12-Ubuntu-222.04, mixed mode, sharing)
core__0.5_on_JDK21/org.smartboot.servlet__servlet-core__0.5$ mvn test
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------< foo:org.smartboot.servlet__servlet-core__0.5 >------------
[INFO] Building CVE-2021-29425 0.0.1
[INFO] --------------------------------[ jar ]---------------------------------
--snip--
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running FilenameUtilsTestCase
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.04 s <<< FAILURE! - in FilenameUtilsTestCase
[ERROR] FilenameUtilsTestCase.testNormalize  Time elapsed: 0.031 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <null> but was: <//-server/a/b/c.txt>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1142)
	at FilenameUtilsTestCase.testNormalize(FilenameUtilsTestCase.java:227)
--snip--
```

## Version `0.6` is also vulnerable

```
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/investigate_org.smartboot.servlet__servlet-core__0.5_on_JDK21$ cp -ar org.smartboot.servlet__servlet-core__0.5 org.smartboot.servlet__servlet-core__0.6
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/investigate_org.smartboot.servlet__servlet-core__0.5_on_JDK21$ cd org.smartboot.servlet__servlet-core__0.6
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/investigate_org.smartboot.servlet__servlet-core__0.5_on_JDK21/org.smartboot.servlet__servlet-core__0.6$ vi pom.xml # Change "0.5" to "0.6"
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/investigate_org.smartboot.servlet__servlet-core__0.5_on_JDK21/org.smartboot.servlet__servlet-core__0.6$ mvn clean
--snip--
wtwhite@wtwhite-vuw-vm:~/code/shadedetector/investigate_org.smartboot.servlet__servlet-core__0.5_on_JDK21/org.smartboot.servlet__servlet-core__0.6$ mvn test
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------< foo:org.smartboot.servlet__servlet-core__0.6 >------------
[INFO] Building CVE-2021-29425 0.0.1
[INFO] --------------------------------[ jar ]---------------------------------
--snip--
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running FilenameUtilsTestCase
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.036 s <<< FAILURE! - in FilenameUtilsTestCase
[ERROR] FilenameUtilsTestCase.testNormalize  Time elapsed: 0.027 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <null> but was: <//-server/a/b/c.txt>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1142)
	at FilenameUtilsTestCase.testNormalize(FilenameUtilsTestCase.java:227)
```

This PR adds these modified poms under a `VULN-CONFIRMED-MANUALLY` subdir, as was done for `CVE-2015-7051`.